### PR TITLE
Make service account on ent license job optional

### DIFF
--- a/templates/enterprise-license.yaml
+++ b/templates/enterprise-license.yaml
@@ -30,7 +30,9 @@ spec:
         component: license
     spec:
       restartPolicy: Never
+      {{- if .Values.global.bootstrapACLs }}
       serviceAccountName: {{ template "consul.fullname" . }}-enterprise-license
+      {{- end }}
       containers:
         - name: apply-enterprise-license
           image: "{{ default .Values.global.image .Values.server.image }}"

--- a/test/unit/enterprise-license.bats
+++ b/test/unit/enterprise-license.bats
@@ -87,3 +87,26 @@ load _helpers
       yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/EnterpriseLicense: no service account specified when global.bootstrapACLS=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/EnterpriseLicense: service account specified when global.bootstrapACLS=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.serviceAccountName | contains("consul-enterprise-license")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
If ACLs are not enabled, the enterprise license application job does
not need any special privileges. This makes the definition of the
service account in that spec key off of the `bootstrapACLs` value
rather than being blanket applied.