### PR TITLE
Correct service account in snapshot agent deployment

### DIFF
--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{ tpl .Values.client.tolerations . | nindent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "consul.fullname" . }}-client
+      serviceAccountName: {{ template "consul.fullname" . }}-snapshot-agent
 
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}


### PR DESCRIPTION
It looks like in #191, a new service account for the snapshot agent was added but it was never changed in the deployment. This makes the snapshot agent init container fail because it starts with the client service account which doesn't have access to the `consul-client-snapshot-agent-acl-token` secret.