### PR TITLE
Add support for servers not in k8s cluster

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -175,14 +175,30 @@ spec:
               # We are not installing server, take the host port which allows an external server to connect.
               hostPort: 8301
               {{- end }}
-              name: serflan
+              protocol: "TCP"
+              name: serflan-tcp
+            - containerPort: 8301
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8301
+              {{- end }}
+              protocol: "UDP"
+              name: serflan-udp
             - containerPort: 8302
               {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-              # We are not installing server, take the host port which allows an external server to connect.
               hostPort: 8302
               {{- end }}
-              name: serfwan
+              protocol: "TCP"
+              name: serfwan-tcp
+            - containerPort: 8302
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8302
+              {{- end }}
+              protocol: "UDP"
+              name: serfwan-udp
             - containerPort: 8300
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8300
+              {{- end }}
               name: server
             - containerPort: 8600
               name: dns-tcp

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -74,10 +74,18 @@ spec:
         - name: consul
           image: "{{ default .Values.global.image .Values.client.image }}"
           env:
-            - name: HOST_IP
+            - name: ADVERTISE_IP
               valueFrom:
                 fieldRef:
+                  {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+                  # If we are here the server is enabled, and the client is enabled, we can't both have 
+                  # the hostports 8301 and 8302.  If the user is doing client and server, then we just run on POD_IPs
+                  fieldPath: status.podIP
+                  {{- else }}
+                  # we are not going to be running a server on this cluster, so have the client listen on NodePorts
+                  # so that it can communicate bidirecationally with servers outside the cluster. 
                   fieldPath: status.hostIP
+                  {{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -102,7 +110,7 @@ spec:
 
               exec /bin/consul agent \
                 -node="${NODE}" \
-                -advertise="${HOST_IP}" \
+                -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
                 {{- if .Values.client.grpc }}
@@ -163,10 +171,16 @@ spec:
               hostPort: 8502
               name: grpc
             - containerPort: 8301
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              # We are not installing server, take the host port which allows an external server to connect.
               hostPort: 8301
+              {{- end }}
               name: serflan
             - containerPort: 8302
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              # We are not installing server, take the host port which allows an external server to connect.
               hostPort: 8302
+              {{- end }}
               name: serfwan
             - containerPort: 8300
               name: server

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -74,10 +74,10 @@ spec:
         - name: consul
           image: "{{ default .Values.global.image .Values.client.image }}"
           env:
-            - name: POD_IP
+            - name: HOST_IP
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP
+                  fieldPath: status.hostIP
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -102,7 +102,7 @@ spec:
 
               exec /bin/consul agent \
                 -node="${NODE}" \
-                -advertise="${POD_IP}" \
+                -advertise="${HOST_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
                 {{- if .Values.client.grpc }}
@@ -163,8 +163,10 @@ spec:
               hostPort: 8502
               name: grpc
             - containerPort: 8301
+              hostPort: 8301
               name: serflan
             - containerPort: 8302
+              hostPort: 8302
               name: serfwan
             - containerPort: 8300
               name: server

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -78,12 +78,12 @@ spec:
               valueFrom:
                 fieldRef:
                   {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-                  # If we are here the server is enabled, and the client is enabled, we can't both have 
-                  # the hostports 8301 and 8302.  If the user is doing client and server, then we just run on POD_IPs
+                  # The server is enabled, which we make the assumption that this is a contained environment and  
+                  # the pods do not need to be exposed, and need to run on Pod IP's to talk to the server (also on pod ips)
                   fieldPath: status.podIP
                   {{- else }}
                   # we are not going to be running a server on this cluster, so have the client listen on NodePorts
-                  # so that it can communicate bidirecationally with servers outside the cluster. 
+                  # so that it can communicate bidirectionally with servers outside the cluster. 
                   fieldPath: status.hostIP
                   {{- end }}
             - name: NAMESPACE

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -217,7 +217,7 @@ load _helpers
       --set 'client.extraVolumes[0].name=foo' \
       --set 'client.extraVolumes[0].load=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command | map(select(test("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].command | map(select(contains("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -497,6 +497,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'server.enabled=true' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
       tee /dev/stderr)
@@ -508,6 +509,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'server.enabled=false' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
       tee /dev/stderr)
@@ -519,6 +521,7 @@ load _helpers
   local object=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'server.enabled=false' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
       tee /dev/stderr)
@@ -526,7 +529,8 @@ load _helpers
   local actual=$(echo $object |
            yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
   [ "${actual}" = "8301" ]
-  local actual=$(echo $object | yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
+  local actual=$(echo $object |
+           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
   [ "${actual}" = "8302" ]
 
 }
@@ -535,6 +539,7 @@ load _helpers
   local object=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'server.enabled=true' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
       tee /dev/stderr)
@@ -543,7 +548,8 @@ load _helpers
            yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
   echo "${actual}"           
   [ "${actual}" = "null" ]
-  local actual=$(echo $object | yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
+  local actual=$(echo $object | 
+           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
   [ "${actual}" = "null" ]
 
 }


### PR DESCRIPTION
The consul client was formerly unable to communicate with a consul server cluster outside of k8s.  This change specifies that if a server is not going to be installed in k8s, the 8301 and 8302 ports are allocated on the host machine, which will allow the existing consul servers to connect to the k8s consul clients.