### PR TITLE
Ensure caBundle is set to string

### DIFF
--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -17,7 +17,7 @@ webhooks:
         name: {{ template "consul.fullname" . }}-connect-injector-svc
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
-      caBundle: {{ .Values.connectInject.certs.caBundle }}
+      caBundle: {{ .Values.connectInject.certs.caBundle | quote }}
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]


### PR DESCRIPTION
Without this change, we output:
```
      caBundle:
```
when `.Values.connectInject.certs.caBundle` is empty instead of
```
      caBundle: ""
```

I can't reproduce the issue (#213) however I'm guessing this may be the
cause if Kubernetes is treating this as null instead of the empty
string.

Might fix #213 