### PR TITLE
Pipe through the default flag for catalog sync

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - |
               consul-k8s sync-catalog \
                 -http-addr=${HOST_IP}:8500 \
+                -k8s-default-sync={{ .Values.syncCatalog.default }} \
                 {{- if (not .Values.syncCatalog.toConsul) }}
                 -to-consul=false \
                 {{- end }}

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -69,6 +69,30 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# default sync
+
+@test "syncCatalog/Deployment: default sync is true by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command | any(contains("-k8s-default-sync=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/Deployment: default sync can be turned off" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.default=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command | any(contains("-k8s-default-sync=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # toConsul and toK8S
 
 @test "syncCatalog/Deployment: bidirectional by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -146,6 +146,7 @@ syncCatalog:
   # True if you want to enable the catalog sync. "-" for default.
   enabled: false
   image: null
+  default: true # true will sync by default, otherwise requires annotation
 
   # Enabling rbac will create cluster roles and cluster role bindings to
   # allow the syncCatalog service to communicate with the kubernetes api


### PR DESCRIPTION
This exposes the consul-k8s [k8s-default-sync](https://github.com/hashicorp/consul-k8s/blob/master/subcommand/sync-catalog/command.go#L52-L55) flag in the Helm chart, which allows users to set the default behavior of the catalog sync from Kubernetes.

Fixes [this](https://github.com/hashicorp/consul-k8s/issues/28) consul-k8s issue.