### PR TITLE
Implement `bootstrapACLs` option

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -11,3 +11,10 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
   $ helm get {{ .Release.Name }}
+
+
+{{- if (and .Values.global.bootstrapACLs (gt (len .Values.server.extraConfig) 3)) }}
+Warning: Defining server extraConfig potentially disrupts the automatic ACL
+         bootstrapping required settings. This may cause future issues if
+         there are conflicts.
+{{- end }}

--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -8,13 +8,24 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.enablePodSecurityPolicies }}
+{{- if (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
 rules:
+{{- end }}
+{{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames:
     - {{ template "consul.fullname" . }}-client
     verbs:
     - use
+{{- end }}
+{{- if .Values.global.bootstrapACLs }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-consul-client-acl-token
+    verbs:
+      - get
 {{- end }}
 {{- end }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -61,6 +61,10 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
+        {{- if .Values.global.bootstrapACLs }}
+        - name: aclconfig
+          emptyDir: {}
+        {{- end }}
 
       containers:
         - name: consul
@@ -106,6 +110,9 @@ spec:
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
                 {{- end }}
+                {{- if .Values.global.bootstrapACLs}}
+                -config-dir=/consul/aclconfig \
+                {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
                 -data-dir=/consul/data \
                 {{- if (and .Values.global.gossipEncryption.enabled .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
@@ -132,6 +139,10 @@ spec:
             - name: userconfig-{{ .name }}
               readOnly: true
               mountPath: /consul/userconfig/{{ .name }}
+            {{- end }}
+            {{- if .Values.global.bootstrapACLs}}
+            - name: aclconfig
+              mountPath: /consul/aclconfig
             {{- end }}
           lifecycle:
             preStop:
@@ -173,6 +184,22 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
+      {{- if .Values.global.bootstrapACLs }}
+      initContainers:
+      - name: client-acl-init
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s acl-init \
+              -secret-name="{{ .Release.Name }}-consul-client-acl-token" \
+              -k8s-namespace={{ .Release.Namespace }} \
+              -init-type="client"
+        volumeMounts:
+          - name: aclconfig
+            mountPath: /consul/aclconfig
+      {{- end }}
       {{- if .Values.client.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.client.nodeSelector . | indent 8 | trim }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: connect-injector
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
     spec:
   {{- if not .Values.connectInject.certs.secretName }}
       serviceAccountName: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-server-acl-init
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-server-acl-init
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,0 +1,56 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ template "consul.fullname" . }}-server-acl-init
+      labels:
+        app: {{ template "consul.name" . }}
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: server-acl-init
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
+      containers:
+        - name: post-install-job
+          image: {{ .Values.global.imageK8S }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              consul-k8s server-acl-init \
+                -release-name={{ .Release.Name }} \
+                -k8s-namespace={{ .Release.Namespace }} \
+                -expected-replicas={{ .Values.server.replicas }} \
+                {{- if .Values.syncCatalog.enabled }}
+                -create-sync-token=true \
+                {{- end }}
+                {{- if (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)) }}
+                -allow-dns=true
+                {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -13,4 +13,15 @@ metadata:
 data:
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
+  {{- if .Values.global.bootstrapACLs }}
+  acl-config.json: |
+    {
+      "acl": {
+        "enabled": true,
+        "default_policy": "deny",
+        "down_policy": "extend-cache",
+        "enable_token_persistence": true
+      }
+    }
+  {{- end }}
 {{- end }}

--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -27,6 +27,15 @@ rules:
       - nodes
     verbs:
       - get
+{{- if .Values.global.bootstrapACLs }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-consul-catalog-sync-acl-token
+    verbs:
+      - get
+{{- end }}
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -48,6 +48,13 @@ spec:
                   name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
                   key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
             {{- end }}
+            {{- if .Values.global.bootstrapACLs }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-consul-catalog-sync-acl-token"
+                  key: "token"
+            {{- end}}
           command:
             - "/bin/sh"
             - "-ec"
@@ -95,6 +102,19 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.global.bootstrapACLs }}
+      initContainers:
+      - name: sync-acl-init
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s acl-init \
+              -secret-name="{{ .Release.Name }}-consul-catalog-sync-acl-token" \
+              -k8s-namespace={{ .Release.Namespace }} \
+              -init-type="sync"
+      {{- end }}
       {{- if .Values.syncCatalog.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.syncCatalog.nodeSelector . | indent 8 | trim }}

--- a/test/unit/client-clusterrole.bats
+++ b/test/unit/client-clusterrole.bats
@@ -51,3 +51,43 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.enablePodSecurityPolicies
+
+@test "client/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-clusterrole.yaml  \
+      --set 'client.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
+@test "client/ClusterRole: allows secret access with global.bootsrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-clusterrole.yaml  \
+      --set 'client.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}
+
+@test "client/ClusterRole: allows secret access with global.bootsrapACLs=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-clusterrole.yaml  \
+      --set 'client.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[1].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}

--- a/test/unit/server-acl-init-clusterrole.bats
+++ b/test/unit/server-acl-init-clusterrole.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInit/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ClusterRole: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRole: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ClusterRole: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInit/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInit/Job: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# dns
+
+@test "serverACLInit/Job: dns acl option enabled with with .dns.enabled=-" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: dns acl option enabled with with .dns.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'dns.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: dns acl option disabled with with .dns.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'dns.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInit/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ServiceAccount: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ServiceAccount: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -51,3 +51,13 @@ load _helpers
       yq '.data["extra-from-values.json"] | match("world") | length' | tee /dev/stderr)
   [ ! -z "${actual}" ]
 }
+
+@test "server/ConfigMap: creates acl config with .global.bootstrapACLs enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.data["acl-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/sync-catalog-clusterrole.bats
+++ b/test/unit/sync-catalog-clusterrole.bats
@@ -51,3 +51,31 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.enablePodSecurityPolicies
+
+@test "syncCatalog/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-clusterrole.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[2].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
+@test "syncCatalog/ClusterRole: allows secret access with global.bootsrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-clusterrole.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[2].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -315,3 +315,34 @@ load _helpers
       yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
+@test "syncCatalog/Deployment: CONSUL_HTTP_TOKEN env variable created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: init container is created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "client-acl-init" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -46,6 +46,12 @@ global:
     secretName: null
     secretKey: null
 
+  # bootstrapACLs will automatically create and assign ACL tokens within 
+  # the Consul cluster. This currently requires enabling both servers and
+  # clients within Kubernetes. Additionally requires Consul v1.4+ and
+  # consul-k8s v0.8.0+.
+  bootstrapACLs: false
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.


### PR DESCRIPTION
This new config option allows folks creating an entire Consul cluster
(both servers and clients, optionally catalog sync) in Kubernetes to
automatically enable ACLs and bootstrap the system with server, client
and (optionally) catalog sync tokens.

It does this by applying a `server-acl-init` job after the servers have
started up to bootstrap the servers and create client and sync tokens
that are written to Kubernetes secrets. The client and sync pods have
an init container when this option is enabled that waits for these
secrets to be populated, then applies them once they become available.

Manual creation of other ACL toekns is possible by extracting the original
bootstrap token out of its Kubernetes secret and connecting directly to
a Consul server.

At the moment, the secrets are not automatically cleaned up when the Helm
chart is deleted. So, like PersistentVolumeClaims, these will need to be
manually deleted.