### PR TITLE
Add support for custom environment variables

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -51,3 +51,15 @@ Add a special case for replicas=1, where it should default to 0 as well.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Inject extra environment vars in the format key:value, if populated
+*/}}
+{{- define "consul.extraEnvironmentVars" -}}
+{{- if .extraEnvironmentVars -}}
+{{- range $key, $value := .extraEnvironmentVars }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -66,6 +66,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- include "consul.extraEnvironmentVars" .Values.client | nindent 12 }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -70,6 +70,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- include "consul.extraEnvironmentVars" .Values.server | nindent 12 }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -220,3 +220,32 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].command | map(select(test("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+#--------------------------------------------------------------------
+# extraEnvironmentVariables
+
+@test "client/DaemonSet: custom environment variables" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.extraEnvironmentVars.custom_proxy=fakeproxy' \
+      --set 'client.extraEnvironmentVars.no_proxy=custom_no_proxy' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[3].name' | tee /dev/stderr)
+  [ "${actual}" = "custom_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[3].value' | tee /dev/stderr)
+  [ "${actual}" = "fakeproxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[4].name' | tee /dev/stderr)
+  [ "${actual}" = "no_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[4].value' | tee /dev/stderr)
+  [ "${actual}" = "custom_no_proxy" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -265,3 +265,32 @@ load _helpers
       yq '.spec.template.spec.affinity | .podAntiAffinity? != null' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# extraEnvironmentVariables
+
+@test "server/StatefulSet: custom environment variables" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraEnvironmentVars.custom_proxy=fakeproxy' \
+      --set 'server.extraEnvironmentVars.no_proxy=custom_no_proxy' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "custom_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "fakeproxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[3].name' | tee /dev/stderr)
+  [ "${actual}" = "no_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[3].value' | tee /dev/stderr)
+  [ "${actual}" = "custom_no_proxy" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,15 @@ server:
   replicas: 3
   bootstrapExpect: 3 # Should <= replicas count
 
+  # extraEnvVars is a list of extra enviroment variables to set with the stateful set. These could be
+  # used to include proxy settings required for cloud auto-join feature, 
+  # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
+  # custom consul parameters.
+  extraEnvironmentVars: {}
+    # http_proxy: http://localhost:3128
+    # https_proxy: http://localhost:3128
+    # no_proxy: internal.domain.com
+
   # enterpriseLicense refers to a Kubernetes secret that you have created that
   # contains your enterprise license. It is required if you are using an
   # enterprise binary. Defining it here applies it to your cluster once a leader
@@ -136,6 +145,15 @@ client:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
+
+  # extraEnvVars is a list of extra enviroment variables to set with the pod. These could be
+  # used to include proxy settings required for cloud auto-join feature, 
+  # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
+  # custom consul parameters.
+  extraEnvironmentVars: {}
+    # http_proxy: http://localhost:3128
+    # https_proxy: http://localhost:3128
+    # no_proxy: internal.domain.com
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)


### PR DESCRIPTION
To support [cloud auto join](https://www.consul.io/docs/agent/cloud-auto-join.html) capabilities in our infrastructure, we needed to add proxies in the client daemon set. This feature will also support custom consul parameters.