### PR TITLE
Add new meshGateway key for Connect Mesh Gateways

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 0.8.1
+version: 0.9.0-beta
 description: Install and configure Consul on Kubernetes.
 home: https://www.consul.io
 sources:

--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.meshGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
+rules:
+{{- if .Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      - {{ template "consul.fullname" . }}-mesh-gateway
+    verbs:
+      - use
+{{- end }}
+{{- if .Values.global.bootstrapACLs }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-consul-mesh-gateway-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/templates/mesh-gateway-clusterrolebinding.yaml
+++ b/templates/mesh-gateway-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.meshGateway.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-mesh-gateway
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -1,0 +1,172 @@
+{{- if .Values.meshGateway.enabled }}
+{{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
+{{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+  {{- if .Values.meshGateway.annotations }}
+  annotations:
+    {{- tpl .Values.meshGateway.annotations . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.meshGateway.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      chart: {{ template "consul.chart" . }}
+      release: {{ .Release.Name }}
+      component: mesh-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ template "consul.name" . }}
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: mesh-gateway
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+    spec:
+      {{- if .Values.meshGateway.affinity }}
+      affinity:
+        {{ tpl .Values.meshGateway.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.meshGateway.tolerations }}
+      tolerations:
+        {{ tpl .Values.meshGateway.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ template "consul.fullname" . }}-mesh-gateway
+      volumes:
+        - name: consul-bin
+          emptyDir: {}
+      {{- if .Values.meshGateway.hostNetwork }}
+      hostNetwork: {{ .Values.meshGateway.hostNetwork }}
+      {{- end }}
+      {{- if .Values.meshGateway.dnsPolicy }}
+      dnsPolicy: {{ .Values.meshGateway.dnsPolicy }}
+      {{- end }}
+      initContainers:
+        # We use the Envoy image as our base image so we use an init container to
+        # copy the Consul binary to a shared directory that can be used when
+        # starting Envoy.
+        - name: copy-consul-bin
+          image: {{ .Values.global.image | quote }}
+          command:
+          - cp
+          - /bin/consul
+          - /consul-bin/consul
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+        {{- if .Values.global.bootstrapACLs }}
+        # Wait for secret containing acl token to be ready.
+        # Doesn't do anything with it but when the main container starts we
+        # know that it's been created.
+        - name: mesh-gateway-acl-init
+          image: {{ .Values.global.imageK8S }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              consul-k8s acl-init \
+                -secret-name="{{ .Release.Name }}-consul-mesh-gateway-acl-token" \
+                -k8s-namespace={{ .Release.Namespace }} \
+                -init-type="sync"
+        {{- end }}
+      containers:
+        - name: mesh-gateway
+          image: {{ .Values.meshGateway.imageEnvoy | quote }}
+          {{- if .Values.meshGateway.resources }}
+          resources:
+            {{ tpl .Values.meshGateway.resources . | nindent 12 | trim }}
+          {{- end }}
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- if .Values.global.bootstrapACLs }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-consul-mesh-gateway-acl-token"
+                  key: "token"
+            {{- end}}
+          command:
+            # /bin/sh -c is needed so we can use the pod-specific environment
+            # variables.
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /consul-bin/consul connect envoy \
+                -mesh-gateway \
+                -register \
+                -address="${POD_IP}:{{ .Values.meshGateway.containerPort }}" \
+                -http-addr="${HOST_IP}:8500" \
+                -grpc-addr="${HOST_IP}:8502" \
+                {{- if .Values.meshGateway.wanAddress.host }}
+                -wan-address="{{ .Values.meshGateway.wanAddress.host }}:{{ .Values.meshGateway.wanAddress.port }}" \
+                {{- else if .Values.meshGateway.wanAddress.useNodeName }}
+                -wan-address="${NODE_NAME}:{{ .Values.meshGateway.wanAddress.port }}" \
+                {{- else if .Values.meshGateway.wanAddress.useNodeIP }}
+                -wan-address="${HOST_IP}:{{ .Values.meshGateway.wanAddress.port }}" \
+                {{- end }}
+                {{- if .Values.meshGateway.consulServiceName }}
+                {{- if .Values.global.bootstrapACLs }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end }}
+                -service={{ .Values.meshGateway.consulServiceName | quote }} \
+                {{- end }}
+          {{- if .Values.meshGateway.enableHealthChecks }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.meshGateway.containerPort }}
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.meshGateway.containerPort }}
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          {{- end }}
+          ports:
+            - name: gateway
+              containerPort: {{ .Values.meshGateway.containerPort }}
+              {{- if .Values.meshGateway.hostPort }}
+              hostPort:  {{ .Values.meshGateway.hostPort }}
+              {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -http-addr=\"${HOST_IP}:8500\" -id=\"{{ default "mesh-gateway" .Values.meshGateway.consulServiceName }}\""]
+      {{- if .Values.meshGateway.priorityClassName }}
+      priorityClassName: {{ .Values.meshGateway.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.meshGateway.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.meshGateway.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.meshGateway.enabled }}
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
+{{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
+{{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,10 +14,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
-  {{- if .Values.meshGateway.annotations }}
-  annotations:
-    {{- tpl .Values.meshGateway.annotations . | nindent 4 }}
-  {{- end }}
 spec:
   replicas: {{ .Values.meshGateway.replicas }}
   selector:
@@ -33,6 +31,9 @@ spec:
         component: mesh-gateway
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.meshGateway.annotations }}
+        {{- tpl .Values.meshGateway.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.meshGateway.affinity }}
       affinity:
@@ -100,10 +101,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if .Values.meshGateway.wanAddress.useNodeName }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- end }}
             {{- if .Values.global.bootstrapACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
@@ -130,8 +133,8 @@ spec:
                 {{- else if .Values.meshGateway.wanAddress.useNodeIP }}
                 -wan-address="${HOST_IP}:{{ .Values.meshGateway.wanAddress.port }}" \
                 {{- end }}
-                {{- if .Values.meshGateway.consulServiceName }}
-                {{- if .Values.global.bootstrapACLs }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end }}
+                {{- if and .Values.meshGateway.consulServiceName }}
+                {{- if and .Values.global.bootstrapACLs (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end }}
                 -service={{ .Values.meshGateway.consulServiceName | quote }} \
                 {{- end }}
           {{- if .Values.meshGateway.enableHealthChecks }}

--- a/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.global.enablePodSecurityPolicies .Values.meshGateway.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/templates/mesh-gateway-service.yaml
+++ b/templates/mesh-gateway-service.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.meshGateway.enabled .Values.meshGateway.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+  {{- if .Values.meshGateway.service.annotations }}
+  annotations:
+    {{ tpl .Values.meshGateway.service.annotations . | nindent 4 | trim }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ template "consul.name" . }}
+    release: "{{ .Release.Name }}"
+    component: mesh-gateway
+  ports:
+    - name: gateway
+      port: {{ .Values.meshGateway.service.port }}
+      targetPort: {{ .Values.meshGateway.containerPort }}
+      {{- if .Values.meshGateway.service.nodePort }}
+      nodePort: {{ .Values.meshGateway.service.nodePort }}
+      {{- end}}
+  type: {{ .Values.meshGateway.service.type }}
+  {{- if .Values.meshGateway.service.additionalSpec }}
+  {{ tpl .Values.meshGateway.service.additionalSpec . | nindent 2 | trim }}
+  {{- end }}
+{{- end }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.meshGateway.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-mesh-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mesh-gateway
+{{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -53,6 +53,9 @@ spec:
                 {{- if .Values.connectInject.enabled }}
                 -create-inject-token=true \
                 {{- end }}
+                {{- if .Values.meshGateway.enabled }}
+                -create-mesh-gateway-token=true \
+                {{- end }}
                 {{- if .Values.connectInject.aclBindingRuleSelector }}
                 -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
                 {{- end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -24,7 +24,7 @@ data:
       }
     }
   {{- end }}
-  {{- if (and .Values.connectInject.enabled .Values.connectInject.centralConfig.enabled) }}
+  {{- if and .Values.connectInject.enabled .Values.connectInject.centralConfig.enabled }}
   central-config.json: |-
     {
       "enable_central_service_config": true
@@ -37,8 +37,28 @@ data:
           {
             "kind": "proxy-defaults",
             "name": "global",
+            {{- if and .Values.meshGateway.enabled .Values.meshGateway.globalMode }}
+            "mesh_gateway": {
+              "mode": {{ .Values.meshGateway.globalMode | quote }}
+            },
+            {{- end }}
             "config":
 {{ tpl .Values.connectInject.centralConfig.proxyDefaults . | trimAll "\"" | indent 14 }}
+          }
+        ]
+      }
+    }
+  {{- else if and .Values.meshGateway.enabled .Values.meshGateway.globalMode }}
+  proxy-defaults-config.json: |-
+    {
+      "config_entries": {
+        "bootstrap": [
+          {
+            "kind": "proxy-defaults",
+            "name": "global",
+            "mesh_gateway": {
+              "mode": {{ .Values.meshGateway.globalMode | quote }}
+            }
           }
         ]
       }

--- a/test/unit/mesh-gateway-clusterrole.bats
+++ b/test/unit/mesh-gateway-clusterrole.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/ClusterRole: enabled with meshGateway.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/ClusterRole: rules for PodSecurityPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+
+@test "meshGateway/ClusterRole: rules for global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}
+
+@test "meshGateway/ClusterRole: rules is empty if no ACLs or PSPs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules' | tee /dev/stderr)
+  [ "${actual}" = "[]" ]
+}
+
+@test "meshGateway/ClusterRole: rules for both ACLs and PSPs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}

--- a/test/unit/mesh-gateway-clusterrole.bats
+++ b/test/unit/mesh-gateway-clusterrole.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ClusterRole: enabled with meshGateway.enabled=true" {
+@test "meshGateway/ClusterRole: enabled with meshGateway, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-clusterrole.yaml  \
@@ -35,7 +35,6 @@ load _helpers
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "podsecuritypolicies" ]
 }
-
 
 @test "meshGateway/ClusterRole: rules for global.bootstrapACLs=true" {
   cd `chart_dir`

--- a/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/ClusterRoleBinding: enabled with meshGateway.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrolebinding.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/ClusterRoleBinding: subject name is correct" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-clusterrolebinding.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-mesh-gateway" ]
+}
+

--- a/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ClusterRoleBinding: enabled with meshGateway.enabled=true" {
+@test "meshGateway/ClusterRoleBinding: enabled with meshGateway, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-clusterrolebinding.yaml  \
@@ -30,6 +30,7 @@ load _helpers
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
+      --name 'release-name' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].name' | tee /dev/stderr)
   [ "${actual}" = "release-name-consul-mesh-gateway" ]

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -1,0 +1,505 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/Deployment: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/Deployment: enabled with meshGateway.enabled true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: fails if connectInject.enabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=false' \
+      --set 'client.grpc=true' \
+      --set 'client.grpc=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.enabled must be true" ]]
+}
+
+@test "meshGateway/Deployment: fails if client.grpc=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=false' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "client.grpc must be true" ]]
+}
+
+@test "meshGateway/Deployment: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.annotations=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "meshGateway/Deployment: replicas defaults to 2" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "meshGateway/Deployment: replicas can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.replicas=3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "meshGateway/Deployment: affinity defaults to one per node" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey' | tee /dev/stderr)
+  [ "${actual}" = "kubernetes.io/hostname" ]
+}
+
+@test "meshGateway/Deployment: affinity can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.affinity=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "meshGateway/Deployment: no tolerations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "meshGateway/Deployment: hostNetwork can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.hostNetwork=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.hostNetwork' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: no dnsPolicy by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.dnsPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: dnsPolicy can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.dnsPolicy=ClusterFirst' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.dnsPolicy' | tee /dev/stderr)
+  [ "${actual}" = "ClusterFirst" ]
+}
+
+@test "meshGateway/Deployment: global.BootstrapACLs enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr )
+  local init_container=$(echo "${actual}" | yq -r '.spec.template.spec.initContainers[1].name' | tee /dev/stderr)
+  [ "${init_container}" = "mesh-gateway-acl-init" ]
+
+  local secret=$(echo "${actual}" | yq -r '.spec.template.spec.containers[0].env[3].name' | tee /dev/stderr)
+  [ "${secret}" = "CONSUL_HTTP_TOKEN" ]
+}
+
+@test "meshGateway/Deployment: envoy image has default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "envoyproxy/envoy:v1.10.0" ]
+}
+
+@test "meshGateway/Deployment: envoy image can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.imageEnvoy=new/image' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "new/image" ]
+}
+
+@test "meshGateway/Deployment: resources has default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "128Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "250m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "256Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "500m" ]
+}
+
+@test "meshGateway/Deployment: resources can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.resources=requests: yadayada' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources.requests' | tee /dev/stderr)
+  [ "${actual}" = "yadayada" ]
+}
+
+@test "meshGateway/Deployment: containerPort defaults to 443" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr \
+      | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  [[ $(echo "$actual" | yq -r '.command[2]')  =~ '-address="${POD_IP}:443"' ]]
+  [ $(echo "$actual" | yq -r '.ports[0].containerPort')  = "443" ]
+  [ $(echo "$actual" | yq -r '.livenessProbe.tcpSocket.port')  = "443" ]
+  [ $(echo "$actual" | yq -r '.readinessProbe.tcpSocket.port')  = "443" ]
+}
+
+@test "meshGateway/Deployment: containerPort can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.containerPort=8443' \
+      . | tee /dev/stderr \
+      | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  [[ $(echo "$actual" | yq -r '.command[2]')  =~ '-address="${POD_IP}:8443"' ]]
+  [ $(echo "$actual" | yq -r '.ports[0].containerPort')  = "8443" ]
+  [ $(echo "$actual" | yq -r '.livenessProbe.tcpSocket.port')  = "8443" ]
+  [ $(echo "$actual" | yq -r '.readinessProbe.tcpSocket.port')  = "8443" ]
+}
+
+@test "meshGateway/Deployment: wanAddress.port defaults to 443" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.wanAddress.useNodeIP=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+  [[ "${actual}" =~ '-wan-address="${HOST_IP}:443"' ]]
+}
+
+@test "meshGateway/Deployment: wanAddress uses NodeIP by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+  [[ "${actual}" =~ '-wan-address="${HOST_IP}:443"' ]]
+}
+
+@test "meshGateway/Deployment: wanAddress.useNodeIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.wanAddress.useNodeIP=true' \
+      --set 'meshGateway.wanAddress.port=4444' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+  [[ "${actual}" =~ '-wan-address="${HOST_IP}:4444"' ]]
+}
+
+@test "meshGateway/Deployment: wanAddress.useNodeName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.wanAddress.useNodeIP=false' \
+      --set 'meshGateway.wanAddress.useNodeName=true' \
+      --set 'meshGateway.wanAddress.port=4444' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+  [[ "${actual}" =~ '-wan-address="${NODE_NAME}:4444"' ]]
+}
+
+@test "meshGateway/Deployment: wanAddress.host" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.wanAddress.useNodeIP=false' \
+      --set 'meshGateway.wanAddress.useNodeName=false' \
+      --set 'meshGateway.wanAddress.host=myhost' \
+      --set 'meshGateway.wanAddress.port=4444' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+  [[ "${actual}" =~ '-wan-address="myhost:4444"' ]]
+}
+
+@test "meshGateway/Deployment: fails if consulServiceName is set and bootstrapACLs is true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.consulServiceName=override' \
+      --set 'global.bootstrapACLs=true' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" ]]
+}
+
+@test "meshGateway/Deployment: consulServiceName can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.consulServiceName=overridden' \
+      . | tee /dev/stderr \
+      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
+
+  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ '-service="overridden"' ]]
+  [[ $(echo "${actual}" | yq -r '.lifecycle.preStop.exec.command' ) =~ '-id=\"overridden\"' ]]
+}
+
+@test "meshGateway/Deployment: healthchecks are on by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr \
+      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
+
+  local liveness=$(echo "${actual}" | yq -r '.livenessProbe | length > 0' | tee /dev/stderr)
+  [ "${liveness}" = "true" ]
+  local readiness=$(echo "${actual}" | yq -r '.readinessProbe | length > 0' | tee /dev/stderr)
+  [ "${readiness}" = "true" ]
+}
+
+@test "meshGateway/Deployment: can disable healthchecks" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.enableHealthChecks=false' \
+      . | tee /dev/stderr \
+      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
+
+  local liveness=$(echo "${actual}" | yq -r '.livenessProbe | length > 0' | tee /dev/stderr)
+  [ "${liveness}" = "false" ]
+  local readiness=$(echo "${actual}" | yq -r '.readinessProbe | length > 0' | tee /dev/stderr)
+  [ "${readiness}" = "false" ]
+}
+
+@test "meshGateway/Deployment: no hostPort by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: can set a hostPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.hostPort=443' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
+
+  [ "${actual}" = "443" ]
+}
+
+@test "meshGateway/Deployment: no priorityClassName by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: can set a priorityClassName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.priorityClassName=name' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+
+  [ "${actual}" = "name" ]
+}
+
+@test "meshGateway/Deployment: no nodeSelector by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Deployment: can set a nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.nodeSelector=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector.key' | tee /dev/stderr)
+
+  [ "${actual}" = "value" ]
+}

