### PR TITLE
Update Metadata volume name to include namespace 

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
                 {{- end }}
                 -server
           volumeMounts:
-            - name: {{ .Values.server.storageClaimName }}
+            - name: data-{{ .Release.Namespace }}
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
@@ -153,7 +153,7 @@ spec:
           {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ .Values.server.storageClaimName }}
+        name: data-{{ .Release.Namespace }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
                 {{- end }}
                 -server
           volumeMounts:
-            - name: data
+            - name: {{ .Values.server.storageClaimName }}
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
@@ -153,7 +153,7 @@ spec:
           {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: data
+        name: {{ .Values.server.storageClaimName }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,7 @@ server:
   # to null (the Kube cluster will pick the default).
   storage: 10Gi
   storageClass: null
+  storageClaimName: "data"
 
   # connect will enable Connect on all the servers, initializing a CA
   # for Connect-related connections. Other customizations can be done

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,6 @@ server:
   # to null (the Kube cluster will pick the default).
   storage: 10Gi
   storageClass: null
-  storageClaimName: "data"
 
   # connect will enable Connect on all the servers, initializing a CA
   # for Connect-related connections. Other customizations can be done


### PR DESCRIPTION
This creates data volumes with unique names based off the namespace in which it is deployed.

Follows up on the work done on #112. 

Fixes #110. 