### PR TITLE
Add flag for turning off tests

### DIFF
--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.tests.enabled) }}
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.tests.enabled) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -29,3 +30,4 @@ spec:
             [ `consul kv get _consul_helm_test` = "$VALUE" ]
             consul kv delete _consul_helm_test
   restartPolicy: Never
+{{- end }}

--- a/test/unit/test-runner.bats
+++ b/test/unit/test-runner.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "testRunner/Pod: enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "testRunner/Pod: disabled when tests.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'tests.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -575,3 +575,6 @@ meshGateway:
 
   # Optional YAML string for additional annotations.
   annotations: null
+
+tests:
+  enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -576,5 +576,8 @@ meshGateway:
   # Optional YAML string for additional annotations.
   annotations: null
 
+# Control whether a test Pod manifest is generated when running helm template.
+# When using helm install, the test Pod is not submitted to the cluster so this
+# is only useful when running helm template.
 tests:
   enabled: true


### PR DESCRIPTION
Useful in the case where users are running `helm template` and they don't want the test Pod submitted. When running `helm install`, helm won't submit the Pod, only if users manually run `helm test`.

Adds docs to #144, closes #144