### PR TITLE
Support node selectors in the Helm chart

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -173,4 +173,8 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
+    {{- if .Values.client.tolerations }}
+      tolerations:
+{{ toYaml .Values.client.tolerations | indent 8 }}
+    {{- end }}
 {{- end }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -173,6 +173,10 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
+    {{- if .Values.client.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.client.nodeSelector | indent 8 }}
+    {{- end }}
     {{- if .Values.client.tolerations }}
       tolerations:
 {{ toYaml .Values.client.tolerations | indent 8 }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -173,12 +173,8 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
-    {{- if .Values.client.nodeSelector }}
+      {{- if .Values.client.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.client.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.client.tolerations }}
-      tolerations:
-{{ toYaml .Values.client.tolerations | indent 8 }}
-    {{- end }}
+        {{ tpl .Values.client.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 {{- end }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -87,4 +87,8 @@ spec:
           secret:
             secretName: {{ .Values.connectInject.certs.secretName }}
 {{- end }}
+    {{- if .Values.connectInject.tolerations }}
+      tolerations:
+{{ toYaml .Values.connectInject.tolerations | indent 8 }}
+    {{- end }}
 {{- end }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -87,12 +87,8 @@ spec:
           secret:
             secretName: {{ .Values.connectInject.certs.secretName }}
 {{- end }}
-    {{- if .Values.connectInject.nodeSelector }}
+      {{- if .Values.connectInject.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.connectInject.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.connectInject.tolerations }}
-      tolerations:
-{{ toYaml .Values.connectInject.tolerations | indent 8 }}
-    {{- end }}
+        {{ tpl .Values.connectInject.nodeSelector . | indent 8 | trim }}
+      {{- end }}  
 {{- end }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -87,6 +87,10 @@ spec:
           secret:
             secretName: {{ .Values.connectInject.certs.secretName }}
 {{- end }}
+    {{- if .Values.connectInject.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.connectInject.nodeSelector | indent 8 }}
+    {{- end }}
     {{- if .Values.connectInject.tolerations }}
       tolerations:
 {{ toYaml .Values.connectInject.tolerations | indent 8 }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -173,6 +173,10 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
+    {{- if .Values.server.tolerations }}
+      tolerations:
+{{ toYaml .Values.server.tolerations | indent 8 }}
+    {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -173,14 +173,10 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
-    {{- if .Values.server.nodeSelector }}
+      {{- if .Values.server.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.server.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.tolerations }}
-      tolerations:
-{{ toYaml .Values.server.tolerations | indent 8 }}
-    {{- end }}
+        {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
+      {{- end }}    
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -173,6 +173,10 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
+    {{- if .Values.server.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.server.nodeSelector | indent 8 }}
+    {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -95,6 +95,10 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
+    {{- if .Values.syncCatalog.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.syncCatalog.nodeSelector | indent 8 }}
+    {{- end }}
     {{- if .Values.syncCatalog.tolerations }}
       tolerations:
 {{ toYaml .Values.syncCatalog.tolerations | indent 8 }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -95,12 +95,8 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
-    {{- if .Values.syncCatalog.nodeSelector }}
+      {{- if .Values.syncCatalog.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.syncCatalog.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.syncCatalog.tolerations }}
-      tolerations:
-{{ toYaml .Values.syncCatalog.tolerations | indent 8 }}
-    {{- end }}
+        {{ tpl .Values.syncCatalog.nodeSelector . | indent 8 | trim }}
+      {{- end }}  
 {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -95,4 +95,8 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
+    {{- if .Values.syncCatalog.tolerations }}
+      tolerations:
+{{ toYaml .Values.syncCatalog.tolerations | indent 8 }}
+    {{- end }}
 {{- end }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -222,6 +222,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# nodeSelector
+
+@test "client/DaemonSet: nodeSelector is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "client/DaemonSet: specified nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml \
+      --set 'client.nodeSelector=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}
+
+#--------------------------------------------------------------------
 # priorityClassName
 
 @test "client/DaemonSet: priorityClassName is not set by default" {

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -190,3 +190,36 @@ load _helpers
       yq '.spec.template.spec.serviceAccountName | contains("connect-injector-webhook-svc-account")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "connectInject/Deployment: nodeSelector is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "connectInject/Deployment: nodeSelector is not set by default with sync enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "connectInject/Deployment: specified nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.nodeSelector=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -267,6 +267,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# nodeSelector
+
+@test "server/StatefulSet: nodeSelector is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/StatefulSet: specified nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.nodeSelector=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}
+
+#--------------------------------------------------------------------
 # priorityClassName
 
 @test "server/StatefulSet: priorityClassName is not set by default" {

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -282,3 +282,36 @@ load _helpers
       yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "syncCatalog/Deployment: nodeSelector is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "syncCatalog/Deployment: nodeSelector is not set by default with sync enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "syncCatalog/Deployment: specified nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.nodeSelector=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -109,6 +109,10 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
+  
+  ## server tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
@@ -204,6 +208,10 @@ client:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  ## client tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns
@@ -285,6 +293,10 @@ syncCatalog:
     secretName: null
     secretKey: null
 
+  ## syncCatalog tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false
@@ -325,3 +337,7 @@ connectInject:
     # defaults but can be customized if necessary.
     certName: tls.crt
     keyName: tls.key
+
+  ## connectInject tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,9 @@ server:
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
   
-  ## server tolerations for pod assignment
+  ## server node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
@@ -209,6 +211,9 @@ client:
     # no_proxy: internal.domain.com
 
   ## client tolerations for pod assignment
+  ## client node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
@@ -293,7 +298,9 @@ syncCatalog:
     secretName: null
     secretKey: null
 
-  ## syncCatalog tolerations for pod assignment
+  ## syncCatalog node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
@@ -338,6 +345,8 @@ connectInject:
     certName: tls.crt
     keyName: tls.key
 
-  ## connectInject tolerations for pod assignment
+  ## connectInject node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -109,12 +109,6 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
-  
-  ## server node selectors and tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  # tolerations: []
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
@@ -133,6 +127,13 @@ server:
   # This should be a multi-line string matching the Toleration array
   # in a PodSpec.
   tolerations: ""
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null
 
   # used to assign priority to server pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
@@ -192,6 +193,13 @@ client:
   #   - operator: "Exists"
   tolerations: ""
 
+  # nodeSelector labels for client pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null
+
   # used to assign priority to client pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
@@ -209,13 +217,6 @@ client:
     # http_proxy: http://localhost:3128,
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
-
-  ## client tolerations for pod assignment
-  ## client node selectors and tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  # tolerations: []
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
@@ -298,11 +299,12 @@ syncCatalog:
     secretName: null
     secretKey: null
 
-  ## syncCatalog node selectors and tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  # tolerations: []
+  # nodeSelector labels for syncCatalog pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
@@ -345,8 +347,9 @@ connectInject:
     certName: tls.crt
     keyName: tls.key
 
-  ## connectInject node selectors and tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  # tolerations: []
+  # nodeSelector labels for connectInject pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null

--- a/values.yaml
+++ b/values.yaml
@@ -112,9 +112,9 @@ server:
   
   ## server node selectors and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  nodeSelector: {}
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  tolerations: []
+  # tolerations: []
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
@@ -213,9 +213,9 @@ client:
   ## client tolerations for pod assignment
   ## client node selectors and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  nodeSelector: {}
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  tolerations: []
+  # tolerations: []
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
@@ -300,9 +300,9 @@ syncCatalog:
 
   ## syncCatalog node selectors and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  nodeSelector: {}
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  tolerations: []
+  # tolerations: []
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
@@ -347,6 +347,6 @@ connectInject:
 
   ## connectInject node selectors and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  nodeSelector: {}
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  tolerations: []
+  # tolerations: []


### PR DESCRIPTION
Builds on the initial implementation from #33, adding tests and standardizing the format.