### PR TITLE
Support the option to create an enterprise license acl token

### DIFF
--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "consul.fullname" . }}-enterprise-license
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-consul-enterprise-license-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/enterprise-license-clusterrolebinding.yaml
+++ b/templates/enterprise-license-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-enterprise-license
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-enterprise-license
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-enterprise-license
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-enterprise-license
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/enterprise-license.yaml
+++ b/templates/enterprise-license.yaml
@@ -14,7 +14,7 @@ metadata:
     release: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "100"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
@@ -30,21 +30,42 @@ spec:
         component: license
     spec:
       restartPolicy: Never
-
+      serviceAccountName: {{ template "consul.fullname" . }}-enterprise-license
       containers:
-        - name: post-install-job
-          image: "appropriate/curl"
+        - name: apply-enterprise-license
+          image: "{{ default .Values.global.image .Values.server.image }}"
           env:
             - name: ENTERPRISE_LICENSE
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.server.enterpriseLicense.secretName }}
                   key: {{ .Values.server.enterpriseLicense.secretKey }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://{{ template "consul.fullname" . }}-server:8500
+            {{- if .Values.global.bootstrapACLs }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-consul-enterprise-license-acl-token"
+                  key: "token"
+            {{- end}}
           command: 
             - "/bin/sh"
             - "-ec"
             - |
-              curl -fsSL -X PUT http://{{ template "consul.fullname" . }}-server:8500/v1/operator/license \
-                --data ${ENTERPRISE_LICENSE}
+              consul license put "${ENTERPRISE_LICENSE}"
+      {{- if .Values.global.bootstrapACLs }}
+      initContainers:
+      - name: ent-license-acl-init
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s acl-init \
+              -secret-name="{{ .Release.Name }}-consul-enterprise-license-acl-token" \
+              -k8s-namespace={{ .Release.Namespace }} \
+              -init-type="sync"
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -44,7 +44,6 @@ spec:
               consul-k8s server-acl-init \
                 -release-name={{ .Release.Name }} \
                 -k8s-namespace={{ .Release.Namespace }} \
-                -expected-replicas={{ .Values.server.replicas }} \
                 {{- if .Values.syncCatalog.enabled }}
                 -create-sync-token=true \
                 {{- end }}
@@ -55,8 +54,12 @@ spec:
                 -create-inject-token=true \
                 {{- end }}
                 {{- if .Values.connectInject.aclBindingRuleSelector }}
-                -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }}
+                -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
                 {{- end }}
+                {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+                -create-enterprise-license-token=true \
+                {{- end }}
+                -expected-replicas={{ .Values.server.replicas }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/enterprise-license-clusterrole.bats
+++ b/test/unit/enterprise-license-clusterrole.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "enterpriseLicense/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: disabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: disabled with server=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: disabled with client=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: disabled when ent secretName missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: disabled when ent secretKey missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRole: can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/enterprise-license-clusterrolebinding.bats
+++ b/test/unit/enterprise-license-clusterrolebinding.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled with server=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled with client=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled when ent secretName missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: disabled when ent secretKey missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ClusterRoleBinding: can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/enterprise-license-serviceaccount.bats
+++ b/test/unit/enterprise-license-serviceaccount.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "enterpriseLicense/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: disabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: disabled with server=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: disabled with client=false, global.bootstrapACLs=true, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: disabled when ent secretName missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: disabled when ent secretKey missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/ServiceAccount: can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -46,7 +46,7 @@ load _helpers
 #--------------------------------------------------------------------
 # dns
 
-@test "serverACLInit/Job: dns acl option enabled with with .dns.enabled=-" {
+@test "serverACLInit/Job: dns acl option enabled with .dns.enabled=-" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
@@ -56,7 +56,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: dns acl option enabled with with .dns.enabled=true" {
+@test "serverACLInit/Job: dns acl option enabled with .dns.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
@@ -67,7 +67,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: dns acl option disabled with with .dns.enabled=false" {
+@test "serverACLInit/Job: dns acl option disabled with .dns.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
@@ -101,4 +101,40 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-acl-binding-rule-selector=\"foo\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+
+#--------------------------------------------------------------------
+# enterpriseLicense
+
+@test "serverACLInit/Job: ent license acl option enabled with server.enterpriseLicense.secretName and server.enterpriseLicense.secretKey set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: ent license acl option disabled missing server.enterpriseLicense.secretName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: ent license acl option disabled missing server.enterpriseLicense.secretKey" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -354,17 +354,18 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: init container is created when global.bootstrapACLs=true" {
+@test "syncCatalog/Deployment: init container is created when global.bootstrapACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/client-daemonset.yaml  \
+      -x templates/sync-catalog-deployment.yaml \
+      --set 'syncCatalog.enabled=true' \
       --set 'global.bootstrapACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.name' | tee /dev/stderr)
-  [ "${actual}" = "client-acl-init" ]
+  [ "${actual}" = "sync-acl-init" ]
 
   local actual=$(echo $object |
       yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)


### PR DESCRIPTION
When bootstraACLs is enabled, this adds an init container to the
enterprise license job that will wait until the appropriate acl
token is populated. Additionally, it marks it to run after the
acl init job so that everything is ready for it.