### PR TITLE
Typo in Kubernetes versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The versions required are:
 
   * **Helm 2.10+** - This is the earliest version of Helm tested. It is possible
     it works with earlier versions but this chart is untested for those versions.
-  * **Kubernetes 2.9+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.9+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
-    untested. Other versions verified are Kubernetes 2.10, 2.11.
+    untested. Other versions verified are Kubernetes 1.10, 1.11.
 
 ## Usage
 


### PR DESCRIPTION
The README referenced Kubernetes major versions **2** instead of **1**.