### PR TITLE
Add support for network policies

### DIFF
--- a/templates/client-networkpolicy.yaml
+++ b/templates/client-networkpolicy.yaml
@@ -1,0 +1,110 @@
+# NetworkPolicies for the Consul client
+{{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)))}}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "consul.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: {{ .Release.Name }}
+      component: client
+  ingress:
+    # consul gossip
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: client
+        {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalClientSelectors }}
+        {{ .Values.networkPolicies.additionalClientSelectors | toYaml | nindent 8 | trim}}
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalServerSelectors }}
+        {{ .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8301
+        - protocol: UDP
+          port: 8301
+    {{- if (or .Values.networkPolicies.clientHTTPSelectors (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled))) }}
+    # consul http
+    - from:
+        {{- if .Values.networkPolicies.clientHTTPSelectors }}
+        {{ .Values.networkPolicies.clientHTTPSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+        {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: sync-catalog
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8500
+    {{- end }}
+
+  egress:
+    # consul gossip
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: client
+        {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalClientSelectors }}
+        {{ .Values.networkPolicies.additionalClientSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalServerSelectors }}
+        {{ .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8301
+        - protocol: UDP
+          port: 8301
+
+    # consul rpc
+    - to:
+        {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- if .Values.networkPolicies.additionalServerSelectors }}
+        {{ .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+        {{- else }}
+        {{ required "networkPolicies.additionalServerSelectors must be set or server must be enabled" .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8300
+{{- end }}

--- a/templates/connect-inject-networkpolicy.yaml
+++ b/templates/connect-inject-networkpolicy.yaml
@@ -1,0 +1,33 @@
+# Network policy for the connect injector
+{{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled))) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    app: {{ template "consul.name" . }}
+    release: "{{ .Release.Name }}"
+    component: connect-injector
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+      from:
+        {{ required "Usage of network policies requires setting a selector for the kubernetes master api endpoint" .Values.networkPolicies.kubernetesMasterSelector | toYaml | nindent 8 | trim }}
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 443
+      to:
+        {{ required "Usage of network policies requires setting a selector for the kubernetes master api endpoint" .Values.networkPolicies.kubernetesMasterSelector | toYaml | nindent 8 | trim }}
+{{- end}}

--- a/templates/dns-networkpolicy.yaml
+++ b/templates/dns-networkpolicy.yaml
@@ -1,0 +1,35 @@
+# Network policy for consul DNS
+{{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)))}}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "consul.fullname" . }}-dns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: "{{ .Release.Name }}"
+      hasDNS: "true"
+  ingress:
+    - from:
+        - podSelector:
+            {{ .Values.networkPolicies.dnsPodSelector | toYaml | nindent 12 | trim }}
+          namespaceSelector:
+            {{ .Values.networkPolicies.dnsNamespaceSelector | toYaml | nindent 12 | trim }}
+      ports:
+        # Although port 53 is the one exposed by the service, we need to use
+        # the ports on which the pod will actually receive the traffic.
+        - protocol: UDP
+          port: 8600
+        - protocol: TCP
+          port: 8600
+{{- end }}

--- a/templates/http-networkpolicies.yaml
+++ b/templates/http-networkpolicies.yaml
@@ -1,0 +1,71 @@
+# Networkpolicy for consul HTTP API
+{{- if (and .Values.global.enableNetworkPolicies .Values.networkPolicies.clientHTTPSelectors (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled))) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-client-http
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: {{ .Release.Name }}
+      component: client
+  ingress:
+    - from:
+        {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: sync-catalog
+        {{- end }}
+        {{ .Values.networkPolicies.clientHTTPSelectors | toYaml | nindent 8 | trim }}
+      ports:
+        - protocol: TCP
+          port: 8500
+{{- end }}
+
+---
+{{- if (and .Values.global.enableNetworkPolicies .Values.networkPolicies.serverHTTPSelectors (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-server-http
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: {{ .Release.Name }}
+      component: server
+  ingress:
+    - from:
+        {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: sync-catalog
+        {{- end }}
+        {{ .Values.networkPolicies.serverHTTPSelectors | toYaml | nindent 8 | trim }}
+      ports:
+        - protocol: TCP
+          port: 8500
+{{- end }}

--- a/templates/server-networkpolicy.yaml
+++ b/templates/server-networkpolicy.yaml
@@ -1,0 +1,122 @@
+# Network policy for the consul server cluster
+{{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "consul.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: server
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: {{ .Release.Name }}
+      component: server
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)))}}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: client
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalClientSelectors }}
+        {{ .Values.networkPolicies.additionalClientSelectors | toYaml | nindent 8 | trim}}
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalServerSelectors }}
+        {{ .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+      ports:
+        # consul gossip
+        - protocol: TCP
+          port: 8301
+        - protocol: UDP
+          port: 8301
+        # rpc
+        - protocol: TCP
+          port: 8300
+    {{- if .Values.networkPolicies.serverWanSelectors }}
+    # consul wan
+    - from:
+        {{ .Values.networkPolicies.serverWanSelectors | toYaml | nindent 8 | trim }}
+      ports:
+        # remote dc forwarding
+        - protocol: TCP
+          port: 8300
+        # wan gossip
+        - protocol: TCP
+          port: 8302
+        - protocol: UDP
+          port: 8302
+    {{- end }}
+    {{- if .Values.networkPolicies.serverHTTPSelectors }}
+    # consul http
+    - from:
+        {{ .Values.networkPolicies.serverHTTPSelectors | toYaml | nindent 8 | trim }}
+      ports:
+        - protocol: TCP
+          port: 8500
+    {{- end }}
+
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: client
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalClientSelectors }}
+        {{ .Values.networkPolicies.additionalClientSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+        {{- if .Values.networkPolicies.additionalServerSelectors }}
+        {{ .Values.networkPolicies.additionalServerSelectors | toYaml | nindent 8 | trim }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8301
+        - protocol: UDP
+          port: 8301
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+      ports:
+        - protocol: TCP
+          port: 8300
+    {{- if .Values.networkPolicies.serverWanSelectors }}
+    - to:
+        {{ .Values.networkPolicies.serverWanSelectors | toYaml | nindent 8 | trim }}
+      ports:
+        # remote dc forwarding
+        - protocol: TCP
+          port: 8300
+        # wan gossip
+        - protocol: TCP
+          port: 8302
+        - protocol: UDP
+          port: 8302
+    {{- end }}
+{{- end }}

--- a/templates/sync-catalog-networkpolicy.yaml
+++ b/templates/sync-catalog-networkpolicy.yaml
@@ -1,0 +1,56 @@
+# Network policy for sync-catalog.
+{{- if (and .Values.global.enableNetworkPolicies (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled))) }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "consul.fullname" . }}-sync-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: {{ .Release.Name }}
+      component: sync-catalog
+  ingress:
+    # Pod Healthcheck
+    - ports:
+        - protocol: TCP
+          port: 8080
+
+  egress:
+    # Kubernetes master API
+    - ports:
+        - protocol: TCP
+          port: 443
+      to:
+        {{ required "Usage of network policies requires setting a selector for the kubernetes master api endpoint" .Values.networkPolicies.kubernetesMasterSelector | toYaml | nindent 8 | trim }}
+    # Consul clients and servers
+    {{- if (or (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
+    - to:
+        {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: client
+        {{- end }}
+        {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: {{ .Release.Name }}
+              component: server
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8500
+    {{- end }}
+{{- end }}

--- a/test/unit/client-networkpolicy.bats
+++ b/test/unit/client-networkpolicy.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "client/networkpolicy: disabled by default" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: enabled with global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true'\
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: disabled with client.enabled=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'client.enabled=false' \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: enabled when not global.enabled and client.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'client.enabled=true' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.additionalServerSelectors[0].ipBlock.cidr="toto"' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#---------------------------------
+# gossip
+@test "client/networkpolicy: open gossip ports by default" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[1].podSelector.matchLabels.component | test("server")),
+                       (.spec.egress[1].to[0].podSelector.matchLabels.component | test("server"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: open gossip ports when client.enabled and server.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'global.enabled=false' \
+                        --set 'client.enabled=true' \
+                        --set 'server.enabled=true' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[1].podSelector.matchLabels.component | test("server")),
+                       (.spec.egress[1].to[0].podSelector.matchLabels.component | test("server"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: append additional gossip clients" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.additionalClientSelectors[0].podSelector.matchLabels.mylabel=toto' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[2].podSelector.matchLabels.mylabel | test("toto")),
+                       (.spec.egress[0].to[2].podSelector.matchLabels.mylabel | test("toto"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "client/networkpolicy: append additional gossip servers" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.additionalServerSelectors[0].podSelector.matchLabels.mylabel=toto' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[2].podSelector.matchLabels.mylabel | test("toto")),
+                       (.spec.egress[0].to[2].podSelector.matchLabels.mylabel | test("toto"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#----------------------------------
+# http
+@test "client/networkpolicy: allow HTTP traffic with clientHTTPSelectors" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.clientHTTPSelectors[0].podSelector.matchLabels.mylabel=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.ingress[1].from[0].podSelector.matchLabels.mylabel' | tee /dev/stderr)
+    [ "${actual}" = "\"toto\"" ]
+}
+
+@test "client/networkpolicy: allow sync-catalog traffic" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector=toto' \
+                        --set 'syncCatalog.enabled=true' \
+                        . | tee /dev/stderr |
+                       yq '.spec.ingress[1].from[0].podSelector.matchLabels.component' | tee /dev/stderr)
+    [ "${actual}" = "\"sync-catalog\"" ]
+}
+
+#----------------------------
+# rpc
+@test "client/networkpolicy: allow egress rpc when server.enabled " {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[1].to[0].podSelector.matchLabels.component' | tee /dev/stderr)
+    [ "${actual}" = "\"server\"" ]
+}
+
+@test "client/networkpolicy: allow egress to additional servers when server.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.additionalServerSelectors[0].podSelector.matchLabels.mylabel=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[1].to[1].podSelector.matchLabels.mylabel' | tee /dev/stderr)
+    [ "${actual}" = "\"toto\"" ]
+}
+
+@test "client/networkpolicy: allow egress to additional servers when not server.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/client-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=false' \
+                        --set 'networkPolicies.additionalServerSelectors[0].podSelector.matchLabels.mylabel=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[1].to[0].podSelector.matchLabels.mylabel' | tee /dev/stderr)
+    [ "${actual}" = "\"toto\"" ]
+}
+
+@test "client/networkpolicy: fail when not server.enabled and networkPolicies.additionalServerSelectors empty" {
+    cd `chart_dir`
+    run helm template \
+        -x templates/client-networkpolicy.yaml \
+        --set 'global.enableNetworkPolicies=true' \
+        --set 'server.enabled=false' \
+        .
+    [ $status = 1 ]
+}

--- a/test/unit/connect-inject-networkpolicies.bats
+++ b/test/unit/connect-inject-networkpolicies.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "connect-inject/networkpolicy: disabled by default when connect-inject is enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/connect-inject-networkpolicy.yaml \
+                        --set 'connectInject.enabled=true' \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "connect-inject/networkpolicy: enabled with global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/connect-inject-networkpolicy.yaml \
+                        --set 'connectInject.enabled=true' \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "connect-inject/networkpolicy: enabled with connectInject.enabled=true and global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/connect-inject-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'connectInject.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "connect-inject/networkpolicy: enabled when not global.enabled and connectInject.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/connect-inject-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'connectInject.enabled=true' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#---------------------------------------
+#
+
+@test "connect-inject/networkpolicy: fail when kubernetes master selector not set" {
+    cd `chart_dir`
+    run helm template \
+        -x templates/client-networkpolicy.yaml \
+        --set 'global.enableNetworkPolicies=true' \
+        --set 'connectInject.enabled=true' \
+        .
+    [ $status = 1 ]
+}
+
+@test "connect-inject/networkpolicy: sets the selector of the kubernetes master" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/connect-inject-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'connectInject.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[0].to[0].ipBlock.cidr | test("toto")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}

--- a/test/unit/dns-networkpolicy.bats
+++ b/test/unit/dns-networkpolicy.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "dns/networkpolicy: disabled by default" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/dns-networkpolicy.yaml \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "dns/networkpolicy: enabled with global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/dns-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "dns/networkpolicy: disabled with dns.enabled=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/dns-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'dns.enabled=false' \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "dns/networkpolicy: enabled when not global.enabled and dns.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/dns-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'dns.enabled=true' \
+                        --set 'global.enabled=false' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#-------------------------------------
+# sets the right selectors
+
+@test "dns/networkpolicy: correctly sets the dns namespace selector" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/dns-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.dnsNamespaceSelector.matchLabels.name=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.ingress[0].from[0].namespaceSelector.matchLabels.name | test("toto")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}

--- a/test/unit/server-networkpolicy.bats
+++ b/test/unit/server-networkpolicy.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+
+@test "server/networkpolicy: disabled by default" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "server/networkpolicy: enabled with global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "server/networkpolicy: disabled with server.enabled=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=false' \
+                        --set 'networkPolicies.additionalServerSelectors=toto' \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "server/networkpolicy: enabled when not global.enabled and server.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=true' \
+                        --set 'global.enabled=false' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+
+#------------------------------
+# gossip
+@test "server/networkpolicy: add client selector if client.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=true' \
+                        --set 'client.enabled=true' \
+                        --set 'global.enabled=false' \
+                        . | tee /dev/stderr |
+                       yq '.spec.ingress[0].from[1].podSelector.matchLabels.component | test("client")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "server/networkpolicy: add additionalClientSlectors gossip/rpc" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=true' \
+                        --set 'client.enabled=true' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.additionalClientSelectors[0].ipBlock.cidr=127.0.0.1/32' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[2].ipBlock.cidr | test("127.0.0.1/32")),
+                       (.spec.egress[0].to[2].ipBlock.cidr | test("127.0.0.1/32"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "server/networkpolicy: add additionalServerSlectors gossip/rpc" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=true' \
+                        --set 'client.enabled=true' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.additionalServerSelectors[0].ipBlock.cidr=127.0.0.1/32' \
+                        . | tee /dev/stderr |
+                       yq '[
+                       (.spec.ingress[0].from[2].ipBlock.cidr | test("127.0.0.1/32")),
+                       (.spec.egress[0].to[2].ipBlock.cidr | test("127.0.0.1/32"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#------------------------------
+# wan
+@test "server/networkpolicy: add wan servers" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'server.enabled=true' \
+                        --set 'client.enabled=true' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.serverWanSelectors[0].ipBlock.cidr=127.0.0.1/32' \
+                        . | tee /dev/stderr |
+                       yq -r '[
+                       (.spec.ingress[1].from[0].ipBlock.cidr | test("127.0.0.1/32")),
+                       (.spec.egress[2].to[0].ipBlock.cidr | test("127.0.0.1/32"))
+                       ] | all' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#---------------------------------
+# http
+@test "server/networkpolicy: add wan servers" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/server-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'networkPolicies.serverHTTPSelectors[0].ipBlock.cidr=127.0.0.1/32' \
+                        . | tee /dev/stderr |
+                       yq -r '.spec.ingress[1].from[0].ipBlock.cidr | test("127.0.0.1/32")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}

--- a/test/unit/sync-catalog-networkpolicy.bats
+++ b/test/unit/sync-catalog-networkpolicy.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "sync-catalog/networkpolicy: disabled by default" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "sync-catalog/networkpolicy: disabled with global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        . | tee /dev/stderr |
+                       yq 'length == 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "sync-catalog/networkpolicy: enabled with syncCatalog.enabled and global.enableNetworkPolicies" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'syncCatalog.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "sync-catalog/networkpolicy: enabled when not global.enabled and syncCatalog.enabled" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'syncCatalog.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        --set 'global.enabled=false' \
+                        --set 'networkPolicies.additionalServerSelectors[0].ipBlock.cidr="toto"' \
+                        . | tee /dev/stderr |
+                       yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------
+#
+
+@test "sync-catalog/networkpolicy: fail when kubernetes master selector not set" {
+    cd `chart_dir`
+    run helm template \
+        -x templates/sync-catalog-networkpolicy.yaml \
+        --set 'global.enableNetworkPolicies=true' \
+        --set 'syncCatalog.enabled=true' \
+        .
+    [ $status = 1 ]
+}
+
+@test "sync-catalog/networkpolicy: sets the selector of the kubernetes master" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'syncCatalog.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[0].to[0].ipBlock.cidr | test("toto")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+
+@test "sync-catalog/networkpolicy: sets the server egress selector" {
+    cd `chart_dir`
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enabled=false' \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'syncCatalog.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        --set 'server.enabled=true' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[1].to[0].podSelector.matchLabels.component | test("server")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}
+
+@test "sync-catalog/networkpolicy: sets the client egress selector" {
+    cd `chart_dir`
+    # either additionalServerSelector must be set or server.enabled in order to
+    # enable the client
+    local actual=$(helm template \
+                        -x templates/sync-catalog-networkpolicy.yaml \
+                        --set 'global.enabled=false' \
+                        --set 'global.enableNetworkPolicies=true' \
+                        --set 'syncCatalog.enabled=true' \
+                        --set 'networkPolicies.kubernetesMasterSelector[0].ipBlock.cidr=toto' \
+                        --set 'client.enabled=true' \
+                        --set 'networkPolicies.additionalServerSelectors[0].ipBlock.cidr=test' \
+                        . | tee /dev/stderr |
+                       yq '.spec.egress[1].to[0].podSelector.matchLabels.component | test("client")' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -37,15 +37,20 @@ global:
   # chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   enablePodSecurityPolicies: false
 
+  # enableNetworkPolicies is a boolean flag that controls whether
+  # network policies are created for the components created by this
+  # chart. See: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  enableNetworkPolicies: false
+
   # Gossip encryption key. To enable gossip encryption, provide the name of
   # a Kubernetes secret that contains a gossip key. You can create a gossip
-  # key with the "consul keygen" command. 
-  # See https://www.consul.io/docs/commands/keygen.html 
+  # key with the "consul keygen" command.
+  # See https://www.consul.io/docs/commands/keygen.html
   gossipEncryption:
     secretName: null
     secretKey: null
 
-  # bootstrapACLs will automatically create and assign ACL tokens within 
+  # bootstrapACLs will automatically create and assign ACL tokens within
   # the Consul cluster. This currently requires enabling both servers and
   # clients within Kubernetes. Additionally requires Consul v1.4+ and
   # consul-k8s v0.8.0+.
@@ -150,7 +155,7 @@ server:
   annotations: null
 
   # extraEnvVars is a list of extra enviroment variables to set with the stateful set. These could be
-  # used to include proxy settings required for cloud auto-join feature, 
+  # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
   # custom consul parameters.
   extraEnvironmentVars: {}
@@ -215,7 +220,7 @@ client:
   annotations: null
 
   # extraEnvVars is a list of extra enviroment variables to set with the pod. These could be
-  # used to include proxy settings required for cloud auto-join feature, 
+  # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
   # custom consul parameters.
   extraEnvironmentVars: {}
@@ -387,3 +392,46 @@ connectInject:
     # configured proxy.
     proxyDefaults: |
       {}
+
+networkPolicies:
+  # Selector for the kubenertes master API endpoint. Must be set for sync-catalog or connect-inject.
+  # In some environments, it will be the IP range of the kubernetes masters, e.g.:
+  # kubernetesMasterSelector:
+  #   - ipBlock:
+  #       cidr: 10.0.0.0/28
+  kubernetesMasterSelector: null
+
+  # additionalClientSelectors and additionalServerSelectors are used to allow traffic
+  # to/from clients/servers outside of kubernetes in hybrid environments.
+  additionalClientSelectors: null
+  additionalServerSelectors: null
+
+  # clientHTTPSelectors and serverHTTPSelectors are both used to allow access to the consul
+  # HTTP API port respectively to the clients and the servers.
+  clientHTTPSelectors: null
+  masterHTTPSelectors: null
+
+  # For consul dns access, a pod will need to match both the dnsPodSelector and
+  # the dnsNamespaceSelector in order to be able to query the service.
+  # dnsPodSelector is the selector for the pods that will be allowed to query the
+  # dns service. Usually, only kube-dns needs to access it.
+  dnsPodSelector:
+    matchLabels:
+      k8s-app: kube-dns
+
+  # dnsNamespaceSelector is the namespace selector used in conjunction with dnsPodSelector
+  # to determine from which namespace the requests can originate. This is usually the kube-system
+  # namespace only.
+  # Note that, since the kube-system namespace doesn't necessarily have labels, we set an
+  # empty selector as default here, but it should be changed to e.g. :
+  #  dnsNamespaceSelector:
+  #    matchLabels:
+  #      name: kube-system
+  dnsNamespaceSelector: {}
+
+  # Selectors for consul WAN gossip/rpc.
+  # Example:
+  # serverWanSelectors:
+  #   - ipBlock:
+  #       cidr: 10.2.0.0/24
+  serverWanSelectors: null


### PR DESCRIPTION
Hi,

This PR adds support for kubernetes network policies.

The network policies are deactivated by default.

It assumes a namespace with a policy that denies all ingress/egress apart from DNS. Example base policy : 
```
---
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: default-deny
spec:
  podSelector: {}
  policyTypes:
    - Ingress
    - Egress
  egress:
    - to:
        - podSelector:
            matchLabels:
              k8s-app: kube-dns
          namespaceSelector:
            matchLabels:
              name: kube-system
      ports:
        - protocol: TCP
          port: 53
        - protocol: UDP
          port: 53
```

