### PR TITLE
Make sure that provided join information is properly quoted

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -89,7 +89,7 @@ spec:
                 -data-dir=/consul/data \
                 {{- if (.Values.client.join) and (gt (len .Values.client.join) 0) }}
                 {{- range $value := .Values.client.join }}
-                -retry-join={{ $value }} \
+                -retry-join="{{ $value }}" \
                 {{- end }}
                 {{- else }}
                 {{- if .Values.server.enabled }}


### PR DESCRIPTION
Especially for auto-join using go-discover, the resultant string
needs to have quotes to be passed correctly.

Fixes #59 .