### PR TITLE
Allow setting the -acl-auth-method flag

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -52,7 +52,9 @@ spec:
                 -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
                 {{ end -}}
                 -listen=:8080 \
-                {{- if .Values.global.bootstrapACLs }}
+                {{- if .Values.connectInject.overrideAuthMethodName }}
+                -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
+                {{ else if .Values.global.bootstrapACLs }}
                 -acl-auth-method="{{ .Release.Name }}-consul-k8s-auth-method" \
                 {{- end }}
                 {{- if .Values.connectInject.centralConfig.enabled }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -270,3 +270,50 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-default-protocol=\"grpc\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# authMethod
+
+@test "connectInject/Deployment: -acl-auth-method is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method="))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: -acl-auth-method is set when global.bootstrapACLs is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"release-name-consul-k8s-auth-method\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: -acl-auth-method is set to connectInject.overrideAuthMethodName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.overrideAuthMethodName=override' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"override\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: -acl-auth-method is overridden by connectInject.overrideAuthMethodName if global.bootstrapACLs is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'connectInject.overrideAuthMethodName=override' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"override\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -433,6 +433,10 @@ connectInject:
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
   aclBindingRuleSelector: "serviceaccount.name!=default"
 
+  # If not using global.bootstrapACLs and instead manually setting up an auth
+  # method for Connect inject, set this to the name of your auth method.
+  overrideAuthMethodName: ""
+
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
   centralConfig:
     enabled: false


### PR DESCRIPTION
For users that are setting up ACLs themselves (e.g. they have external
Consul servers so can't use bootstrapACLs) this allows them to create
their own Kubernetes auth method that the init container will use during
connect injection to receive an ACL token.

Fixes https://github.com/hashicorp/consul-k8s/issues/131