### PR TITLE
Support monitoring via prometheus and statsd-exporter

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -28,6 +28,10 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.client.monitoring.enabled }}
+        "prometheus.io/scrape": "true"
+        "prometheus.io/port": "9102"
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
 
@@ -48,6 +52,14 @@ spec:
             {{- else if (eq .type "secret") }}
             secretName: {{ .name }}
             {{- end }}
+        {{- end }}
+        {{- if .Values.client.monitoring.enabled }}
+        - name: stats-exporter-mapping-config
+          configMap:
+            name: consul-statsd-mapping-config
+            items:
+            - key: exporterConfiguration
+              path: mapping-config.yaml
         {{- end }}
 
       containers:
@@ -77,6 +89,10 @@ spec:
                 -advertise="${POD_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
+                {{- if .Values.client.monitoring.enabled }}
+                -hcl='telemetry { dogstatsd_addr = "localhost:8125" }' \
+                -hcl='telemetry { disable_hostname = true }' \
+                {{- end }}
                 {{- if .Values.client.grpc }}
                 -hcl="ports { grpc = 8502 }" \
                 {{- end }}
@@ -150,4 +166,18 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
+        {{- if .Values.client.monitoring.enabled }}
+        - name: consul-client-statsd
+          image: prom/statsd-exporter:v0.7.0
+          ports:
+          - name: metrics
+            containerPort: 9102
+          - name: listener
+            containerPort: 8125
+          args: ["--statsd.listen-udp=:8125", "--statsd.mapping-config=/statsd-exporter/mapping-config.yaml"]
+          volumeMounts:
+          - name: stats-exporter-mapping-config
+            mountPath: /statsd-exporter/
+            readOnly: true
+        {{- end }}
 {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -37,6 +37,10 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.server.monitoring.enabled }}
+        "prometheus.io/scrape": "true"
+        "prometheus.io/port": "9102"
+        {{- end }}
     spec:
     {{- if .Values.server.affinity }}
       affinity:
@@ -58,6 +62,16 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
+        {{- if .Values.server.monitoring.enabled }}
+        - name: stats-exporter-mapping-config
+          configMap:
+            name: consul-statsd-mapping-config
+            items:
+            - key: exporterConfiguration
+              path: mapping-config.yaml
+        {{- end }}
+      imagePullSecrets:
+        - name: {{ .Values.imageCredentials.name }}
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image }}"
@@ -90,6 +104,10 @@ spec:
                 -datacenter={{ .Values.global.datacenter }} \
                 -data-dir=/consul/data \
                 -domain={{ .Values.global.domain }} \
+                {{- if .Values.server.monitoring.enabled }}
+                -hcl='telemetry { dogstatsd_addr = "localhost:8125" }' \
+                -hcl='telemetry { disable_hostname = true }' \
+                {{- end }}
                 {{- if .Values.server.connect }}
                 -hcl="connect { enabled = true }" \
                 {{- end }}
@@ -151,6 +169,20 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
+        {{- if .Values.server.monitoring.enabled }}
+        - name: consul-server-statsd
+          image: prom/statsd-exporter:v0.7.0
+          ports:
+          - name: metrics
+            containerPort: 9102
+          - name: listener
+            containerPort: 8125
+          args: ["--statsd.listen-udp=:8125", "--statsd.mapping-config=/statsd-exporter/mapping-config.yaml"]
+          volumeMounts:
+          - name: stats-exporter-mapping-config
+            mountPath: /statsd-exporter/
+            readOnly: true
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/templates/statsd-configmap.yaml
+++ b/templates/statsd-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if or .Values.client.monitoring.enabled .Values.server.monitoring.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: consul-statsd-mapping-config
+data:
+  exporterConfiguration: |
+    ---
+    mappings:
+    - match: consul.raft.replication.heartbeat.*
+      name: consul_raft_replication_heartbeat
+      labels:
+        log: "$1"
+    - match: consul.raft.replication.appendEntries.logs.*
+      name: consul_raft_replication_appendEntries_logs
+      labels:
+        log: "$1"
+    - match: consul.raft.replication.appendEntries.rpc.*
+      name: consul_raft_replication_appendEntries_rpc
+      labels:
+        log: "$1"
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,12 @@ server:
   # via the extraConfig setting.
   connect: true
 
+  # If monitoring is enabled, a statsd exporter will be spun up next to
+  # every server pod. The statsd sidecar will be annotated for automatic
+  # discovery by Prometheus.
+  monitoring:
+    enabled: true
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
@@ -104,6 +110,12 @@ client:
   # grpc should be set to true if the gRPC listener should be enabled.
   # This should be set to true if connectInject is enabled.
   grpc: false
+
+  # If monitoring is enabled, a statsd exporter will be spun up next to
+  # every client pod. The statsd sidecar will be annotated for automatic
+  # discovery by Prometheus.
+  monitoring:
+    enabled: true
 
   # Resource requests, limits, etc. for the client cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,


### PR DESCRIPTION
This PR enhances the Helm chart to spin up a Prometheus `statsd-exporter` sidecar next to each client and server pod. Consul will publish telemetry to the statsd port on the sidecar, which will make the data available for scraping by Prometheus, if it is installed on the cluster. The pods are annotated so that Prometheus will automatically discover the endpoints.

The behavior is controlled by two new options in `Values.yaml`:
- `server.monitoring.enabled`
- `client.monitoring.enabled`

Future enhancements would support monitoring systems other than Prometheus (e.g. DataDog, InfluxDB, AppDynamics, CloudWatch, etc.)