### PR TITLE
Support Consul Connect Injector Installation

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -71,6 +71,9 @@ spec:
                 -advertise="${POD_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
+                {{- if .Values.client.grpc }}
+                -hcl="ports { grpc = 8502 }" \
+                {{- end }}
                 -config-dir=/consul/config \
                 {{- range .Values.client.extraVolumes }}
                 {{- if .load }}
@@ -112,6 +115,9 @@ spec:
             - containerPort: 8500
               hostPort: 8500
               name: http
+            - containerPort: 8502
+              hostPort: 8502
+              name: grpc
             - containerPort: 8301
               name: serflan
             - containerPort: 8302

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              consul-k8s inject \
+              consul-k8s inject-connect \
                 -default-inject={{ .Values.connectInject.default }} \
                 -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
                 {{ if .Values.connectInject.imageEnvoy -}}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: sidecar-injector
-          image: "{{ .Values.connectInject.image }}"
+          image: "{{ default .Values.global.imageK8S .Values.connectInject.image }}"
           env:
             - name: NAMESPACE
               valueFrom:
@@ -41,6 +41,10 @@ spec:
 
               consul-k8s inject \
                 -default-inject={{ .Values.connectInject.default }} \
+                -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
+                {{ if .Values.connectInject.imageEnvoy -}}
+                -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
+                {{ end -}}
                 -listen=:8080 \
 {{- if .Values.connectInject.certs.secretName }}
                 -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }}

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -16,7 +16,7 @@ webhooks:
         name: {{ template "consul.fullname" . }}-connect-injector-svc
         namespace: default
         path: "/mutate"
-      caBundle: {{ .Values.connectInject.caBundle }}
+      caBundle: {{ .Values.connectInject.certs.caBundle }}
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -24,6 +24,8 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: sync-catalog
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
     spec:
       containers:
         - name: consul-sync-catalog

--- a/test/unit/client-daemonset.yaml
+++ b/test/unit/client-daemonset.yaml
@@ -73,6 +73,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# grpc
+
+@test "client/DaemonSet: grpc is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("grpc"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/DaemonSet: grpc can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("grpc"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # extraVolumes
 
 @test "client/DaemonSet: adds extra volume" {

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -42,6 +42,56 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+#--------------------------------------------------------------------
+# consul and envoy images
+
+@test "connectInject/Deployment: consul-image defaults to global" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'global.image=foo' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-image=\"foo\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: consul-image can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'global.image=foo' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.imageConsul=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-image=\"bar\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: envoy-image is not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-envoy-image"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: envoy-image can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.imageEnvoy=foo' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-envoy-image=\"foo\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# cert secrets
+
 @test "connectInject/Deployment: no secretName: no tls-{cert,key}-file set" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -159,7 +159,7 @@ syncCatalog:
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
-  enabled: false # "-" disable this by default for now until the image is public
+  enabled: false
   default: false # true will inject by default, otherwise requires annotation
 
   # imageConsul and imageEnvoy can be set to Docker images for Consul and

--- a/values.yaml
+++ b/values.yaml
@@ -67,7 +67,7 @@ server:
     maxUnavailable: null
 
   # extraConfig is a raw string of extra configuration to set with the
-  # server. This should be JSON or HCL.
+  # server. This should be JSON.
   extraConfig: |
     {}
 
@@ -87,13 +87,17 @@ client:
   image: null
   join: null
 
+  # grpc should be set to true if the gRPC listener should be enabled.
+  # This should be set to true if connectInject is enabled.
+  grpc: false
+
   # Resource requests, limits, etc. for the client cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.
   resources: {}
 
   # extraConfig is a raw string of extra configuration to set with the
-  # server. This should be JSON or HCL.
+  # server. This should be JSON.
   extraConfig: |
     {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -160,9 +160,7 @@ syncCatalog:
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false # "-" disable this by default for now until the image is public
-  image: null
   default: false # true will inject by default, otherwise requires annotation
-  caBundle: "" # empty will auto generate the bundle
 
   # imageConsul and imageEnvoy can be set to Docker images for Consul and
   # Envoy, respectively. If the Consul image is not specified, the global

--- a/values.yaml
+++ b/values.yaml
@@ -156,9 +156,16 @@ syncCatalog:
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false # "-" disable this by default for now until the image is public
-  image: "TODO"
+  image: null
   default: false # true will inject by default, otherwise requires annotation
   caBundle: "" # empty will auto generate the bundle
+
+  # imageConsul and imageEnvoy can be set to Docker images for Consul and
+  # Envoy, respectively. If the Consul image is not specified, the global
+  # default will be used. If the Envoy image is not specified, an early
+  # version of Envoy will be used.
+  imageConsul: null
+  imageEnvoy: null
 
   # namespaceSelector is the selector for restricting the webhook to only
   # specific namespaces. This should be set to a multiline string.


### PR DESCRIPTION
This adds support for the Consul Connect injector installation. This is kind of an update since the support was actually already committed to master a long time ago but just disabled (and totally not working).

This required two major changes:

  * **client: allow enabling gRPC** - gRPC is required for the injected sidecar which is Envoy.
  * **connectInject: configurable images and fixing brokenness** - The images to use for both Consul and Envoy are configurable now. Additionally, invalid subcommand names and other things that have changed in the months since we first wrote this have been updated.

## RBAC

This doesn't configure any roles because the injector itself doesn't require any permissions. The installer must ensure that Tiller/Helm has permission to setup a `MutatingAdmissionWebhook` and the various deployments. With that configured, the apiserver will call out to the webhook to make changes. The injector itself doesn't make API calls.