### PR TITLE
Remove rbac option for sync catalog

### DIFF
--- a/templates/sync-catalog-cluster-role-binding.yaml
+++ b/templates/sync-catalog-cluster-role-binding.yaml
@@ -1,6 +1,5 @@
-{{- $rbacEnabled := (or (and (ne (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.syncCatalog.rbac.enabled) (and (eq (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.global.enabled)) }}
 {{- $syncEnabled := (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and $rbacEnabled $syncEnabled) }}
+{{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/sync-catalog-cluster-role.yaml
+++ b/templates/sync-catalog-cluster-role.yaml
@@ -1,6 +1,5 @@
-{{- $rbacEnabled := (or (and (ne (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.syncCatalog.rbac.enabled) (and (eq (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.global.enabled)) }}
 {{- $syncEnabled := (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and $rbacEnabled $syncEnabled) }}
+{{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -1,5 +1,4 @@
-# The deployment for running the Connect sidecar injector
-{{- $rbacEnabled := (or (and (ne (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.syncCatalog.rbac.enabled) (and (eq (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.global.enabled)) }}
+# The deployment for running the sync-catalog pod
 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -28,9 +27,7 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
     spec:
-      {{- if $rbacEnabled }}
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
-      {{- end }}
       containers:
         - name: consul-sync-catalog
           image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"

--- a/templates/sync-catalog-service-account.yaml
+++ b/templates/sync-catalog-service-account.yaml
@@ -1,6 +1,5 @@
-{{- $rbacEnabled := (or (and (ne (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.syncCatalog.rbac.enabled) (and (eq (.Values.syncCatalog.rbac.enabled | toString) "-") .Values.global.enabled)) }}
 {{- $syncEnabled := (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and $rbacEnabled $syncEnabled) }}
+{{- if $syncEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/test/unit/sync-catalog-cluster-role-binding.bats
+++ b/test/unit/sync-catalog-cluster-role-binding.bats
@@ -11,47 +11,43 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "sync/ClusterRoleBinding: enable with global.enabled false" {
+@test "sync/ClusterRoleBinding: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role-binding.yaml  \
       --set 'global.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "sync/ClusterRoleBinding: disabled with sync disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-cluster-role-binding.yaml  \
+      --set 'syncCatalog.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "sync/ClusterRoleBinding: enabled with sync enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-cluster-role-binding.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "sync/ClusterRoleBinding: disable with syncCatalog.enabled" {
+@test "sync/ClusterRoleBinding: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role-binding.yaml  \
-      --set 'syncCatalog.enabled=false' \
-      --set 'syncCatalog.rbac.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "sync/ClusterRoleBinding: disable with syncCatalog.rbac.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/sync-catalog-cluster-role-binding.yaml  \
-      --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "sync/ClusterRoleBinding: disable with global.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/sync-catalog-cluster-role-binding.yaml  \
-      --set 'syncCatalog.rbac.enabled="-"' \
       --set 'global.enabled=false' \
+      --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/sync-catalog-cluster-role.bats
+++ b/test/unit/sync-catalog-cluster-role.bats
@@ -11,47 +11,43 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "sync/ClusterRole: enable with global.enabled false" {
+@test "sync/ClusterRole: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role.yaml  \
       --set 'global.enabled=false' \
-      --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
-      yq -s 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
-@test "sync/ClusterRole: disable with syncCatalog.enabled" {
+@test "sync/ClusterRole: disabled with sync disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role.yaml  \
       --set 'syncCatalog.enabled=false' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "sync/ClusterRole: disable with rbac.enabled" {
+@test "sync/ClusterRole: enabled with sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
-@test "sync/ClusterRole: disable with global.enabled" {
+@test "sync/ClusterRole: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-cluster-role.yaml  \
       --set 'global.enabled=false' \
-      --set 'syncCatalog.rbac.enabled="-"' \
+      --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -177,12 +177,11 @@ load _helpers
 #--------------------------------------------------------------------
 # serviceAccount
 
-@test "syncCatalog/Deployment: serviceAccount set with rbac.enabled" {
+@test "syncCatalog/Deployment: serviceAccount set when sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.serviceAccountName | contains("sync-catalog")' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/sync-service-account.bats
+++ b/test/unit/sync-service-account.bats
@@ -11,47 +11,43 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "sync/ServiceAccount: enable with global.enabled false" {
+@test "sync/ServiceAccount: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-service-account.yaml  \
       --set 'global.enabled=false' \
-      --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
-      yq -s 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
-@test "sync/ServiceAccount: disable with syncCatalog.enabled" {
+@test "sync/ServiceAccount: disabled with sync disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-service-account.yaml  \
       --set 'syncCatalog.enabled=false' \
-      --set 'syncCatalog.rbac.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "sync/ServiceAccount: disable with syncCatalog.rbac.enabled" {
+@test "sync/ServiceAccount: enabled with sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-service-account.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'syncCatalog.rbac.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
-@test "sync/ServiceAccount: disable with global.enabled" {
+@test "sync/ServiceAccount: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-service-account.yaml  \
-      --set 'syncCatalog.rbac.enabled="-"' \
       --set 'global.enabled=false' \
+      --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -161,12 +161,6 @@ syncCatalog:
   image: null
   default: true # true will sync by default, otherwise requires annotation
 
-  # Enabling rbac will create cluster roles and cluster role bindings to
-  # allow the syncCatalog service to communicate with the kubernetes api
-  # to get/create services.
-  rbac:
-    enabled: true
-
   # toConsul and toK8S control whether syncing is enabled to Consul or K8S
   # as a destination. If both of these are disabled, the sync will do nothing.
   toConsul: true


### PR DESCRIPTION
This removes the option to disable the RBAC setup for sync-catalog.
In most cases, RBAC is necessary for the sync functionality to work
correctly and there isn't a good use case for disabling it.

Additionally, this now mirrors the connect-inject implementation
and simplifies the logic for things that augment RBAC, like pod
security policies.

Note: I've standardized some of the tests across these files, so the
order of tests in each file has changed.