### PR TITLE
Adding StorageClass object

### DIFF
--- a/templates/server-storageclass.yaml
+++ b/templates/server-storageclass.yaml
@@ -1,0 +1,13 @@
+{{- if eq .Values.server.provisionerEnabled "-"}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.server.storageClass }}
+  annotations:
+    "storageclass.kubernetes.io/is-default-class": "true"
+provisioner: {{ .Values.server.provisioner }}
+parameters:
+  type: {{ .Values.server.type }}
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,14 @@ server:
   # the attached volume. storageClass is the class of storage which defaults
   # to null (the Kube cluster will pick the default).
   storage: 10Gi
-  storageClass: null
+  storageClass: consul
+
+  # provisioner determines the dynamic volume provisioner used by a cloud provider
+  # type is a cloud provider unique value of the type of volume to create
+  # provisionerEnabled will enable the StorageClass to be created.
+  provisioner: # e.g. kubernetes.io/aws-ebs
+  type: # e.g. gp2
+  provisionerEnabled: #"-"
 
   # connect will enable Connect on all the servers, initializing a CA
   # for Connect-related connections. Other customizations can be done


### PR DESCRIPTION
When running the example on a stock Amazon EKS cluster, the server pods do not come up because the PersistentVolumeClaims indicate `no persistent volumes available for this claim and no storage class is set`.

I believe a StorageClass is needed for the [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#enabling-dynamic-provisioning) to function properly in the Cloud Providers, by creating the PersistentVolumes (related to .  This change offers the option to create a StorageClass, and enable it as the default provisioner.  I commented out the AWS values, but provided examples to reference.

This is related to #8.