### PR TITLE
Allows to add annotations on the client service account ressource

### DIFF
--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,4 +9,8 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.client.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.client.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.client.snapshotAgent.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.client.snapshotAgent.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.connectInject.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.connectInject.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -9,4 +9,8 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.connectInject.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.connectInject.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.server.enterpriseLicense.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.server.enterpriseLicense.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
+  {{- if .Values.meshGateway.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.meshGateway.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,4 +9,8 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.syncCatalog.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.syncCatalog.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/templates/tls-init-cleanup-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-serviceaccount.yaml
+++ b/templates/tls-init-serviceaccount.yaml
@@ -13,5 +13,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+  {{- if .Values.server.serviceAccount.annotations }}
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/client-serviceaccount.bats
+++ b/test/unit/client-serviceaccount.bats
@@ -51,3 +51,22 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "client/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-serviceaccount.yaml \
+      --set "client.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/client-snapshot-agent-serviceaccount.bats
+++ b/test/unit/client-snapshot-agent-serviceaccount.bats
@@ -42,3 +42,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "client/SnapshotAgentServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-snapshot-agent-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/connect-inject-authmethod-serviceaccount.bats
+++ b/test/unit/connect-inject-authmethod-serviceaccount.bats
@@ -44,3 +44,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "connectInjectAuthMethod/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/connect-inject-serviceaccount.bats
+++ b/test/unit/connect-inject-serviceaccount.bats
@@ -53,3 +53,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "connectInject/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/enterprise-license-serviceaccount.bats
+++ b/test/unit/enterprise-license-serviceaccount.bats
@@ -53,3 +53,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "enterpriseLicense/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -23,3 +23,11 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "meshGateway/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -42,3 +42,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInitCleanup/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -42,3 +42,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInit/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -51,3 +51,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/sync-catalog-serviceaccount.bats
+++ b/test/unit/sync-catalog-serviceaccount.bats
@@ -51,3 +51,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "syncCatalog/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/tls-init-cleanup-serviceaccount.bats
+++ b/test/unit/tls-init-cleanup-serviceaccount.bats
@@ -53,3 +53,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "tlsInitCleanup/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tls-init-cleanup-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/tls-init-serviceaccount.bats
+++ b/test/unit/tls-init-serviceaccount.bats
@@ -53,3 +53,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "tlsInit/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tls-init-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -130,6 +130,12 @@ server:
     secretName: null
     secretKey: null
 
+    # Extra annotations to attach to the entreprise license service account
+    # This should be a multi-line string mapping directly to the a map of
+    # the annotations to apply to the service account
+    serviceAccount:
+      annotations: null
+
   # storage and storageClass are the settings for configuring stateful
   # storage for the server pods. storage should be set to the disk size of
   # the attached volume. storageClass is the class of storage which defaults
@@ -174,6 +180,12 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
+
+  # Extra annotations to attach to the server service account
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the service account
+  serviceAccount:
+    annotations: null
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
@@ -302,6 +314,12 @@ client:
   # the annotations to apply to the client pods
   annotations: null
 
+  # Extra annotations to attach to the client service account
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the service account
+  serviceAccount:
+    annotations: null
+
   # extraEnvVars is a list of extra enviroment variables to set with the pod. These could be
   # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
@@ -333,6 +351,12 @@ client:
 
     # replicas determines how many snapshot agent pods are created
     replicas: 2
+
+    # Extra annotations to attach to the snapshot agent service account
+    # This should be a multi-line string mapping directly to the a map of
+    # the annotations to apply to the service account
+    serviceAccount:
+      annotations: null
 
     # configSecret references a Kubernetes secret that should be manually created to
     # contain the entire config to be used on the snapshot agent. This is the preferred
@@ -460,6 +484,12 @@ syncCatalog:
     secretName: null
     secretKey: null
 
+  # Extra annotations to attach to the sync catalog service account
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the service account
+  serviceAccount:
+    annotations: null
+
   # nodeSelector labels for syncCatalog pod assignment, formatted as a multi-line string.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # Example:
@@ -498,6 +528,12 @@ connectInject:
   #   matchLabels:
   #     namespace-label: label-value
   namespaceSelector: null
+  #
+  # Extra annotations to attach to the connect inject service account
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the service account
+  serviceAccount:
+    annotations: null
 
   # The certs section configures how the webhook TLS certs are configured.
   # These are the TLS certs for the Kube apiserver communicating to the
@@ -669,6 +705,12 @@ meshGateway:
   # will fail health checks. You may disable health checks as a temporary
   # workaround.
   enableHealthChecks: true
+
+  # Extra annotations to attach to the mesh gateway service account
+  # This should be a multi-line string mapping directly to the a map of
+  # the annotations to apply to the service account
+  serviceAccount:
+    annotations: null
 
   resources: |
     requests:


### PR DESCRIPTION
Regarding the issue #235 , This PR allows users to provide annotations for the client service account (It seems to be the only relevant place to support this, at least for now).

If you have any comments, feel free!