--- a/test/unit/mesh-gateway-podsecuritypolicy.bats
+++ b/test/unit/mesh-gateway-podsecuritypolicy.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/PodSecurityPolicy: enabled with meshGateway.enabled and global.enablePodSecurityPolicies=true" {
+@test "meshGateway/PodSecurityPolicy: enabled with meshGateway, connectInject and client.grpc enabled and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-podsecuritypolicy.yaml  \

--- a/test/unit/mesh-gateway-podsecuritypolicy.bats
+++ b/test/unit/mesh-gateway-podsecuritypolicy.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-podsecuritypolicy.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/PodSecurityPolicy: enabled with meshGateway.enabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-podsecuritypolicy.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/mesh-gateway-service.bats
+++ b/test/unit/mesh-gateway-service.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/Service: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/Service: disabled with meshGateway.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/Service: enabled with meshGateway.enabled=true meshGateway.service.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Service: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Service: can set annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.service.annotations=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "meshGateway/Service: has default port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "meshGateway/Service: can set port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.service.port=8443' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
+@test "meshGateway/Service: has default targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "meshGateway/Service: uses targetPort from containerPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.containerPort=8443' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
+@test "meshGateway/Service: no nodePort by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "meshGateway/Service: can set a nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.service.nodePort=8443' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
+@test "meshGateway/Service: defaults to type ClusterIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "ClusterIP" ]
+}
+
+@test "meshGateway/Service: can set type" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.service.type=LoadBalancer' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "LoadBalancer" ]
+}
+
+@test "meshGateway/Service: can add additionalSpec" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-service.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'meshGateway.service.enabled=true' \
+      --set 'meshGateway.service.additionalSpec=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/test/unit/mesh-gateway-service.bats
+++ b/test/unit/mesh-gateway-service.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/Service: disabled with meshGateway.enabled=true" {
+@test "meshGateway/Service: disabled by default with meshGateway, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-service.yaml  \
@@ -35,6 +35,9 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
 
 @test "meshGateway/Service: no annotations by default" {
   cd `chart_dir`
@@ -63,6 +66,9 @@ load _helpers
   [ "${actual}" = "value" ]
 }
 
