### PR TITLE
Add configuration to save persistent data on node between restarts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - tar xzvf helm-v2.13.0-linux-amd64.tar.gz
   - mv linux-amd64/helm helm
   - chmod u+x helm
+  - ./helm init --client-only
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ script:
   - mkdir build
   - ./helm package ./
   - mv *.tgz build/
-  - cd build
   - ./helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
-
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: go
+
+os:
+  - linux
+
+before_install:
+  - wget https://kubernetes-helm.storage.googleapis.com/helm-v2.13.0-linux-amd64.tar.gz
+  - tar xzvf helm-v2.13.0-linux-amd64.tar.gz
+  - mv linux-amd64/helm helm
+  - chmod u+x helm
+
+script:
+  - mkdir build
+  - helm package ./
+  - mv *.tgz build/
+  - helm repo index . --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - mv index.yaml build/index.yaml
+
+deploy:
+  provider: s3
+  access_key_id: "${AWS_ACCESS_KEY_ID}"
+  secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+  bucket: "helm-repo.sphera.tools"
+  skip_cleanup: true
+  region: "us-east-1"
+  local_dir: build
+  upload-dir: consul-helm

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ deploy:
   region: "us-east-1"
   local_dir: build
   upload-dir: consul-helm
+  acl: public_read

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ deploy:
   region: "us-east-1"
   local_dir: build
   upload-dir: consul-helm
-  acl: public_read

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ before_install:
   - rm helm-v2.13.0-linux-amd64.tar.gz
   - mv linux-amd64/helm helm
   - chmod u+x helm
-  - ./tmp/helm/helm init --client-only
+  - /tmp/helm/helm init --client-only
 
 script:
   - mkdir build
-  - ./tmp/helm/helm package ./
+  - /tmp/helm/helm package ./
   - mv *.tgz build/
-  - ./tmp/helm/helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - /tmp/helm/helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
 
 script:
   - mkdir build
-  - ./tmp/helm package ./
+  - ./tmp/helm/helm package ./
   - mv *.tgz build/
-  - ./tmp/helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - ./tmp/helm/helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - rm helm-v2.13.0-linux-amd64.tar.gz
   - mv linux-amd64/helm helm
   - chmod u+x helm
-  - ./tmp/helm init --client-only
+  - ./tmp/helm/helm init --client-only
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - ./helm package ./
   - mv *.tgz build/
   - cd build
-  - ./helm repo index . --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - ./helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
 
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 script:
   - mkdir build
-  - helm package ./
+  - ./helm package ./
   - mv *.tgz build/
-  - helm repo index . --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - ./helm repo index . --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
   - mv index.yaml build/index.yaml
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ os:
 before_install:
   - mkdir /tmp/helm
   - wget https://kubernetes-helm.storage.googleapis.com/helm-v2.13.0-linux-amd64.tar.gz -O /tmp/helm/helm-v2.13.0-linux-amd64.tar.gz
-  - cd /tmp/helm
-  - tar xzvf helm-v2.13.0-linux-amd64.tar.gz
-  - rm helm-v2.13.0-linux-amd64.tar.gz
-  - mv linux-amd64/helm helm
-  - chmod u+x helm
+  - tar xzvf /tmp/helm/helm-v2.13.0-linux-amd64.tar.gz -C /tmp/helm
+  - mv /tmp/helm/linux-amd64/helm /tmp/helm/helm
+  - chmod u+x /tmp/helm/helm
   - /tmp/helm/helm init --client-only
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,20 @@ os:
   - linux
 
 before_install:
-  - wget https://kubernetes-helm.storage.googleapis.com/helm-v2.13.0-linux-amd64.tar.gz
+  - mkdir /tmp/helm
+  - wget https://kubernetes-helm.storage.googleapis.com/helm-v2.13.0-linux-amd64.tar.gz -O /tmp/helm/helm-v2.13.0-linux-amd64.tar.gz
+  - cd /tmp/helm
   - tar xzvf helm-v2.13.0-linux-amd64.tar.gz
+  - rm helm-v2.13.0-linux-amd64.tar.gz
   - mv linux-amd64/helm helm
   - chmod u+x helm
-  - ./helm init --client-only
+  - ./tmp/helm init --client-only
 
 script:
   - mkdir build
-  - ./helm package ./
+  - ./tmp/helm package ./
   - mv *.tgz build/
