### PR TITLE
added default logLevel and consulWriteInterval

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -72,6 +72,12 @@ spec:
                 {{- if .Values.syncCatalog.nodePortSyncType }}
                 -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }} \
                 {{- end }}
+                {{- if .Values.syncCatalog.consulWriteInterval }}
+                -consul-write-interval={{ .Values.syncCatalog.consulWriteInterval }} \
+                {{- end }}
+                {{- if .Values.syncCatalog.logLevel }}
+                -log-level={{ .Values.syncCatalog.logLevel }} \
+                {{- end }}
                 {{- if .Values.syncCatalog.k8sTag }}
                 -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }}
                 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -306,12 +306,11 @@ syncCatalog:
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: null
 
-  #Log verbosity level. Supported values (in order of detail) are \"trace\", "+
-  #"\"debug\", \"info\", \"warn\", and \"error\".")
+  # Log verbosity level. One of "trace", "debug", "info", "warn", or "error".
   logLevel: info
 
-  # The interval to perform syncing operations creating Consul services
-  consulWriteInterval: 30s
+  # Override the default interval to perform syncing operations creating Consul services.
+  consulWriteInterval: null
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:

--- a/values.yaml
+++ b/values.yaml
@@ -306,6 +306,13 @@ syncCatalog:
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: null
 
+  #Log verbosity level. Supported values (in order of detail) are \"trace\", "+
+  #"\"debug\", \"info\", \"warn\", and \"error\".")
+  logLevel: info
+
+  # The interval to perform syncing operations creating Consul services
+  consulWriteInterval: 30s
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   enabled: false


### PR DESCRIPTION
log-level and consul-write-interval are important configuration properties that should be exposed to edit in the values.yaml (The defaults are similar to these in 'consul-k8s')