### PR TITLE
Allow hardcoding DNS service's IP

### DIFF
--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  {{- if .Values.dns.clusterIP }}
+  clusterIP: {{ .Values.dns.clusterIP }}
+  {{- end }}
   ports:
     - name: dns-tcp
       port: 53

--- a/values.yaml
+++ b/values.yaml
@@ -253,6 +253,7 @@ client:
 # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configure-stub-domain-and-upstream-dns-servers
 dns:
   enabled: "-"
+  clusterIP: ""
 
 ui:
   # True if you want to enable the Consul UI. The UI will run only


### PR DESCRIPTION
In order to use Consul's DNS inside a Kubernetes cluster, we need to manually add the service's IP address after it is created to CoreDNS's or kube-dns's configuration. If the service is recreated, we need to manually change the configuration to reflect this and forgetting this will cause issues.

With this we can hardcode the DNS service's cluster IP to a known value and avoid the extra manual work.

PS: I do not know if I should upgrade the chart's version. Just let me know if that is the case.