+#--------------------------------------------------------------------
+# port
+
 @test "meshGateway/Service: has default port" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -89,6 +95,9 @@ load _helpers
       yq -r '.spec.ports[0].port' | tee /dev/stderr)
   [ "${actual}" = "8443" ]
 }
+
+#--------------------------------------------------------------------
+# targetPort
 
 @test "meshGateway/Service: has default targetPort" {
   cd `chart_dir`
@@ -117,6 +126,9 @@ load _helpers
   [ "${actual}" = "8443" ]
 }
 
+#--------------------------------------------------------------------
+# nodePort
+
 @test "meshGateway/Service: no nodePort by default" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -144,6 +156,9 @@ load _helpers
   [ "${actual}" = "8443" ]
 }
 
+#--------------------------------------------------------------------
+# Service type
+
 @test "meshGateway/Service: defaults to type ClusterIP" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -170,6 +185,9 @@ load _helpers
       yq -r '.spec.type' | tee /dev/stderr)
   [ "${actual}" = "LoadBalancer" ]
 }
+
+#--------------------------------------------------------------------
+# additionalSpec
 
 @test "meshGateway/Service: can add additionalSpec" {
   cd `chart_dir`

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ServiceAccount: enabled with meshGateway.enabled = true" {
+@test "meshGateway/ServiceAccount: enabled with meshGateway, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-serviceaccount.yaml  \

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "meshGateway/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/ServiceAccount: enabled with meshGateway.enabled = true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-serviceaccount.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -163,3 +163,16 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-create-snapshot-agent-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInit/Job: mesh gateway acl option enabled with .meshGateway.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-mesh-gateway-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -111,3 +111,48 @@ load _helpers
       yq '.data["proxy-defaults-config.json"] | match("world") | length' | tee /dev/stderr)
   [ ! -z "${actual}" ]
 }
