### PR TITLE
Add ability to run sidecars with consul

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -173,9 +173,9 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
-{{- with .Values.server.extraContainers }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+        {{- if .Values.server.extraContainers }}
+          {{ tpl .Values.server.extraContainer . | nindent 8 }}
+        {{- end }}
       {{- if .Values.server.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -173,6 +173,9 @@ spec:
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
+{{- with .Values.server.extraContainers }}
+{{ tpl . $ | indent 8 }}
+{{- end }}
       {{- if .Values.server.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -101,6 +101,7 @@ spec:
                 -bootstrap-expect={{ .Values.server.bootstrapExpect }} \
                 -client=0.0.0.0 \
                 -config-dir=/consul/config \
+                -log-level={{ .Values.server.loglevel }} \
                 {{- range .Values.server.extraVolumes }}
                 {{- if .load }}
                 -config-dir=/consul/userconfig/{{ .name }} \
@@ -121,7 +122,7 @@ spec:
                 {{- range $index := until (.Values.server.replicas | int) }}
                 -retry-join=${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
                 {{- end }}
-                -server
+                -server \
           volumeMounts:
             - name: data-{{ .Release.Namespace }}
               mountPath: /consul/data

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -174,7 +174,7 @@ spec:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}
           {{- end }}
         {{- if .Values.server.extraContainers }}
-          {{ tpl .Values.server.extraContainer . | nindent 8 }}
+          {{ toYaml .Values.server.extraContainers | nindent 8}}
         {{- end }}
       {{- if .Values.server.nodeSelector }}
       nodeSelector:

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -471,3 +471,85 @@ load _helpers
       yq -r '.[3].value' | tee /dev/stderr)
   [ "${actual}" = "custom_no_proxy" ]
 }
+
+#--------------------------------------------------------------------
+# extraContainers
+
+@test "server/standalone-StatefulSet: adds extra containers" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraContainers[0].image=test-image' \
+      --set 'server.extraContainers[0].name=test-container' \
+      --set 'server.extraContainers[0].ports[0].name=test-port' \
+      --set 'server.extraContainers[0].ports[0].containerPort=9410' \
+      --set 'server.extraContainers[0].ports[0].protocol=TCP' \
+      --set 'server.extraContainers[0].env[0].name=TEST_ENV' \
+      --set 'server.extraContainers[0].env[0].value=test_env_value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[] | select(.name == "test-container")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "test-container" ]
+
+  local actual=$(echo $object |
+      yq -r '.image' | tee /dev/stderr)
+  [ "${actual}" = "test-image" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].name' | tee /dev/stderr)
+  [ "${actual}" = "test-port" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].containerPort' | tee /dev/stderr)
+  [ "${actual}" = "9410" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].protocol' | tee /dev/stderr)
+  [ "${actual}" = "TCP" ]
+
+  local actual=$(echo $object |
+      yq -r '.env[0].name' | tee /dev/stderr)
+  [ "${actual}" = "TEST_ENV" ]
+
+  local actual=$(echo $object |
+      yq -r '.env[0].value' | tee /dev/stderr)
+  [ "${actual}" = "test_env_value" ]
+
+}
+
+@test "server/standalone-StatefulSet: add two extra containers" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraContainers[0].image=test-image' \
+      --set 'server.extraContainers[0].name=test-container' \
+      --set 'server.extraContainers[1].image=test-image' \
+      --set 'server.extraContainers[1].name=test-container-2' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local containers_count=$(echo $object |
+      yq -r 'length' | tee /dev/stderr)
+  [ "${containers_count}" = 3 ]
+
+}
+
+@test "server/standalone-StatefulSet: no extra containers added" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local containers_count=$(echo $object |
+      yq -r 'length' | tee /dev/stderr)
+  [ "${containers_count}" = 1 ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -61,6 +61,9 @@ server:
   replicas: 3
   bootstrapExpect: 3 # Should <= replicas count
 
+  # Configure the Log Level Supported log levels. This defaults to "info". The available log levels are "trace", "debug", "info", "warn", and "err"
+  loglevel: "err"
+
   # enterpriseLicense refers to a Kubernetes secret that you have created that
   # contains your enterprise license. It is required if you are using an
   # enterprise binary. Defining it here applies it to your cluster once a leader
@@ -268,7 +271,7 @@ client:
 # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configure-stub-domain-and-upstream-dns-servers
 dns:
   enabled: "-"
-  
+
   # Set a predefined cluster IP for the DNS service.
   # Useful if you need to reference the DNS service's IP
   # address in CoreDNS config.

--- a/values.yaml
+++ b/values.yaml
@@ -159,6 +159,17 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
+  extraContainers: |
+    - name: consul-exporter
+      image: prom/consul-exporter
+      ports:
+      - name: metrics
+        containerPort: 9107
+        protocol: TCP
+      args:
+          - --consul.server=http://127.0.0.1:8500
+
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
 # DC where a single agent is deployed per node.
@@ -223,10 +234,6 @@ client:
     # http_proxy: http://localhost:3128,
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
-
-  # extraContainer is a list of side-car containers that you might need to run with your
-  # vault instance e.g. prometheus exporter
-  extraContainers: |
 
   # snaphotAgent contains settings for setting up and running snapshot agents
   # within the Consul clusters. They are required to be co-located with Consul

--- a/values.yaml
+++ b/values.yaml
@@ -160,15 +160,7 @@ server:
     # no_proxy: internal.domain.com
 
   # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
-  extraContainers: |
-    - name: consul-exporter
-      image: prom/consul-exporter
-      ports:
-      - name: metrics
-        containerPort: 9107
-        protocol: TCP
-      args:
-          - --consul.server=http://127.0.0.1:8500
+  extraContainers: null
 
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional

--- a/values.yaml
+++ b/values.yaml
@@ -224,6 +224,10 @@ client:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # extraContainer is a list of side-car containers that you might need to run with your
+  # vault instance e.g. prometheus exporter
+  extraContainers: |
+
   # snaphotAgent contains settings for setting up and running snapshot agents
   # within the Consul clusters. They are required to be co-located with Consul
   # clients, so will inherit the clients' nodeSelector, tolerations and affinity.


### PR DESCRIPTION
Problem: This chart does not allow running sidecar containers with consul, that might me needed for some scenarios e.g. running prometheus exporter.

Solution: Add configurable sidecar containers to the chart