### PR TITLE
Add support for k8s source namespace flag

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -72,6 +72,9 @@ spec:
                 {{- if .Values.syncCatalog.k8sPrefix }}
                 -k8s-service-prefix="{{ .Values.syncCatalog.k8sPrefix}}" \
                 {{- end }}
+                {{- if .Values.syncCatalog.k8sSourceNamespace }}
+                -k8s-source-namespace="{{ .Values.syncCatalog.k8sSourceNamespace}}" \
+                {{- end }}
                 -k8s-write-namespace=${NAMESPACE} \
                 {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
                 -sync-clusterip-services=false \

--- a/values.yaml
+++ b/values.yaml
@@ -301,6 +301,11 @@ syncCatalog:
   # prepended with "consul-". (Consul -> Kubernetes sync)
   k8sPrefix: null
 
+  # k8sSourceNamespace is the Kubernetes namespace to watch for service
+  # changes and sync to Consul. If this is not set then it will default
+  # to all namespaces.
+  k8sSourceNamespace: null
+
   # consulPrefix is the service prefix which preprends itself
   # to Kubernetes services registered within Consul
   # For example, "k8s-" will register all services peprended with "k8s-".


### PR DESCRIPTION
Add support for k8s source namespace flag defined here: https://github.com/hashicorp/consul-k8s/blob/3c0cf6872a839a753fa7a0775dca9a7c3fa10704/subcommand/sync-catalog/command.go#L73