### PR TITLE
Add K8sConsulPrefix

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -73,8 +73,11 @@ spec:
                 -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }} \
                 {{- end }}
                 {{- if .Values.syncCatalog.k8sTag }}
-                -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }}
+                -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }} \
                 {{- end }}
+                {{- if .Values.syncCatalog.consulPrefix}}
+                -consul-service-prefix="{{ .Values.syncCatalog.consulPrefix}}" \
+                {{- end}}
           livenessProbe:
             httpGet:
               path: /health/ready

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -175,6 +175,30 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# consulPrefix
+
+@test "syncCatalog/Deployment: no consulPrefix by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-service-prefix"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "syncCatalog/Deployment: can specify consulPrefix" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.consulPrefix=foo-' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-service-prefix=\"foo-\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # k8sTag
 
 @test "syncCatalog/Deployment: no k8sTag flag by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -274,6 +274,12 @@ syncCatalog:
   # prepended with "consul-". (Consul -> Kubernetes sync)
   k8sPrefix: null
 
+  # consulPrefix is the service prefix which preprends itself
+  # to Kubernetes services registered within Consul
+  # For example, "k8s-" will register all services peprended with "k8s-".
+  # (Kubernetes -> Consul sync)
+  consulPrefix: null
+
   # k8sTag is an optional tag that is applied to all of the Kubernetes services
   # that are synced into Consul. If nothing is set, defaults to "k8s".
   # (Kubernetes -> Consul sync)


### PR DESCRIPTION
Updates values file to allow users to prefix k8s services registered within consul with a string.