### PR TITLE
Support auth method in connect-inject

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -9,11 +9,7 @@ be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-client

--- a/templates/client-clusterrolebinding.yaml
+++ b/templates/client-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-client

--- a/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/templates/connect-inject-authmethod-clusterrole.yaml
@@ -1,19 +1,19 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-admin-role-binding
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-role
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
-    namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+{{- end }}
 {{- end }}

--- a/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -1,0 +1,39 @@
+{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-authdelegator-role-binding
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:auth-delegator"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-serviceaccount-role-binding
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}
+{{- end }}

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -1,6 +1,6 @@
 # The ClusterRole to enable the Connect injector to get, list, watch and patch MutatingWebhookConfiguration.
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -52,8 +52,11 @@ spec:
                 -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
                 {{ end -}}
                 -listen=:8080 \
+                {{- if .Values.global.bootstrapACLs }}
+                -acl-auth-method="{{ .Release.Name }}-consul-k8s-auth-method" \
+                {{- end }}
 {{- if .Values.connectInject.certs.secretName }}
-                -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }}
+                -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
                 -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }}
 {{- else }}
                 -tls-auto=${CONSUL_FULLNAME}-connect-injector-cfg \

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -22,6 +22,18 @@ rules:
     verbs:
       - create
       - get
+{{- if .Values.connectInject.enabled }}
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs:
+      - get
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -49,7 +49,13 @@ spec:
                 -create-sync-token=true \
                 {{- end }}
                 {{- if (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)) }}
-                -allow-dns=true
+                -allow-dns=true \
+                {{- end }}
+                {{- if .Values.connectInject.enabled }}
+                -create-inject-token=true \
+                {{- end }}
+                {{- if .Values.connectInject.aclBindingRuleSelector }}
+                -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }}
                 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-clusterrole.yaml
+++ b/templates/server-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-server

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server

--- a/test/terraform/service-account.yaml
+++ b/test/terraform/service-account.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helm
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: helm

--- a/test/unit/connect-inject-authmethod-clusterrole.bats
+++ b/test/unit/connect-inject-authmethod-clusterrole.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "connectInjectAuthMethod/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRole: enabled with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRole: disabled with connectInject.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrole.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRole: enabled with global.bootstrapACLs.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrole.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/connect-inject-authmethod-clusterrolebinding.bats
+++ b/test/unit/connect-inject-authmethod-clusterrolebinding.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "connectInjectAuthMethod/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRoleBinding: enabled with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRoleBinding: disabled with connectInject.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ClusterRoleBinding: enabled with global.bootstrapACLs.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/connect-inject-authmethod-serviceaccount.bats
+++ b/test/unit/connect-inject-authmethod-serviceaccount.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "connectInjectAuthMethod/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ServiceAccount: enabled with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      --set 'global.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInjectAuthMethod/ServiceAccount: disabled with connectInject.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInjectAuthMethod/ServiceAccount: enabled with global.bootstrapACLs.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -77,3 +77,28 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# aclBindingRuleSelector/global.bootstrapACLs
+
+@test "serverACLInit/Job: no acl-binding-rule-selector flag by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml \
+      --set 'connectInject.aclBindingRuleSlector=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: can specify acl-binding-rule-selector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'connectInject.aclBindingRuleSelector="foo"' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-binding-rule-selector=\"foo\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -365,3 +365,9 @@ connectInject:
   # nodeSelector: |
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: null
+
+  # aclBindingRuleSelector is a string that defines the automatic binding
+  # rule to control the allowed authentication for Connect injection. The
+  # default disallows using the default service account for ACl generation.
+  # Requires Consul v1.5+ and consul-k8s v0.8.0+.
+  aclBindingRuleSelector: "serviceaccount.name!=default"


### PR DESCRIPTION
Updates the server-acl-init job to also register Kuberentes as an
auth method for Connect. Additionally adds an init container for the
connect injection deployment to wait for the resultant acl token to
be available in a Kubernetes secret.

Updates rbac resources to use v1 instead of the beta tag. Removes the
helper method that stopped name duplication if the release is explicitly
named `consul`, since this breaks several necessary naming assumptions.