+
+@test "server/ConfigMap: proxyDefaults and meshGateways can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.globalMode=remote' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["proxy-defaults-config.json"]' | yq -r '.config_entries.bootstrap[0].mesh_gateway.mode' | tee /dev/stderr)
+  [ "${actual}" = "remote" ]
+}
+
+@test "server/ConfigMap: proxyDefaults should have no gateway mode if disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.globalMode=' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["proxy-defaults-config.json"]' | yq '.config_entries.bootstrap[0].mesh_gateway' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: global gateway mode is set even if there are no proxyDefaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.proxyDefaults=""' \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.globalMode=remote' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["proxy-defaults-config.json"]' | yq -r '.config_entries.bootstrap[0].mesh_gateway.mode' | tee /dev/stderr)
+  [ "${actual}" = "remote" ]
+}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -127,7 +127,7 @@ load _helpers
   [ "${actual}" = "remote" ]
 }
 
-@test "server/ConfigMap: proxyDefaults should have no gateway mode if disabled" {
+@test "server/ConfigMap: proxyDefaults should have no gateway mode if set to empty string" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
@@ -136,6 +136,21 @@ load _helpers
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["proxy-defaults-config.json"]' | yq '.config_entries.bootstrap[0].mesh_gateway' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: proxyDefaults should have no gateway mode if set to null" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=true' \
+      --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.globalMode=null' \
       --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.data["proxy-defaults-config.json"]' | yq '.config_entries.bootstrap[0].mesh_gateway' | tee /dev/stderr)

