### PR TITLE
fix consul-k8s:nodeport-syncing get node ip forbidden

### DIFF
--- a/templates/sync-catalog-cluster-role.yaml
+++ b/templates/sync-catalog-cluster-role.yaml
@@ -14,6 +14,7 @@ rules:
     resources:
       - services
       - endpoints
+      - nodes
     verbs:
       - get
       - list


### PR DESCRIPTION
project: consul-k8s branch nodeport-syncing get node ip forbidden
"to-consul/source: error getting node info: error="nodes "X.X.X.X" is forbidden: User "system:serviceaccount:default:consul-sync-catalog" cannot get nodes at the cluster scope""