### PR TITLE
#7 added an optional storageClass to the server-statefuset

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -160,4 +160,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.server.storage }}
+        {{- if .Values.server.storageClass }}
+        storageClassName: {{ .Values.server.storageClass }}
+        {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ server:
   replicas: 3
   bootstrapExpect: 3 # Should <= replicas count
   storage: 10Gi
+  #storageClass: default # <= name of the storage class to use
 
   # connect will enable Connect on all the servers, initializing a CA
   # for Connect-related connections. Other customizations can be done


### PR DESCRIPTION
This PR adds an optional storageClass support to the HELM template as specified in #7

When defined, the provided `server.storageClass` shall be rendered into the `server-statefulset.yaml`.


@mitchellh Is that satisfactory? Please note that I'm not a GO expert, so if there's anything wrong, please let me know.