--- a/values.yaml
+++ b/values.yaml
@@ -415,15 +415,15 @@ meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs
   # gateways and Consul Connect will be configured to use gateways.
   # See https://www.consul.io/docs/connect/mesh_gateway.html
-  # Requirements: consul >= 1.6.0 and consul-k8s >= 0.8.2 if using global.bootstrapACLs.
+  # Requirements: consul >= 1.6.0 and consul-k8s >= 0.9.0 if using global.bootstrapACLs.
   enabled: false
 
   # Globally configure which mode the gateway should run in.
-  # Can be set to either "remote", "local", "none" or "".
+  # Can be set to either "remote", "local", "none" or empty string or null.
   # See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
   # a description of each mode.
-  # If set, connectInject.centralConfig.enabled should be set to true so that
-  # the global config will actually be used.
+  # If set to anything other than "" or null, connectInject.centralConfig.enabled
+  # should be set to true so that the global config will actually be used.
   # If set to the empty string, no global default will be set and the gateway mode
   # will need to be set individually for each service.
   globalMode: local
@@ -501,6 +501,8 @@ meshGateway:
   # to expose the gateways directly from the node.
   # If hostNetwork is true, this must be null or set to the same port as
   # containerPort.
+  # NOTE: Cannot set to 8500 or 8502 because those are reserved for the Consul
+  # agent.
   hostPort: null
 
   # If there are no connect-enabled services running, then the gateway

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,8 @@ global:
   # Note: support for the catalog sync's liveness and readiness probes was added
   # to consul-k8s v0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
