### PR TITLE
Proof of concept for specifying additional labels via helm 

### DIFF
--- a/example-values.yaml
+++ b/example-values.yaml
@@ -1,0 +1,4 @@
+global:
+  commonLabels:
+    1: 2
+    foo: bar

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -59,3 +59,20 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate standard helm labels
+*/}}
+{{- define "consul.labels" }}
+app: {{ template "consul.name" . }}
+chart: {{ template "consul.chart" . }}
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+app.kubernetes.io/name: {{ template "consul.name" . }}
+helm.sh/chart: {{ template "consul.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- if .Values.global.commonLabels }}
+{{ toYaml .Values.global.commonLabels }}
+{{- end }}
+{{- end }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -6,24 +6,18 @@ metadata:
   name: {{ template "consul.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
+    {{- include "consul.labels" . | indent 4 -}}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      {{- include "consul.labels" . | indent 6 -}}
       component: client
       hasDNS: "true"
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        {{- include "consul.labels" . | indent 8 -}}
         component: client
         hasDNS: "true"
       annotations:

--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -6,10 +6,7 @@ metadata:
   name: {{ template "consul.fullname" . }}-dns
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "consul.labels" . | indent 4 -}}
 spec:
   ports:
     - name: dns-tcp


### PR DESCRIPTION
This is an initial approach at addressing https://github.com/hashicorp/consul-helm/issues/120. This is not a complete or merge-able pull-request, but I've included an idea of how additional labels could be specified in addition to the helm recommended labels. I've modified `templates/dns-service.yaml`, a small template, and `/templates/client-daemonset.yaml`, a large template, as an example. To see what `templates/dns-service.yaml` would render as, just run

```shell
helm template ./consul-helm -f consul-helm/example-values.yaml -x templates/dns-service.yaml
```

which would show

```yaml
# Source: consul/templates/dns-service.yaml
# Service for Consul DNS.
apiVersion: v1
kind: Service
metadata:
  name: release-name-consul-dns
  namespace: default
  labels:    
    app: consul
    chart: consul-helm
    release: "release-name"
    heritage: "Tiller"
    app.kubernetes.io/name: consul
    helm.sh/chart: consul-helm
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: "Tiller"
    "1": 2
    foo: bar
    spec:
  ports:
    - name: dns-tcp
      port: 53
      protocol: "TCP"
      targetPort: dns-tcp
    - name: dns-udp
      port: 53
      protocol: "UDP"
      targetPort: dns-udp
  selector:
    app: consul
    release: "release-name"
    hasDNS: "true"
```