### PR TITLE
Update expected server name in acceptance tests

### DIFF
--- a/test/acceptance/server.bats
+++ b/test/acceptance/server.bats
@@ -4,10 +4,10 @@ load _helpers
 
 @test "server: default, comes up healthy" {
   helm_install
-  wait_for_ready $(name_prefix)-server-0
+  wait_for_ready $(name_prefix)-consul-server-0
 
   # Verify there are three servers
-  local server_count=$(kubectl exec "$(name_prefix)-server-0" consul members |
+  local server_count=$(kubectl exec "$(name_prefix)-consul-server-0" consul members |
       grep server |
       wc -l)
   [ "${server_count}" -eq "3" ]


### PR DESCRIPTION
To deal with a naming issue, the removal of duplicate `consul`
prefixes in the naming of things was updated. This updates the
acceptance test names to follow the new convention.