### PR TITLE
add resources to injector for sidecar/init container

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -61,6 +61,13 @@ spec:
                 {{- if (and .Values.connectInject.centralConfig.enabled .Values.connectInject.centralConfig.defaultProtocol) }}
                 -default-protocol="{{ .Values.connectInject.centralConfig.defaultProtocol }}" \
                 {{- end }}
+                {{- if .Values.connectInject.sidecarResources.enabled }}
+                -enable-resources=true \
+                -cpu-limit="{{ .Values.connectInject.sidecarResources.limits.cpu }}" \
+                -cpu-request="{{ .Values.connectInject.sidecarResources.requests.cpu }}" \
+                -memory-limit="{{ .Values.connectInject.sidecarResources.limits.memory }}" \
+                -memory-request="{{ .Values.connectInject.sidecarResources.requests.memory }}" \
+                {{- end }}
 {{- if .Values.connectInject.certs.secretName }}
                 -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
                 -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -270,3 +270,31 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-default-protocol=\"grpc\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# sidecarResources
+
+@test "connectInject/Deployment: sidecarResources is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-resources"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: sidecarResources can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.sidecarResources.enabled=true' \
+      --set 'connectInject.sidecarResources.limits.cpu=100m' \
+      --set 'connectInject.sidecarResources.limits.memory=128Mi' \
+      --set 'connectInject.sidecarResources.requests.cpu=100m' \
+      --set 'connectInject.sidecarResources.limits.cpu=128Mi' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-resources"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -387,3 +387,13 @@ connectInject:
     # configured proxy.
     proxyDefaults: |
       {}
+
+  # enable resources for sidecar and init containers for injector
+  sidecarResources:
+    enabled: false
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi


### PR DESCRIPTION
if resource quotas for namespace are set, init container and sidecar pod require to set cpu and memory resources, else they are not able to start. the init container uses the same resources as are specified for the sidecar pod. the resources for the injector are disabled by default.

related PR https://github.com/hashicorp/consul-k8s/pull/109