### PR TITLE
Switch liveness probe to an http call

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -57,8 +57,10 @@ spec:
                 -tls-auto-hosts=${CONSUL_FULLNAME}-connect-injector-svc,${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE},${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE}.svc
 {{- end }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health/ready
               port: 8080
+              scheme: HTTPS
             failureThreshold: 2
             initialDelaySeconds: 1
             periodSeconds: 2


### PR DESCRIPTION
The TCP check against the port was passing in Kubernetes view because
something responded, even though it couldn't connect because it didn't
have the correct credentials (TLS handshake error). This left lots of 
unnecessary error messages in the logs.