### PR TITLE
Update consul.chart definition to not include the version number

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -21,7 +21,7 @@ be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "consul.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-helm" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Fixes #86.

In Kubernetes, when updating StatefulSets and DaemonSets, only a small
number of fields are allowed to change. Unfortunately, labels are not
included. This means updating the helm chart, which currently updates
 the `consul.chart` label, will cause errors and interfere with the upgrade.

This switches the calculated `consul.chart` value to be a consistent
value, which should fix the previously encountered errors when updating.