### PR TITLE
Add `syncClusterIPServices` to the values file

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -58,5 +58,8 @@ spec:
                 {{- if .Values.syncCatalog.k8sPrefix }}
                 -k8s-service-prefix="{{ .Values.syncCatalog.k8sPrefix}}" \
                 {{- end }}
-                -k8s-write-namespace=${NAMESPACE}
+                -k8s-write-namespace=${NAMESPACE} \
+                {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
+                -sync-clusterip-services=false
+                {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -173,6 +173,11 @@ syncCatalog:
   # prepended with "consul-".
   k8sPrefix: null
 
+  # syncClusterIPServices syncs services of the ClusterIP type, which may
+  # or may not be broadly accessible depending on your Kubernetes cluster.
+  # Set this to false to skip syncing ClusterIP services.
+  syncClusterIPServices: true
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -16,12 +16,12 @@ global:
 
   # Image is the name (and tag) of the Consul Docker image for clients and
   # servers below. This can be overridden per component.
-  image: "consul:1.3.0"
+  image: "consul:1.3.1"
 
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as the catalog sync. This can be overridden
   # per component below.
-  imageK8S: "hashicorp/consul-k8s:0.2.1"
+  imageK8S: "hashicorp/consul-k8s:0.3.0"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running


### PR DESCRIPTION
This supports the new optional functionality in `consul-k8s` to sync
ClusterIP-type services. Updates the `consul-k8s` image
to 0.3.0 that supports this feature. Additionally updates the `consul`
image to 1.3.1 to get a catalog tag filter compatibility fix.