### PR TITLE
Support PriorityClass for sync-catalog

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -29,6 +29,11 @@ spec:
         "consul.hashicorp.com/connect-inject": "false"
     spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
+
+      {{- if .Values.syncCatalog.priorityClassName }}
+      priorityClassName: {{ .Values.syncCatalog.priorityClassName | quote }}
+      {{- end }}
+
       containers:
         - name: consul-sync-catalog
           image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -371,3 +371,27 @@ load _helpers
       yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# priorityClassName
+
+@test "syncCatalog/Deployment: priorityClassName is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "syncCatalog/Deployment: specified priorityClassName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.priorityClassName=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -265,7 +265,7 @@ client:
 # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configure-stub-domain-and-upstream-dns-servers
 dns:
   enabled: "-"
-  
+
   # Set a predefined cluster IP for the DNS service.
   # Useful if you need to reference the DNS service's IP
   # address in CoreDNS config.
@@ -371,6 +371,10 @@ syncCatalog:
 
   # Override the default interval to perform syncing operations creating Consul services.
   consulWriteInterval: null
+
+  # used to assign priority to syncCatalog pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:


### PR DESCRIPTION
This PR adds support for setting PriorityClass on sync-catalog pods.