### PR TITLE
Mount in extra-configs as files instead of a whole folder

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -134,7 +134,8 @@ spec:
             - name: data
               mountPath: /consul/data
             - name: config
-              mountPath: /consul/config
+              mountPath: /consul/config/extra-from-values.json
+              subPath: extra-from-values.json
             {{- range .Values.client.extraVolumes }}
             - name: userconfig-{{ .name }}
               readOnly: true

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -126,7 +126,8 @@ spec:
             - name: data-{{ .Release.Namespace }}
               mountPath: /consul/data
             - name: config
-              mountPath: /consul/config
+              mountPath: /consul/config/extra-from-values.json
+              subPath: extra-from-values.json
             {{- range .Values.server.extraVolumes }}
             - name: userconfig-{{ .name }}
               readOnly: true


### PR DESCRIPTION
Mounting extra-from-values.json as a whole folder makes the folder read-only preventing people from adding in more configs to the config directory.

This PR modifies the chart to mount extra-from-values.json as a file and allows people to mount in other extra configs into the config directory as necessary. 