-  imageK8S: "hashicorp/consul-k8s:0.8.1"
+  # If using mesh gateways and bootstrapACLs then must be >= 0.9.0.
+  imageK8S: "hashicorp/consul-k8s:0.9.0"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running
@@ -167,7 +168,7 @@ client:
   join: null
 
   # grpc should be set to true if the gRPC listener should be enabled.
-  # This should be set to true if connectInject is enabled.
+  # This should be set to true if connectInject or meshGateway is enabled.
   grpc: false
 
   # Resource requests, limits, etc. for the client cluster placement. This
@@ -408,3 +409,134 @@ connectInject:
     # configured proxy.
     proxyDefaults: |
       {}
+
+# Mesh Gateways enable Consul Connect to work across Consul datacenters.
+meshGateway:
+  # If mesh gateways are enabled, a Deployment will be created that runs
+  # gateways and Consul Connect will be configured to use gateways.
+  # See https://www.consul.io/docs/connect/mesh_gateway.html
+  # Requirements: consul >= 1.6.0 and consul-k8s >= 0.8.2 if using global.bootstrapACLs.
+  enabled: false
+
+  # Globally configure which mode the gateway should run in.
+  # Can be set to either "remote", "local", "none" or "".
+  # See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
+  # a description of each mode.
+  # If set, connectInject.centralConfig.enabled should be set to true so that
+  # the global config will actually be used.
+  # If set to the empty string, no global default will be set and the gateway mode
+  # will need to be set individually for each service.
+  globalMode: local
+
+  # Number of replicas for the Deployment.
+  replicas: 2
+
+  # What gets registered as wan address for the gateway.
+  wanAddress:
+    # Port that gets registered.
+    port: 443
+
+    # If true, each Gateway Pod will advertise its NodeIP
+    # (as provided by the Kubernetes downward API) as the wan address.
+    # This is useful if the node IPs are routable from other DCs.
+    # useNodeName and host must be false and "" respectively.
+    useNodeIP: true
+
+    # If true, each Gateway Pod will advertise its NodeName
+    # (as provided by the Kubernetes downward API) as the wan address.
+    # This is useful if the node names are DNS entries that are
+    # routable from other DCs.
+    # meshGateway.wanAddress.port will be used as the port for the wan address.
+    # useNodeIP and host must be false and "" respectively.
+    useNodeName: false
+
+    # If set, each gateway Pod will use this host as its wan address.
+    # Users must ensure that this address routes to the Gateway pods,
+    # for example via a DNS entry that routes to the Service fronting the Deployment.
+    # meshGateway.wanAddress.port will be used as the port for the wan address.
+    # useNodeIP and useNodeName must be false.
+    host: ""
+
+  # The service option configures the Service that fronts the Gateway Deployment.
+  service:
+    # Whether to create a Service or not.
+    enabled: false
+
+    # Type of service, ex. LoadBalancer, ClusterIP.
+    type: ClusterIP
+
+    # Port that the service will be exposed on.
+    # The targetPort will be set to meshGateway.containerPort.
+    port: 443
+
+    # Optional nodePort of the service. Can be used in conjunction with
+    # type: NodePort.
+    nodePort: null
+
+    # Optional YAML string for additional annotations.
+    annotations: null
+
+    # Optional YAML string that will be appended to the Service spec.
+    additionalSpec: null
+
+  # Envoy image to use.
+  imageEnvoy: envoyproxy/envoy:v1.10.0
+
+  # If set to true, gateway Pods will run on the host network.
+  hostNetwork: false
+
+  # dnsPolicy to use.
+  dnsPolicy: null
+
+  # Override the default 'mesh-gateway' service name registered in Consul.
+  # Cannot be used if bootstrapACLs is true since the ACL token generated
+  # is only for the name 'mesh-gateway'.
+  consulServiceName: ""
+
+  # Port that the gateway will run on inside the container.
+  containerPort: 443
+
+  # Optional hostPort for the gateway to be exposed on.
+  # This can be used with wanAddress.port and wanAddress.useNodeIP
+  # to expose the gateways directly from the node.
+  # If hostNetwork is true, this must be null or set to the same port as
+  # containerPort.
+  hostPort: null
+
+  # If there are no connect-enabled services running, then the gateway
+  # will fail health checks. You may disable health checks as a temporary
+  # workaround.
+  enableHealthChecks: true
+
+  resources: |
+    requests:
+      memory: "128Mi"
+      cpu: "250m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+
+  # By default, we set an anti affinity so that two gateway pods won't be
+  # on the same node. NOTE: Gateways require that Consul client agents are
+  # also running on the nodes alongside each gateway Pod.
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: "{{ .Release.Name }}"
+              component: mesh-gateway
+          topologyKey: kubernetes.io/hostname
+
+  # Optional YAML string to specify tolerations.
+  tolerations: null
+
+  # Optional YAML string to specify a nodeSelector config.
+  nodeSelector: null
+
+  # Optional priorityClassName.
+  priorityClassName: ""
+
+  # Optional YAML string for additional annotations.
+  annotations: null


### PR DESCRIPTION
- [x] consul-k8s changes merged
- [x] test with bootstrap acl
        - NOTE: this worked *but* the gateways fail unless there's a connect-enabled service running **and** for some reason the connect inject container kept getting `Error logging in: Unexpected response code: 403 (rpc error making call: rpc error making call: Permission denied)` errors...
- [x] figure out how best to specify wan-address
- [x] finish Service config
- [x] decide on default resources
- [x] liveness/readiness probes (should be able to use localhost tcp 443)
- [x] docs for all the options in values.yaml
- [x] deregistration on exit
- [x] add pod security policy
- [x] website docs
- [x] test with multi-dc
- [x] tests
