### PR TITLE
Use recommended labels as defined in kubernetes docs

### DIFF
--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -4,10 +4,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-client
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- if (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}

--- a/templates/client-clusterrolebinding.yaml
+++ b/templates/client-clusterrolebinding.yaml
@@ -4,10 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-client
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/client-config-configmap.yaml
+++ b/templates/client-config-configmap.yaml
@@ -7,10 +7,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-client-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 data:
   extra-from-values.json: |-
 {{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -6,24 +6,25 @@ metadata:
   name: {{ template "consul.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: client
       hasDNS: "true"
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: client
         hasDNS: "true"
       annotations:

--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -4,10 +4,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-client
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ template "consul.fullname" . }}-client
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}

--- a/templates/client-snapshot-agent-clusterrole.yaml
+++ b/templates/client-snapshot-agent-clusterrole.yaml
@@ -5,10 +5,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- if not (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
 rules: []
 {{- else }}

--- a/templates/client-snapshot-agent-clusterrolebinding.yaml
+++ b/templates/client-snapshot-agent-clusterrolebinding.yaml
@@ -5,10 +5,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -6,24 +6,25 @@ metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   replicas: {{ .Values.client.snapshotAgent.replicas }}
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: client-snapshot-agent
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: client-snapshot-agent
       annotations:
         "consul.hashicorp.com/connect-inject": "false"

--- a/templates/client-snapshot-agent-podsecuritypolicy.yaml
+++ b/templates/client-snapshot-agent-podsecuritypolicy.yaml
@@ -5,10 +5,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -6,9 +6,10 @@ metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/templates/connect-inject-authmethod-clusterrole.yaml
@@ -5,10 +5,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-authmethod-role
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -5,10 +5,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-authmethod-authdelegator-role-binding
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,10 +24,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-authmethod-serviceaccount-role-binding
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -6,9 +6,10 @@ metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -5,14 +5,15 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: 
+  verbs:
     - "get"
     - "list"
     - "watch"

--- a/templates/connect-inject-clusterrolebinding.yaml
+++ b/templates/connect-inject-clusterrolebinding.yaml
@@ -4,10 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook-admin-role-binding
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -6,24 +6,25 @@ metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook-deployment
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: connect-injector
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: connect-injector
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
@@ -101,5 +102,5 @@ spec:
       {{- if .Values.connectInject.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.connectInject.nodeSelector . | indent 8 | trim }}
-      {{- end }}  
+      {{- end }}
 {{- end }}

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -6,10 +6,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-cfg
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
     clientConfig:

--- a/templates/connect-inject-podsecuritypolicy.yaml
+++ b/templates/connect-inject-podsecuritypolicy.yaml
@@ -4,10 +4,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/connect-inject-service.yaml
+++ b/templates/connect-inject-service.yaml
@@ -6,17 +6,18 @@ metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-svc
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   ports:
   - port: 443
     targetPort: 8080
   selector:
-    app: {{ template "consul.name" . }}
-    release: "{{ .Release.Name }}"
+    helm.sh/chart: {{ template "consul.chart" . }}
+    app.kubernetes.io/name: {{ template "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     component: connect-injector
 {{- end }}
-

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}

--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -6,10 +6,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-dns
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   ports:
     - name: dns-tcp
@@ -21,7 +22,8 @@ spec:
       protocol: "UDP"
       targetPort: dns-udp
   selector:
-    app: {{ template "consul.name" . }}
-    release: "{{ .Release.Name }}"
+    helm.sh/chart: {{ template "consul.chart" . }}
+    app.kubernetes.io/name: {{ template "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     hasDNS: "true"
 {{- end }}

--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -7,10 +7,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/enterprise-license-clusterrolebinding.yaml
+++ b/templates/enterprise-license-clusterrolebinding.yaml
@@ -7,10 +7,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -8,10 +8,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license.yaml
+++ b/templates/enterprise-license.yaml
@@ -51,7 +51,7 @@ spec:
                   name: "{{ .Release.Name }}-consul-enterprise-license-acl-token"
                   key: "token"
             {{- end}}
-          command: 
+          command:
             - "/bin/sh"
             - "-ec"
             - |

--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -4,10 +4,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
 {{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
 rules:

--- a/templates/mesh-gateway-clusterrolebinding.yaml
+++ b/templates/mesh-gateway-clusterrolebinding.yaml
@@ -4,10 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -9,25 +9,26 @@ metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
 spec:
   replicas: {{ .Values.meshGateway.replicas }}
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: mesh-gateway
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: mesh-gateway
       annotations:
         "consul.hashicorp.com/connect-inject": "false"

--- a/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -4,10 +4,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
 spec:
   privileged: false

--- a/templates/mesh-gateway-service.yaml
+++ b/templates/mesh-gateway-service.yaml
@@ -5,10 +5,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
   {{- if .Values.meshGateway.service.annotations }}
   annotations:
@@ -16,8 +17,9 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: {{ template "consul.name" . }}
-    release: "{{ .Release.Name }}"
+    helm.sh/chart: {{ template "consul.chart" . }}
+    app.kubernetes.io/name: {{ template "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     component: mesh-gateway
   ports:
     - name: gateway

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -5,9 +5,10 @@ metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
     component: mesh-gateway
 {{- end }}

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -6,10 +6,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -6,10 +6,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -7,10 +7,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
@@ -20,9 +21,9 @@ spec:
     metadata:
       name: {{ template "consul.fullname" . }}-server-acl-init
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: server-acl-init
       annotations:
         "consul.hashicorp.com/connect-inject": "false"

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -7,10 +7,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-clusterrole.yaml
+++ b/templates/server-clusterrole.yaml
@@ -4,10 +4,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-server
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 rules:
 - apiGroups: ["policy"]

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -4,10 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -6,10 +6,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-server-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 data:
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -7,15 +7,17 @@ metadata:
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   maxUnavailable: {{ template "consul.pdb.maxUnavailable" . }}
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      release: "{{ .Release.Name }}"
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: server
 {{- end }}

--- a/templates/server-podsecuritypolicy.yaml
+++ b/templates/server-podsecuritypolicy.yaml
@@ -4,10 +4,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -10,10 +10,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
   annotations:
     # This must be set in addition to publishNotReadyAddresses due
     # to an open issue where it may not work:
@@ -56,7 +57,8 @@ spec:
       port: 8600
       targetPort: dns-udp
   selector:
-    app: {{ template "consul.name" . }}
-    release: "{{ .Release.Name }}"
+    helm.sh/chart: {{ template "consul.chart" . }}
+    app.kubernetes.io/name: {{ template "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
 {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -6,10 +6,11 @@ metadata:
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   serviceName: {{ template "consul.fullname" . }}-server
   podManagementPolicy: Parallel
@@ -22,17 +23,17 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: server
       hasDNS: "true"
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: server
         hasDNS: "true"
       annotations:
@@ -176,7 +177,7 @@ spec:
       {{- if .Values.server.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
-      {{- end }}    
+      {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}

--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -5,10 +5,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/sync-catalog-clusterrolebinding.yaml
+++ b/templates/sync-catalog-clusterrolebinding.yaml
@@ -5,10 +5,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -6,24 +6,25 @@ metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "consul.name" . }}
-      chart: {{ template "consul.chart" . }}
-      release: {{ .Release.Name }}
+      helm.sh/chart: {{ template "consul.chart" . }}
+      app.kubernetes.io/name: {{ template "consul.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: sync-catalog
   template:
     metadata:
       labels:
-        app: {{ template "consul.name" . }}
-        chart: {{ template "consul.chart" . }}
-        release: {{ .Release.Name }}
+        helm.sh/chart: {{ template "consul.chart" . }}
+        app.kubernetes.io/name: {{ template "consul.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         component: sync-catalog
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
@@ -121,5 +122,5 @@ spec:
       {{- if .Values.syncCatalog.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.syncCatalog.nodeSelector . | indent 8 | trim }}
-      {{- end }}  
+      {{- end }}
 {{- end }}

--- a/templates/sync-catalog-podsecuritypolicy.yaml
+++ b/templates/sync-catalog-podsecuritypolicy.yaml
@@ -4,10 +4,11 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -6,18 +6,20 @@ metadata:
   name: {{ template "consul.fullname" . }}-ui
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "consul.name" . }}
-    chart: {{ template "consul.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    helm.sh/chart: {{ include "consul.chart" . }}
+    app.kubernetes.io/name: {{ include "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
   {{- if .Values.ui.service.annotations }}
   annotations:
     {{ tpl .Values.ui.service.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
   selector:
-    app: {{ template "consul.name" . }}
-    release: "{{ .Release.Name }}"
+    helm.sh/chart: {{ template "consul.chart" . }}
+    app.kubernetes.io/name: {{ template "consul.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
   ports:
     - name: http


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul-helm/issues/120.

Use labels as defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels. There are now 5 labels for the outer template and 3 labels for the inner template (selector, matchLabels, etc.). Labels are not alphabetically organized in order to minimize the number of labels copying/pasting from the outer template to the inner template. Style of ordering was copied from https://github.com/hashicorp/vault-helm/pull/8.