### PR TITLE
#14 ensured consul agent is using physical node's name

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -61,6 +61,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command:
             - "/bin/sh"
             - "-ec"
@@ -68,10 +72,11 @@ spec:
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
               exec /bin/consul agent \
+                -node="${NODE}" \
                 -advertise="${POD_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
-                -config-dir=/consul/config \
+                -config-dir=/consul/config \                
                 {{- range .Values.client.extraVolumes }}
                 {{- if .load }}
                 -config-dir=/consul/userconfig/{{ .name }}


### PR DESCRIPTION
This PR fixes #14 by introducing a local ENV variable **NODE** which contains the name of the physical node hosting the pod. The ENV variable is used to pass `-node` arg into **consul agent**. 