### PR TITLE
Add annotations configuration to DNS service.

### DIFF
--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.dns.annotations }}
+  annotations:
+    {{ tpl .Values.dns.annotations . | nindent 4 | trim }}
+  {{- end }}
 spec:
   ports:
     - name: dns-tcp

--- a/test/unit/dns-service.bats
+++ b/test/unit/dns-service.bats
@@ -41,3 +41,27 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "dns/Service: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/dns-service.yaml  \
+      --set 'dns.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "dns/Service: can set annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/dns-service.yaml  \
+      --set 'dns.enabled=true' \
+      --set 'dns.annotations=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -254,6 +254,11 @@ client:
 dns:
   enabled: "-"
 
+  # Extra annotations to attach to the dns service
+  # This should be a multi-line string of
+  # annotations to apply to the dns Service
+  annotations: null
+
 ui:
   # True if you want to enable the Consul UI. The UI will run only
   # on the server nodes. This makes UI access via the service below (if


### PR DESCRIPTION
Many cloud providers support bind Load Balancer address by using service
annotations. Such as Amazon AWS, Alibaba AliCloud etc.

So, then we can set a fixed LB address in coredns configMap settings, not a non-stable dynamic cluster ip.