### PR TITLE
removing line 47: -consul-image="{{…

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -44,7 +44,6 @@ spec:
 
               consul-k8s inject-connect \
                 -default-inject={{ .Values.connectInject.default }} \
-                -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
                 {{ if .Values.connectInject.imageEnvoy -}}
                 -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
                 {{ end -}}


### PR DESCRIPTION
due to error on pod

```
callum@minta:~/code/demo/consul-helm$ kubectl logs consul-connect-injector-webhook-deployment-5cfb588495-q845p -n default
flag provided but not defined: -consul-image
Usage:
  -default-inject
        Inject by default. (default true)
  -listen string
        Address to bind listener to. (default ":8080")
  -tls-auto string
        MutatingWebhookConfiguration name. If specified, will auto generate cert bundle.
  -tls-auto-hosts string
        Comma-separated hosts for auto-generated TLS cert. If specified, will auto generate cert bundle.
  -tls-cert-file string
        PEM-encoded TLS certificate to serve. If blank, will generate random cert.
  -tls-key-file string
        PEM-encoded TLS private key to serve. If blank, will generate random cert.
```

After removing that line the pod launches cleanly