### PR TITLE
Provide a mechanism to run a Prometheus monitoring sidecar

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -151,6 +151,15 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+        {{- if (or (and (ne (.Values.server.prometheusSidecar.enabled | toString) "-") .Values.server.prometheusSidecar.enabled) (and (eq (.Values.server.prometheusSidecar.enabled | toString) "-") .Values.global.enabled)) }}
+        - name: consul-exporter
+          image: {{ default .Values.server.prometheusSidecar.image }}
+          args:
+          - --consul.server=localhost:8500
+          ports:
+          - containerPort: 9107
+            name: http-monitoring
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/templates/sidecar-service.yaml
+++ b/templates/sidecar-service.yaml
@@ -1,0 +1,20 @@
+{{- if (or (and (ne (.Values.server.prometheusSidecar.enabled | toString) "-") .Values.server.prometheusSidecar.enabled) (and (eq (.Values.server.prometheusSidecar.enabled | toString) "-") .Values.global.enabled)) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "consul.fullname" . }}-exporter
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "consul.name" . }}
+    release: "{{ .Release.Name }}"
+    component: server
+  ports:
+    - name: http-metrics
+      port: 9107
+      targetPort: 9107
+{{- end }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -198,6 +198,20 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# prometheusSidecar
+
+@test "server/StatefulSet: enable promethuesSidecar" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.prometheusSidecar.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  [ "${actual}" = "prom/consul-exporter:v0.4.0" ]
+}
+
+
+#--------------------------------------------------------------------
 # updateStrategy
 
 @test "server/StatefulSet: no storageClass on claim by default" {
@@ -219,4 +233,3 @@ load _helpers
       yq -r '.spec.volumeClaimTemplates[0].spec.storageClassName' | tee /dev/stderr)
   [ "${actual}" = "foo" ]
 }
-

--- a/test/unit/sidecar-service.bats
+++ b/test/unit/sidecar-service.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "sidecar/Service: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sidecar-service.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "sidecar/Service: enable with server.prometheusSidecar.enable true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sidecar-service.yaml  \
+      --set 'server.prometheusSidecar.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
Since Prometheus and Kubernetes go together, and there's an official Consul exporter maintained by the authors of Prometheus, I thought some local changes for testing might be worth sharing.

Things I'm still uncertain about:
- Is `server.prometheusSidecar` the right place to put the feature flag (and should it be called that)?
- Should the service always be created if the sidecar is enabled? (we use Prometheus operator, so services are a must)
- Assuming the disabled by default is correct, should a sidecar be an exception to the `global.enabled` flag?

