### PR TITLE
feat: enable consul-servers to be accessed externally

### DIFF
--- a/templates/server-clusterrole.yaml
+++ b/templates/server-clusterrole.yaml
@@ -16,6 +16,15 @@ rules:
   - {{ template "consul.fullname" . }}-server
   verbs:
   - use
+- apiGroups: [""]
+  resources:
+    - pods
+    - services
+  verbs:
+    - get
+    - list
+    - update
+    - patch
 {{- else }}
 rules: []
 {{- end }}

--- a/templates/server-external-service.yaml
+++ b/templates/server-external-service.yaml
@@ -1,0 +1,53 @@
+{{- $root := . }}
+{{- $fullName := include "consul.fullname" $root }}
+{{- $serviceType := $root.Values.server.external.type }}
+{{- if (or (and (ne (.Values.server.external.enabled | toString) "-") .Values.server.external.enabled) (and (eq (.Values.server.external.enabled | toString) "-") .Values.global.enabled)) }}
+  {{- range $index := until (.Values.server.replicas | int) }}
+    {{- $responsiblePod := printf "%s-server-%d" $fullName $index }}
+---
+# This service can be used to provide connectivity with a consul cluster
+# running in another datacenter.Each consul-server should have an external
+# service that it will use to advertise on the WAN
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-server-{{ $index }}-external
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{  $root.Release.Service }}
+    release: {{  $root.Release.Name }}
+  annotations:
+    # This must be set in addition to publishNotReadyAddresses due
+    # to an open issue where it may not work:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # See your cloud provider's documentation for the correct annotations
+    # needed for creating an external LoadBalancer.
+    {{- range $key, $value :=  $root.Values.server.external.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  # Kubernetes does not allow LoadBalancer service types have mixed
+  # protocols. Consul federation will work with just TCP but will throw
+  # out errors (e.g. "other probes failed")
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8500
+      targetPort: 8500
+    - name: serfwan-tcp
+      protocol: "TCP"
+      port: 8302
+      targetPort: 8302
+    - name: server
+      port: 8300
+      targetPort: 8300
+  selector:
+    app: {{ template "consul.name" $root }}
+    release: "{{ $root.Release.Name }}"
+    component: server
+    pod: {{ $responsiblePod | quote }}
+  {{- end }}
+{{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -1,5 +1,6 @@
 # StatefulSet to run the actual Consul server cluster.
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $externalEnabled := (or (and (ne (.Values.server.external.enabled | toString) "-") .Values.server.external.enabled) (and (eq (.Values.server.external.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -66,6 +67,10 @@ spec:
           secret:
             secretName: {{ template "consul.fullname" . }}-server-cert
         {{- end }}
+        {{- if $externalEnabled }}
+        - name: tmp
+          emptydir: {}
+        {{- end }}
         {{- range .Values.server.extraVolumes }}
         - name: userconfig-{{ .name }}
           {{ .type }}:
@@ -77,6 +82,29 @@ spec:
         {{- end }}
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
+      {{- end }}
+      {{- if $externalEnabled }}
+      initContainers:
+        - name: init-ext
+          image: "{{ default .Values.global.imageExtInit .Values.server.external.image }}"
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              kubectl label pods ${NAME} --namespace ${NAMESPACE} pod=${NAME}
+              kubectl get svc ${NAME}-external --namespace ${NAMESPACE} -o jsonpath='{.status.loadBalancer.ingress[0].ip}' | tee /consul/tmp/external_ip
+          env:
+            - name: NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: tmp
+              mountPath: /consul/tmp
       {{- end }}
       containers:
         - name: consul
@@ -109,9 +137,21 @@ spec:
             - "-ec"
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
-
+              {{- if $externalEnabled }}
+              if [ -f /consul/tmp/external_ip ]; then
+                EXTERNAL_IP="$(cat /consul/tmp/external_ip)"
+              else
+                echo "Could not find file with external IP info"
+                exit 1
+              fi
+              EXTERNAL_IP="$(cat /consul/tmp/external_ip)"
+              echo "Will set advertise-wan to ${EXTERNAL_IP}"
+              {{- end }}
               exec /bin/consul agent \
                 -advertise="${POD_IP}" \
+                {{- if $externalEnabled }}
+                -advertise-wan="${EXTERNAL_IP}" \
+                {{- end }}
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ .Values.server.bootstrapExpect }} \
                 {{- if .Values.global.tls.enabled }}
@@ -163,6 +203,10 @@ spec:
             - name: tls-server-cert
               mountPath: /consul/tls/server
               readOnly: true
+            {{- end }}
+            {{- if $externalEnabled }}
+            - name: tmp
+              mountPath: /consul/tmp
             {{- end }}
             {{- range .Values.server.extraVolumes }}
             - name: userconfig-{{ .name }}

--- a/test/unit/server-external-service.bats
+++ b/test/unit/server-external-service.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server-external/Service: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server-external/Service: enable with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.external.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server-external/Service: disable with server.external.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      --set 'server.external.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server-external/Service: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      --set 'global.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server-external/Service: tolerates unready endpoints" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      --set 'server.external.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[1].metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      -x templates/server-external-service.yaml  \
+      --set 'server.external.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[1].spec.publishNotReadyAddresses' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -323,6 +323,30 @@ load _helpers
       yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+#--------------------------------------------------------------------
+# externalService
+
+@test "server/StatefulSet: enabled initContainer with server.external.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.enabled=true' \
+      --set 'server.external.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/StatefulSet: disable initContainer with server.external.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.enabled=true' \
+      --set 'server.external.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
 
 #--------------------------------------------------------------------
 # annotations

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,10 @@ global:
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.12.0"
 
+  # imageExtInit refers to the image used for initializing the consul server pods
+  # when you enable external access. This can be overridden per component below.
+  imageExtInit: "lwolf/kubectl_deployer:1.13.0"
+
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value
@@ -138,6 +142,19 @@ server:
   enterpriseLicense:
     secretName: null
     secretKey: null
+  # Set to true to create an external LoadBalancer for each consul server to enable
+  # communication with another consul cluster in a multi-datacenter environment.
+  # Because kubernetes does not allow the LoadBalancer service type to have mixed
+  # protocols, the external service will only enable communication via TCP.
+  external:
+    enabled: false
+
+    # Set what image is used to initialize the consul server pods.
+    # The image set in global.imageExtInit will be used if not set here.
+    image: null
+
+    # Provide annotations for your cloud provider to correctly create the LoadBalancer.
+    annotations: {}
 
   # storage and storageClass are the settings for configuring stateful
   # storage for the server pods. storage should be set to the disk size of


### PR DESCRIPTION
For properly creating a multi-datacenter federated consul cluster. Creates an external LoadBalancer service for each consul server. Depends on the end-user knowing the correct annotations for creating an external LoadBalancer service for their cloud provider.