### PR TITLE
Adding snapshot agent logic to clients.

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -184,6 +184,20 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
+        {{- if .Values.client.snapshotAgent.enabled }}
+        - name: consul-snapshot-agent
+          image: "{{ default .Values.global.image .Values.client.image }}"
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /bin/consul snapshot agent \
+                -config-dir=/consul/config
+          volumeMounts:
+            - name: config
+              mountPath: /consul/config
+       {{- end }}
+
       {{- if .Values.global.bootstrapACLs }}
       initContainers:
       - name: client-acl-init

--- a/values.yaml
+++ b/values.yaml
@@ -176,6 +176,12 @@ client:
   # is made.
   resources: null
 
+  # snapshotAgent enables the snapshot agent to be run in each agent pod.
+  # The configuration options should be configured via the extraConfig key.
+  # Note: This is a Consul Enterprise only feature.
+  snapshotAgent:
+    enabled: false
+
   # extraConfig is a raw string of extra configuration to set with the
   # server. This should be JSON.
   extraConfig: |


### PR DESCRIPTION
My example config for this is below. I'm running on a 5 node AKS cluster, using different labels for 3 (servers) and 2 (snapshots) k8s nodes respectively, then using `nodeSelector` to place the appropriate agents. This may not be ideal. Note the `snapshotAgent` config option is only available on the clients to enforce best practice.

```
global:
  enabled: true
  image: "hashicorp/consul-enterprise:1.5.1-ent"
  domain: consul
  datacenter: dc1

server:
  enabled: true
  replicas: 3
  bootstrapExpect: 3
  storage: 10Gi

  enterpriseLicense:
    secretName: "consul-ent-license"
    secretKey: "key"

  nodeSelector: |
      consul-agent-type: server

syncCatalog:
  enabled: true

client:
  enabled: true
  grpc: true

  snapshotAgent:
    enabled: true

  nodeSelector: |
    consul-agent-type: snapshot

  extraConfig: '{ 
    "snapshot_agent": { 
      "snapshot": {
          "interval": "10s"
      },
      "azure_blob_storage": { 
        "account_name": "neilexample", 
        "account_key": "", 
        "container_name": "neiltestcontainer" 
      } 
    } 
  }'

connectInject:
  enabled: true
  default: false

dns:
  enabled: true

ui:
  enabled: true
  service:
    enabled: true
    type: LoadBalancer

```