### PR TITLE
#10 consul-server readinessProbe settings moved to values file

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -146,11 +146,11 @@ spec:
                 - |
                   curl http://127.0.0.1:8500/v1/status/leader 2>/dev/null | \
                   grep -E '".+"'
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            successThreshold: 1
-            timeoutSeconds: 5
+            failureThreshold: {{ .Values.server.readinessProbe.failureTreshold }}
+            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.server.readinessProbe.successTreshold }}
+            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/values.yaml
+++ b/values.yaml
@@ -78,7 +78,13 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
-
+  
+  readinessProbe:
+    failureThreshold: 2
+    initialDelaySeconds: 5
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
 # DC where a single agent is deployed per node.


### PR DESCRIPTION
This PR makes the consul-servers' stateful set readiness check configurable via the chart values.

This way, the operator gets to tweak the settings in case the check fails under the default settings.

This PR aims to unblock cases similar to the one describe in #10 