### PR TITLE
Allow to specify custom annotations

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -28,6 +28,9 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.client.annotations }}
+{{ toYaml .Values.client.annotations | indent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
 

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.client.annotations }}
-          {{- toYaml .Values.client.annotations | nindent 8 }}
+          {{- tpl .Values.client.annotations . | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 10

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.client.annotations }}
-{{ toYaml .Values.client.annotations | indent 8 }}
+          {{- toYaml .Values.client.annotations | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 10

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.server.annotations }}
-{{ toYaml .Values.server.annotations | indent 8 }}
+          {{- toYaml .Values.server.annotations | nindent 8 }}
         {{- end }}
     spec:
     {{- if .Values.server.affinity }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.server.annotations }}
-          {{- toYaml .Values.server.annotations | nindent 8 }}
+          {{- tpl .Values.server.annotations . | nindent 8 }}
         {{- end }}
     spec:
     {{- if .Values.server.affinity }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.server.annotations }}
+{{ toYaml .Values.server.annotations | indent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.server.affinity }}
       affinity:

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -242,3 +242,25 @@ load _helpers
       yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "client/DaemonSet: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "client/DaemonSet: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -288,3 +288,25 @@ load _helpers
       yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "server/StatefulSet: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "server/StatefulSet: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -305,7 +305,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'server.annotations.foo=bar' \
+      --set 'server.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/values.yaml
+++ b/values.yaml
@@ -114,7 +114,9 @@ server:
   priorityClassName: ""
 
   # Extra annotations to attach to the server pods
-  annotations: {}
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the server pods
+  annotations: null
 
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
@@ -152,7 +154,9 @@ client:
   priorityClassName: ""
 
   # Extra annotations to attach to the client pods
-  annotations: {}
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the client pods
+  annotations: null
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)

--- a/values.yaml
+++ b/values.yaml
@@ -112,7 +112,7 @@ server:
   # used to assign priority to server pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
-  
+
   # Extra annotations to attach to the server pods
   annotations: {}
 
@@ -150,7 +150,7 @@ client:
   # used to assign priority to client pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
- 
+
   # Extra annotations to attach to the client pods
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,9 @@ server:
   # used to assign priority to server pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
+  
+  # Extra annotations to attach to the server pods
+  annotations: {}
 
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
@@ -147,6 +150,9 @@ client:
   # used to assign priority to client pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
+ 
+  # Extra annotations to attach to the client pods
+  annotations: {}
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)


### PR DESCRIPTION
[kube2iam](https://github.com/jtblin/kube2iam#kubernetes-annotation) and [kiam](https://github.com/uswitch/kiam#overview) require to be able to assign a role to the pod and have the necessary permissions to use the Cloud Auto Join feature on AWS.