### PR TITLE
feat: add option to assign priorityClassName for client and server pods

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -31,6 +31,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
 
+      {{- if .Values.client.priorityClassName }}
+      priorityClassName: "{{ .Values.client.priorityClassName }}"
+      {{- end }}
+
       # Consul agents require a directory for data, even clients. The data
       # is okay to be wiped though if the Pod is removed, so just use an
       # emptyDir volume.

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 10
 
       {{- if .Values.client.priorityClassName }}
-      priorityClassName: "{{ .Values.client.priorityClassName }}"
+      priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
 
       # Consul agents require a directory for data, even clients. The data

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
             {{- end }}
         {{- end }}
       {{- if .Values.server.priorityClassName }}
-      priorityClassName: "{{ .Values.server.priorityClassName }}"
+      priorityClassName: {{ .Values.server.priorityClassName | quote }}
       {{- end }}
       containers:
         - name: consul

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -58,6 +58,9 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: "{{ .Values.server.priorityClassName }}"
+      {{- end }}
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image }}"

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -220,3 +220,25 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].command | map(select(test("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+#--------------------------------------------------------------------
+# priorityClassName
+
+@test "client/DaemonSet: priorityClassName is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "client/DaemonSet: specified priorityClassName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.priorityClassName=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -265,3 +265,26 @@ load _helpers
       yq '.spec.template.spec.affinity | .podAntiAffinity? != null' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+
+#--------------------------------------------------------------------
+# priorityClassName
+
+@test "server/StatefulSet: priorityClassName is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/StatefulSet: specified priorityClassName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.priorityClassName=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -106,6 +106,10 @@ server:
               component: server
           topologyKey: kubernetes.io/hostname
 
+  # used to assign priority to server pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
 # DC where a single agent is deployed per node.
@@ -136,6 +140,10 @@ client:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
+
+  # used to assign priority to client pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)


### PR DESCRIPTION
Hey,

This simple PR allows user to specify priorityClassName (see [docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) for servers and clients.