-  - ./helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
+  - ./tmp/helm repo index build/ --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ script:
   - mkdir build
   - ./helm package ./
   - mv *.tgz build/
+  - cd build
   - ./helm repo index . --url http://helm-repo.sphera.tools.s3-website-us-east-1.amazonaws.com/consul-helm
-  - mv index.yaml build/index.yaml
+
 
 deploy:
   provider: s3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: consul
+name: consul-helm
 version: 0.8.1
 description: Install and configure Consul on Kubernetes.
 home: https://www.consul.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 name: consul-helm
-version: 0.8.1
+version: 0.8.2
 description: Install and configure Consul on Kubernetes.
-home: https://www.consul.io
+home: https://github.com/wix-playground/consul-helm
 sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-helm
   - https://github.com/hashicorp/consul-k8s
+  - https://www.consul.io
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Wix.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -48,7 +48,14 @@ spec:
       # emptyDir volume.
       volumes:
         - name: data
+        {{- if .Values.client.hostPath }}
+          hostPath:
+            # directory location on host
+            path: {{ .Values.client.hostPath }}
+            type: DirectoryOrCreate
+        {{- else }}
           emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-client-config

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -11,6 +11,12 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  {{- if .Values.global.updateStrategy.enabled }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.global.updateStrategy.maxUnavailable }}
+    type: RollingUpdate
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "consul.name" . }}
@@ -68,6 +74,7 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
+        dnsPolicy: {{.Values.client.DnsPolicy }}        
         {{- if .Values.global.bootstrapACLs }}
         - name: aclconfig
           emptyDir: {}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -49,6 +49,8 @@ spec:
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
 
+      # Default DnsPolicy is not dafualt for kube
+      dnsPolicy: {{.Values.client.DnsPolicy }}        
       # Consul agents require a directory for data, even clients. The data
       # is okay to be wiped though if the Pod is removed, so just use an
       # emptyDir volume.
@@ -74,7 +76,7 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
-        dnsPolicy: {{.Values.client.DnsPolicy }}        
+        
         {{- if .Values.global.bootstrapACLs }}
         - name: aclconfig
           emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -223,6 +223,13 @@ client:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # hostPath is fullpath to folder on host machine to mount as /consul/data folder. consul agent stores
+  # its configuration in this folder. By default its created as emptyDir: {}. To save data between pod restarts
+  # specify folder name on host machine to be mounted as /consul/data.
+  # Example:
+  # hostPath: '/var/consul-data'
+  hostPath: null
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ global:
   # Examples:
   #   image: "consul:1.5.0"
   #   image: "hashicorp/consul-enterprise:1.5.0-ent"   # Enterprise Consul image
-  image: "consul:1.5.0"
+  image: "consul:1.5.1"
 
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as the catalog sync. This can be overridden
@@ -50,6 +50,12 @@ global:
   # clients within Kubernetes. Additionally requires Consul v1.4+ and
   # consul-k8s v0.8.0+.
   bootstrapACLs: false
+  # updateStrategy used to customize number of pods that can be upgraded simultaniously
+  # starting from version 1.5.1 and using host path to store data between restarts, we can rollout 
+  # consul much faster with 10  maxUnavailable pods for example.
+  updateStrategy:
+    enabled: true
+    maxUnavailable: 1
 
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
@@ -230,6 +236,8 @@ client:
   # hostPath: '/var/consul-data'
   hostPath: null
 
+  # Deafult DnsPolicy is not default in kube. Specify your prefered DnsPolicy here.
+  DnsPolicy: "Default"
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns

--- a/values.yaml
+++ b/values.yaml
@@ -50,6 +50,7 @@ global:
   # clients within Kubernetes. Additionally requires Consul v1.4+ and
   # consul-k8s v0.8.0+.
   bootstrapACLs: false
+  
   # updateStrategy used to customize number of pods that can be upgraded simultaniously
   # starting from version 1.5.1 and using host path to store data between restarts, we can rollout 
   # consul much faster with 10  maxUnavailable pods for example.


### PR DESCRIPTION
During consul agent upgrade , consul agent pod gets restarted and since /consul/data folder is mounted to emptyDir - all the data is erased, and new agent will try to register as a completely new agent.
If we save /consul/data content between pod restarts, new pod will continue with id and configuration that previous pod had.
This will decrease pressure on consul server during consul-agent upgrades.
This pull request adds hostPath parameter that can be configured with path to host machine folder to save contents of /consul/data folder.If this parameter is not defined everything will continue to work as before.
