### PR TITLE
Allow configuration of hostPorts on client daemonSet

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -157,10 +157,10 @@ spec:
                 - consul leave
           ports:
             - containerPort: 8500
-              hostPort: 8500
+              hostPort: {{ .Values.client.hostPort.http }}
               name: http
             - containerPort: 8502
-              hostPort: 8502
+              hostPort: {{ .Values.client.hostPort.grpc }}
               name: grpc
             - containerPort: 8301
               name: serflan

--- a/values.yaml
+++ b/values.yaml
@@ -167,7 +167,8 @@ client:
   image: null
   join: null
 
-  # Host ports uses by daemon set
+  # Host ports used by the client daemon set. These can be changed if one
+  # of the ports is already in use on one of the nodes.
   hostPort:
     http: 8500
     gprc: 8502

--- a/values.yaml
+++ b/values.yaml
@@ -167,6 +167,11 @@ client:
   image: null
   join: null
 
+  # Host ports uses by daemon set
+  hostPort:
+    http: 8500
+    gprc: 8502
+
   # grpc should be set to true if the gRPC listener should be enabled.
   # This should be set to true if connectInject or meshGateway is enabled.
   grpc: false

--- a/values.yaml
+++ b/values.yaml
@@ -171,7 +171,7 @@ client:
   # of the ports is already in use on one of the nodes.
   hostPort:
     http: 8500
-    gprc: 8502
+    grpc: 8502
 
   # grpc should be set to true if the gRPC listener should be enabled.
   # This should be set to true if connectInject or meshGateway is enabled.


### PR DESCRIPTION
Re-creation of #267 from new branch.

---

The `hostPort`s for the client daemonSet are hardcoded (ports 8500 and 8502).

This can cause a potential port conflict. While normally the defaults values are desirable, this PR allows you to modify these defaults.

To demonstrate this, you can deploy 2 Consul clusters, where the `hostPort`s are different, and don't conflict.

```
helm upgrade --install consul1 --namespace consul1 .
helm upgrade --install consul2 --namespace consul2 . --set client.hostPort.http=9500 --set client.hostPort.grpc=9502
```

Feel free to change names of values if not consistent.