### PR TITLE
Add server-acl-init-cleanup job

### DIFF
--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -4,41 +4,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "consul.fullname" . }}-server-acl-init
+  name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - list
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-  - apiGroups: ["apps"]
-    resources:
-      - statefulsets
-    verbs:
-      - get
-{{- if .Values.connectInject.enabled }}
-  - apiGroups: [""]
-    resources:
-      - serviceaccounts
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - services
-    verbs:
-      - get
-{{- end }}
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "delete"]
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -2,43 +2,22 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-server-acl-init
+  name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - list
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-  - apiGroups: ["apps"]
-    resources:
-      - statefulsets
-    verbs:
-      - get
-{{- if .Values.connectInject.enabled }}
-  - apiGroups: [""]
-    resources:
-      - serviceaccounts
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - services
-    verbs:
-      - get
-{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,0 +1,55 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+# This job deletes the server-acl-init job once it completes successfully.
+# It runs as a helm hook because it only needs to run when the server-acl-init
+# Job gets recreated which only happens during an install or upgrade.
+# We also utilize the helm hook-delete-policy to delete this job itself.
+# We want to delete the server-acl-init job because once it runs successfully
+# it's not needed and also because if it stays around then when users run
+# helm upgrade with values that change the spec of the job, Kubernetes errors
+# because the job spec is immutable. If the job is deleted, then a new job
+# is created and there's no error.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    # If the hook fails then all that happens is we didn't delete the job.
+    # There's no reason for *this* job to stay around in that case so delete
+    # regardless of success.
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+      labels:
+        app: {{ template "consul.name" . }}
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: server-acl-init-cleanup
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+      containers:
+        - name: server-acl-init-cleanup
+          image: {{ .Values.global.imageK8S }}
+          command:
+            - consul-k8s
+          args:
+            - delete-completed-job
+            - -k8s-namespace={{ .Release.Namespace }}
+            - {{ template "consul.fullname" . }}-server-acl-init
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.bootstrapACLs }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/test/unit/server-acl-init-cleanup-clusterrole.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrole.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInitCleanup/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ClusterRole: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ClusterRole: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ClusterRole: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInitCleanup/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ClusterRoleBinding: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ClusterRoleBinding: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInitCleanup/Job: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/Job: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/Job: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/Job: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/Job: consul-k8s delete-completed-job is called with correct arguments" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+  [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","release-name-consul-server-acl-init"]' ]
+}

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serverACLInitCleanup/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ServiceAccount: enabled with global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ServiceAccount: disabled with server=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInitCleanup/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -25,7 +25,7 @@ global:
   # to consul-k8s v0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
   # If using mesh gateways and bootstrapACLs then must be >= 0.9.0.
-  imageK8S: "hashicorp/consul-k8s:0.9.2"
+  imageK8S: "hashicorp/consul-k8s:0.9.3"
 
   # Datacenter is the name of the datacenter that the agents should register
   # as. This shouldn't be changed once the Consul cluster is up and running


### PR DESCRIPTION
This job deletes the server-acl-init job when it completes successfully.
This keeps things clean and more importantly fixes the issue where if
you try to make a change to the helm values that result in updating the
spec for the Job that you get an error because the Job spec is
immutable. If the Job is deleted then this isn't a problem.

Also upgrades consul-k8s to the version with the new
delete-completed-job command.

Fixes #227 
Needs https://github.com/hashicorp/consul-k8s/pull/152