### PR TITLE
Update to latest consul-k8s version.

### DIFF
--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -25,22 +25,6 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
-      initContainers:
-        - name: wait-for-leader
-          image: bitnami/kubectl:1.13
-          command:
-            - "/bin/bash"
-            - "-c"
-            - |
-              echo "Waiting for {{ .Values.server.replicas }} server pods to be running"
-              COUNT=0;
-              while [[ $COUNT -lt {{ .Values.server.replicas }} ]]; do
-                sleep 5s;
-                COUNT=$(kubectl get pods -n {{ .Release.Namespace }} -l "app=consul,component=server,release={{.Release.Name}}" | grep 'Running' | wc -l);
-                echo "Current count: $COUNT";
-              done;
-              # Sleep for 10 to allow for leader election.
-              sleep 10s;
       containers:
         - name: post-install-job
           image: {{ .Values.global.imageK8S }}

--- a/values.yaml
+++ b/values.yaml
@@ -25,7 +25,7 @@ global:
   # to consul-k8s v0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
   # If using mesh gateways and bootstrapACLs then must be >= 0.9.0.
-  imageK8S: "hashicorp/consul-k8s:0.9.1"
+  imageK8S: "hashicorp/consul-k8s:0.9.2"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running


### PR DESCRIPTION
This version fixes a bug that required Consul leaders to be elected
prior to running the consul-k8s server-acl-init command. Since the
command will now wait for leaders to be elected, we no longer need the
init container.

Companion to https://github.com/hashicorp/consul-k8s/pull/143