### PR TITLE
Configuration to save persistent data on node, updateStrategy and dnsPolicy configuration

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -11,6 +11,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  {{- if .Values.client.updateStrategy }}
+  updateStrategy:
+    {{ toYaml .Values.client.updateStrategy | nindent 4 | trim }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "consul.name" . }}
@@ -43,12 +47,23 @@ spec:
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
 
+      {{- if .Values.client.dnsPolicy }}
+      dnsPolicy: {{ .Values.client.dnsPolicy }}
+      {{- end }}
+
       # Consul agents require a directory for data, even clients. The data
       # is okay to be wiped though if the Pod is removed, so just use an
       # emptyDir volume.
       volumes:
         - name: data
+        {{- if .Values.client.hostPath }}
+          hostPath:
+            # directory location on host
+            path: {{ .Values.client.hostPath }}
+            type: DirectoryOrCreate
+        {{- else }}
           emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-client-config

--- a/values.yaml
+++ b/values.yaml
@@ -245,6 +245,25 @@ client:
       secretName: null
       secretKey: null
 
+    # updateStrategy for the DaemonSet.
+    # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+    # This should be a multi-line string mapping directly to the updateStrategy
+    # Example:
+    #  updateStrategy:
+    #    rollingUpdate:
+    #      maxUnavailable: 5
+    #    type: RollingUpdate
+    updateStrategy: null
+
+    # hostPath is fullpath to folder on host machine to mount as /consul/data folder. consul agent stores
+    # its configuration in this folder. By default its created as emptyDir: {}. To save data between pod restarts
+    # specify folder name on host machine to be mounted as /consul/data.
+    # Example:
+    # hostPath: '/var/consul-data'
+    hostPath: null
+
+    dnsPolicy: null
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns


### PR DESCRIPTION
**Configuration to save persistent data on node**
During consul agent upgrade , consul agent pod gets restarted and since /consul/data folder is mounted to emptyDir - all the data is erased, and new agent will try to register as a completely new agent.
If we save /consul/data content between pod restarts, new pod will continue with id and configuration that previous pod had.
This will decrease pressure on consul server during consul-agent upgrades.
This pull request adds hostPath parameter that can be configured with path to host machine folder to save contents of /consul/data folder.If this parameter is not defined everything will continue to work as before.

**dnsPolicy configuration**
If you use external DNS service you may want to explicitly contol DNS resolution priorities

**updateStrategy configuration**
On big clusters it may take hours to upgrade daemonset with 500+ pods, modifying updateStrategy  can drastically reduce rollout time.