### PR TITLE
Support consul-k8s v0.4.0 features in the Helm chart

### DIFF
--- a/templates/sync-catalog-cluster-role.yaml
+++ b/templates/sync-catalog-cluster-role.yaml
@@ -14,6 +14,7 @@ rules:
     resources:
       - services
       - endpoints
+      - nodes
     verbs:
       - get
       - list

--- a/templates/sync-catalog-cluster-role.yaml
+++ b/templates/sync-catalog-cluster-role.yaml
@@ -14,7 +14,6 @@ rules:
     resources:
       - services
       - endpoints
-      - nodes
     verbs:
       - get
       - list
@@ -23,4 +22,9 @@ rules:
       - patch
       - delete
       - create
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
 {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -60,9 +60,12 @@ spec:
                 {{- end }}
                 -k8s-write-namespace=${NAMESPACE} \
                 {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
-                -sync-clusterip-services=false
+                -sync-clusterip-services=false \
                 {{- end }}
                 {{- if .Values.syncCatalog.nodePortSyncType }}
-                -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }}
+                -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }} \
+                {{- end }}
+                {{- if .Values.syncCatalog.k8sTag }}
+                -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }}
                 {{- end }}
 {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -62,4 +62,7 @@ spec:
                 {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
                 -sync-clusterip-services=false
                 {{- end }}
+                {{- if .Values.syncCatalog.nodePortSyncType }}
+                -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }}
+                {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ global:
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as the catalog sync. This can be overridden
   # per component below.
-  imageK8S: "hashicorp/consul-k8s:0.3.0"
+  imageK8S: "hashicorp/consul-k8s:0.4.0"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running
@@ -189,7 +189,7 @@ syncCatalog:
   # - InternalOnly use's the node's InternalIP address
   # - ExternalFirst will preferentially use the node's ExternalIP address, but
   #   if it doesn't exist, it will use the node's InternalIP address instead.
-  nodePortSyncType: ExternalOnly
+  nodePortSyncType: ExternalFirst
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:

--- a/values.yaml
+++ b/values.yaml
@@ -178,6 +178,14 @@ syncCatalog:
   # Set this to false to skip syncing ClusterIP services.
   syncClusterIPServices: true
 
+  # nodePortSyncType configures the type of syncing that happens for NodePort
+  # services. The valid options are: ExternalOnly, InternalOnly, ExternalFirst.
+  # - ExternalOnly will only use a node's ExternalIP address for the sync
+  # - InternalOnly use's the node's InternalIP address
+  # - ExternalFirst will preferentially use the node's ExternalIP address, but
+  #   if it doesn't exist, it will use the node's InternalIP address instead.
+  nodePortSyncType: ExternalOnly
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -170,8 +170,13 @@ syncCatalog:
 
   # k8sPrefix is the service prefix to prepend to services before registering
   # with Kubernetes. For example "consul-" will register all services
-  # prepended with "consul-".
+  # prepended with "consul-". (Consul -> Kubernetes sync)
   k8sPrefix: null
+
+  # k8sTag is an optional tag that is applied to all of the Kubernetes services
+  # that are synced into Consul. If nothing is set, defaults to "k8s".
+  # (Kubernetes -> Consul sync)
+  k8sTag: null
 
   # syncClusterIPServices syncs services of the ClusterIP type, which may
   # or may not be broadly accessible depending on your Kubernetes cluster.


### PR DESCRIPTION
Adds support for the new NodePort syncing style and the newly configurable consul-k8s-tag. Also updates the default consul-k8s version to the latest, v0.4.0.