### PR TITLE
Run server-acl-init even when clients are disabled

### DIFF
--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -14,6 +13,5 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "delete"]
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18,6 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 # This job deletes the server-acl-init job once it completes successfully.
 # It runs as a helm hook because it only needs to run when the server-acl-init
@@ -50,6 +49,5 @@ spec:
             - delete-completed-job
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
-  {{- end }}
   {{- end }}
   {{- end }}

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,6 +10,5 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -38,7 +37,6 @@ rules:
       - services
     verbs:
       - get
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18,6 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: batch/v1
 kind: Job
@@ -61,7 +60,9 @@ spec:
                 {{- if .Values.client.snapshotAgent.enabled }}
                 -create-snapshot-agent-token=true \
                 {{- end }}
+                {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+                -create-client-token=false \
+                {{- end }}
                 -expected-replicas={{ .Values.server.replicas }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,6 +10,5 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/server-acl-init-cleanup-clusterrole.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrole.bats
@@ -32,13 +32,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRole: enabled with client=true and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
       --set 'global.bootstrapACLs=true' \
-      --set 'client.enabled=false' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
@@ -32,7 +32,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
@@ -40,5 +40,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -32,7 +32,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/Job: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/Job: enabled with client=true and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
@@ -40,7 +40,7 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "serverACLInitCleanup/Job: consul-k8s delete-completed-job is called with correct arguments" {

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -32,7 +32,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ServiceAccount: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
@@ -40,5 +40,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-clusterrole.bats
+++ b/test/unit/server-acl-init-clusterrole.bats
@@ -32,7 +32,19 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRole: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrole.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRole: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-clusterrole.bats
+++ b/test/unit/server-acl-init-clusterrole.bats
@@ -32,18 +32,6 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with server=true, client=false and global.bootstrapACLs=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'server.enabled=true' \
-      --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "serverACLInit/ClusterRole: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -32,7 +32,19 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrolebinding.yaml  \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -32,18 +32,6 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with server=true, client=false and global.bootstrapACLs=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'server.enabled=true' \
-      --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -11,56 +11,59 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled server & client acls with global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled with global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual="$(helm template \
+  local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr)"
-  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
-  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
-  [ "${actual_enabled}" = "true" ]
-  [ "${actual_client_acl_disabled}" = "false" ]
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: disabled server & client acls with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: disabled with server=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual="$(helm template \
+  local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=false' \
-      . | tee /dev/stderr)"
-  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
-  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
-  [ "${actual_enabled}" = "false" ]
-  [ "${actual_client_acl_disabled}" = "false" ]
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled server acls, disabled client acls with server=true, client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled with client=false global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual="$(helm template \
-      -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'server.enabled=true' \
-      --set 'client.enabled=false' \
-      . | tee /dev/stderr)"
-  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
-  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
-  [ "${actual_enabled}" = "true" ]
-  [ "${actual_client_acl_disabled}" = "true" ]
-}
-
-@test "serverACLInit/Job: enabled server acls, disabled client acls with client=false and global.bootstrapACLs=true" {
-  cd `chart_dir`
-  local actual="$(helm template \
+  local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'client.enabled=false' \
-      . | tee /dev/stderr)"
-  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
-  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
-  [ "${actual_enabled}" = "true" ]
-  [ "${actual_client_acl_disabled}" = "true" ]
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: does not set -create-client-token=false when client is enabled (the default)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
+      tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: sets -create-client-token=false when client is disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
+      tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -11,36 +11,56 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled server & client acls with global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "false" ]
 }
 
-@test "serverACLInit/Job: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: disabled server & client acls with server=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "false" ]
+  [ "${actual_client_acl_disabled}" = "false" ]
 }
 
-@test "serverACLInit/Job: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled server acls, disabled client acls with server=true, client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual="$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "true" ]
+}
+
+@test "serverACLInit/Job: enabled server acls, disabled client acls with client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual="$(helm template \
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' \
       --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      . | tee /dev/stderr)"
+  local actual_enabled=$(echo "$actual" | yq 'length > 0' | tee /dev/stderr)
+  local actual_client_acl_disabled=$(echo "$actual" | grep "create-client-token=false" >/dev/null && echo "true" || echo "false" | tee /dev/stderr )
+  [ "${actual_enabled}" = "true" ]
+  [ "${actual_client_acl_disabled}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -32,6 +32,18 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "serverACLInit/ServiceAccount: enabled with server=true, client=false and global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "serverACLInit/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -40,5 +52,5 @@ load _helpers
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -32,19 +32,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ServiceAccount: enabled with server=true, client=false and global.bootstrapACLs=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-acl-init-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'server.enabled=true' \
-      --set 'client.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "serverACLInit/ServiceAccount: disabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ServiceAccount: enabled with client=false and global.bootstrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-serviceaccount.yaml  \


### PR DESCRIPTION
BootstrapACLs is still useful when there are no Consul clients running and it doesn't need clients itself.

Refactors tests from https://github.com/hashicorp/consul-helm/pull/190 and updates the acl-cleanup job so it also runs when clients are disabled.

Needs #246 