### PR TITLE
Add liveness and readiness probes for the catalog sync pod

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -75,4 +75,24 @@ spec:
                 {{- if .Values.syncCatalog.k8sTag }}
                 -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }}
                 {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,10 @@ global:
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as the catalog sync. This can be overridden
   # per component below.
-  imageK8S: "hashicorp/consul-k8s:0.5.0"
+  # Note: support for the catalog sync's liveness and readiness probes was added
+  # to consul-k8s v0.6.0. If using an older consul-k8s version, you may need to
+  # remove these checks to make the sync work.
+  imageK8S: "hashicorp/consul-k8s:0.6.0"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running


### PR DESCRIPTION
With the addition of a `/health/ready` endpoint in the latest
version of consul-k8s, it's possible to add healthchecks to this
pod, allowing Kubernetes to restart it if it has any issues.

Updates consul-k8s default image to v0.6.0 which supports these
checks. Adds note about removing these checks if using an older
version.

Finishes [consul-k8s issue 57](https://github.com/hashicorp/consul-k8s/issues/57).