### PR TITLE
#183 bootstrapACLs when server is enabled, regardless of client

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 0.9.0
+version: 0.9.1
 description: Install and configure Consul on Kubernetes.
 home: https://www.consul.io
 sources:

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -33,7 +32,6 @@ rules:
       - services
     verbs:
       - get
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18,6 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -76,6 +76,9 @@ spec:
                 {{- if .Values.client.snapshotAgent.enabled }}
                 -create-snapshot-agent-token=true \
                 {{- end }}
+                {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+                -create-client-token=false \
+                {{- end }}
                 -expected-replicas={{ .Values.server.replicas }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: batch/v1
 kind: Job
@@ -78,6 +77,5 @@ spec:
                 -create-snapshot-agent-token=true \
                 {{- end }}
                 -expected-replicas={{ .Values.server.replicas }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,6 +10,5 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/server-acl-init-clusterrole.bats
+++ b/test/unit/server-acl-init-clusterrole.bats
@@ -32,7 +32,19 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRole: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRole: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -32,7 +32,19 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrolebinding.yaml  \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -11,48 +11,56 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled server & client acls with global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "false" ]
 }
 
-@test "serverACLInit/Job: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: disabled server & client acls with server=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "false" ]
+  [ "${actual_client_acl_disabled}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled with server=true, client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled server acls, disabled client acls with server=true, client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=true' \
       --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "true" ]
 }
 
-@test "serverACLInit/Job: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled server acls, disabled client acls with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -32,7 +32,19 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
@@ -40,7 +52,7 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -32,6 +32,18 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "serverACLInit/ServiceAccount: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "serverACLInit/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }


### PR DESCRIPTION
bootstrapACLs is useful and fully functional even when the client isn't enabled, so regardless of whether or not the client is enabled, we should bootstrap the server acls

Fix for #183 