### PR TITLE
Add a catalog sync acl token configuration option

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -41,6 +41,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if (and .Values.syncCatalog.aclSyncToken.secretName .Values.syncCatalog.aclSyncToken.secretKey) }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
+                  key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
+            {{- end }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -245,3 +245,40 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-node-port-sync-type=ExternalOnly"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# aclSyncToken
+
+@test "syncCatalog/Deployment: aclSyncToken disabled when secretName is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.aclSyncToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "syncCatalog/Deployment: aclSyncToken disabled when secretKey is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.aclSyncToken.secretName=foo' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "syncCatalog/Deployment: aclSyncToken enabled when secretName and secretKey is provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.aclSyncToken.secretName=foo' \
+      --set 'syncCatalog.aclSyncToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -204,6 +204,13 @@ syncCatalog:
   #   if it doesn't exist, it will use the node's InternalIP address instead.
   nodePortSyncType: ExternalFirst
 
+  # aclSyncToken refers to a Kubernetes secret that you have created that contains
+  # an ACL token for your Consul cluster which allows the sync process the correct
+  # permissions. This is only needed if ACLs are enabled on the Consul cluster.
+  aclSyncToken:
+    secretName: null
+    secretKey: null
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false


### PR DESCRIPTION
If ACLs are enabled on your Consul cluster, the catalog sync pod
requires a valid ACL token to perform its syncing. This allows
users to pass a token to the process through a Kubernetes secret.