### PR TITLE
Support central configuration and proxy defaults

### DIFF
--- a/templates/client-config-configmap.yaml
+++ b/templates/client-config-configmap.yaml
@@ -14,4 +14,10 @@ metadata:
 data:
   extra-from-values.json: |-
 {{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}
+  {{- if (and .Values.connectInject.enabled .Values.connectInject.centralConfig.enabled) }}
+  central-config.json: |-
+    {
+      "enable_central_service_config": true
+    }
+  {{- end }}
 {{- end }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -55,6 +55,12 @@ spec:
                 {{- if .Values.global.bootstrapACLs }}
                 -acl-auth-method="{{ .Release.Name }}-consul-k8s-auth-method" \
                 {{- end }}
+                {{- if .Values.connectInject.centralConfig.enabled }}
+                -enable-central-config=true \
+                {{- end }}
+                {{- if (and .Values.connectInject.centralConfig.enabled .Values.connectInject.centralConfig.defaultProtocol) }}
+                -default-protocol="{{ .Values.connectInject.centralConfig.defaultProtocol }}" \
+                {{- end }}
 {{- if .Values.connectInject.certs.secretName }}
                 -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
                 -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -14,7 +14,7 @@ data:
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
   {{- if .Values.global.bootstrapACLs }}
-  acl-config.json: |
+  acl-config.json: |-
     {
       "acl": {
         "enabled": true,
@@ -23,5 +23,26 @@ data:
         "enable_token_persistence": true
       }
     }
+  {{- end }}
+  {{- if (and .Values.connectInject.enabled .Values.connectInject.centralConfig.enabled) }}
+  central-config.json: |-
+    {
+      "enable_central_service_config": true
+    }
+  {{- if gt (len .Values.connectInject.centralConfig.proxyDefaults) 3 }}
+  proxy-defaults-config.json: |-
+    {
+      "config_entries": {
+        "bootstrap": [
+          {
+            "kind": "proxy-defaults",
+            "name": "global",
+            "config":
+{{ tpl .Values.connectInject.centralConfig.proxyDefaults . | trimAll "\"" | indent 14 }}
+          }
+        ]
+      }
+    }
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/test/unit/client-configmap.bats
+++ b/test/unit/client-configmap.bats
@@ -51,3 +51,27 @@ load _helpers
       yq '.data["extra-from-values.json"] | match("world") | length' | tee /dev/stderr)
   [ ! -z "${actual}" ]
 }
+
+#--------------------------------------------------------------------
+# connectInject.centralConfig
+
+@test "client/ConfigMap: centralConfig is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/ConfigMap: centralConfig can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | contains("enable_central_service_config")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -223,3 +223,50 @@ load _helpers
       yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+
+#--------------------------------------------------------------------
+# centralConfig
+
+@test "connectInject/Deployment: centralConfig is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-central-config"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: centralConfig can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-central-config"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: defaultProtocol is disabled by default with centralConfig enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-default-protocol"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: defaultProtocol can be enabled with centralConfig enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.defaultProtocol=grpc' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-default-protocol=\"grpc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -52,6 +52,9 @@ load _helpers
   [ ! -z "${actual}" ]
 }
 
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
 @test "server/ConfigMap: creates acl config with .global.bootstrapACLs enabled" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -60,4 +63,51 @@ load _helpers
       . | tee /dev/stderr |
       yq '.data["acl-config.json"] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# connectInject.centralConfig
+
+@test "server/ConfigMap: centralConfig is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: centralConfig can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | contains("enable_central_service_config")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ConfigMap: proxyDefaults disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["proxy-defaults-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: proxyDefaults can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
+      . | tee /dev/stderr |
+      yq '.data["proxy-defaults-config.json"] | match("world") | length' | tee /dev/stderr)
+  [ ! -z "${actual}" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -371,3 +371,20 @@ connectInject:
   # default disallows using the default service account for ACl generation.
   # Requires Consul v1.5+ and consul-k8s v0.8.0+.
   aclBindingRuleSelector: "serviceaccount.name!=default"
+
+  # Requires Consul v1.5+ and consul-k8s v0.8.0+
+  centralConfig:
+    enabled: false
+
+    # defaultProtocol allows you to specify a convenience default protocol if
+    # all of your service are of the same protocol type. The individual annotation
+    # on any given pod will override this value. A protocol must be provided,
+    # either through this setting or individual annotation, for a service to be
+    # registered correctly. Valid values are "http", "http2", "grpc" and "tcp".
+    defaultProtocol: null
+
+    # proxyDefaults is a raw json string that will be applied to all Connect
+    # proxy sidecar pods that can include any valid configuration for the
+    # configured proxy.
+    proxyDefaults: |
+      {}

--- a/values.yaml
+++ b/values.yaml
@@ -377,7 +377,7 @@ connectInject:
     enabled: false
 
     # defaultProtocol allows you to specify a convenience default protocol if
-    # all of your service are of the same protocol type. The individual annotation
+    # most of your services are of the same protocol type. The individual annotation
     # on any given pod will override this value. A protocol must be provided,
     # either through this setting or individual annotation, for a service to be
     # registered correctly. Valid values are "http", "http2", "grpc" and "tcp".


### PR DESCRIPTION
Added in Consul 1.5, proxy defaults allow users to define config
options that will be automatically applied to all injected sidecar
proxies.

Additionally, it is possible to enable Connect services to be centrally
registered.