### PR TITLE
Remove quotes from `extraConfig` inputs

### DIFF
--- a/templates/client-config-configmap.yaml
+++ b/templates/client-config-configmap.yaml
@@ -13,5 +13,5 @@ metadata:
     release: {{ .Release.Name }}
 data:
   extra-from-values.json: |-
-{{ tpl .Values.client.extraConfig . | indent 4 }}
+{{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}
 {{- end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -12,5 +12,5 @@ metadata:
     release: {{ .Release.Name }}
 data:
   extra-from-values.json: |-
-{{ tpl .Values.server.extraConfig . | indent 4 }}
+{{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Fixes #74. 

This enables users to specify `extraConfig` values using Helm's `--set` CLI
flag while installing the Helm chart. The format for using this command is:

```
--set 'client.extraConfig="{"log_level": "DEBUG"}"'
```

If client or server `extraConfig` values are specified in values.yaml,
this change will generally not impact the values as they are already
strings without the addition of quotes.