### PR TITLE
Add flag to deployment: -k8s-source-namespace

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -57,5 +57,6 @@ spec:
                 {{- if .Values.syncCatalog.k8sPrefix }}
                 -k8s-service-prefix="{{ .Values.syncCatalog.k8sPrefix}}" \
                 {{- end }}
-                -k8s-write-namespace=${NAMESPACE}
+                -k8s-write-namespace=${NAMESPACE} \
+                -k8s-source-namespace=${NAMESPACE}
 {{- end }}


### PR DESCRIPTION
Sync-Catalog version 0.2.1 was throwing errors for me without this additional setting.

Error message:
ERROR: logging before flag.Parse: E1203 15:35:47.427485       7 reflector.go:205] pkg/mod/k8s.io/client-go@v8.0.0+incompatible/tools/cache/reflector.go:99: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:swfactory:default" cannot list services at the cluster scope