### PR TITLE
Ensure rules is always set.

### DIFF
--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -10,7 +10,6 @@ metadata:
     release: {{ .Release.Name }}
 {{- if (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
 rules:
-{{- end }}
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
@@ -27,5 +26,8 @@ rules:
       - {{ .Release.Name }}-consul-client-acl-token
     verbs:
       - get
+{{- end }}
+{{- else}}
+rules: []
 {{- end }}
 {{- end }}

--- a/templates/server-clusterrole.yaml
+++ b/templates/server-clusterrole.yaml
@@ -16,5 +16,7 @@ rules:
   - {{ template "consul.fullname" . }}-server
   verbs:
   - use
+{{- else }}
+rules: []
 {{- end }}
 {{- end }}

--- a/test/unit/client-clusterrole.bats
+++ b/test/unit/client-clusterrole.bats
@@ -52,6 +52,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+# The rules key must always be set (#178).
+@test "client/ClusterRole: rules empty with client.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-clusterrole.yaml  \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.rules' | tee /dev/stderr)
+  [ "${actual}" = "[]" ]
+}
+
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 

--- a/test/unit/server-clusterrole.bats
+++ b/test/unit/server-clusterrole.bats
@@ -51,3 +51,14 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+# The rules key must always be set (#178).
+@test "server/ClusterRole: rules empty with server.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-clusterrole.yaml  \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.rules' | tee /dev/stderr)
+  [ "${actual}" = "[]" ]
+}


### PR DESCRIPTION
Fixes #178. The rules key must always be set, even if it's to be empty.