### PR TITLE
Less privileges when syncCatalog.toK8S = false

### DIFF
--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -18,10 +18,12 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.syncCatalog.toK8S }}
       - update
       - patch
       - delete
       - create
+{{- end }}
   - apiGroups: [""]
     resources:
       - nodes

--- a/test/unit/sync-catalog-clusterrole.bats
+++ b/test/unit/sync-catalog-clusterrole.bats
@@ -79,3 +79,28 @@ load _helpers
       yq -r '.rules[2].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]
 }
+
+#--------------------------------------------------------------------
+# syncCatalog.toK8S={true,false}
+
+@test "syncCatalog/ClusterRole: has reduced permissions if toK8s=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-clusterrole.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.toK8S=false' \
+      . | tee /dev/stderr |
+      yq -c '.rules[0].verbs' | tee /dev/stderr)
+  [ "${actual}" = '["get","list","watch"]' ]
+}
+
+@test "syncCatalog/ClusterRole: has full permissions if toK8s=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-clusterrole.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.toK8S=true' \
+      . | tee /dev/stderr |
+      yq -c '.rules[0].verbs' | tee /dev/stderr)
+  [ "${actual}" = '["get","list","watch","update","patch","delete","create"]' ]
+}


### PR DESCRIPTION
When `syncCatalog.toK8S=false` we don't need as many permissions since we're not creating any kube services.

Takes commit from #224 and adds tests. Will close #224 since we hadn't heard back for a while.