### PR TITLE
Prevent incorrect connectInject config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 BREAKING CHANGES
   * `client.grpc` defaults to `true` now instead of `false`. This is to make it
-     harder to misconfigure connect [[GH-282](https://github.com/hashicorp/consul-helm/pull/282)]
+     harder to misconfigure Connect [[GH-282](https://github.com/hashicorp/consul-helm/pull/282)]
      
-     If you wish to not have client grpc ports exposed, set `client.grpc` to
+     If you do not wish to enable gRPC for clients, set `client.grpc` to
      `false` in your local values file.
 
 ## 0.12.0 (Oct 28, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+BREAKING CHANGES
+  * `client.grpc` defaults to `true` now instead of `false`. This is to make it
+     harder to misconfigure connect [[GH-282](https://github.com/hashicorp/consul-helm/pull/282)]
+     
+     If you wish to not have client grpc ports exposed, set `client.grpc` to
+     `false` in your local values file.
+
 ## 0.12.0 (Oct 28, 2019)
 
 IMPROVEMENTS:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -1,5 +1,7 @@
 # The deployment for running the Connect sidecar injector
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
+{{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -90,23 +90,23 @@ load _helpers
 #--------------------------------------------------------------------
 # grpc
 
-@test "client/DaemonSet: grpc is disabled by default" {
+@test "client/DaemonSet: grpc is enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("grpc"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "client/DaemonSet: grpc can be enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/client-daemonset.yaml  \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("grpc"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: grpc can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.grpc=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("grpc"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/connect-inject-authmethod-clusterrole.bats
+++ b/test/unit/connect-inject-authmethod-clusterrole.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-clusterrole.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.bootstrapACLs=true' \
       . | tee /dev/stderr |

--- a/test/unit/connect-inject-authmethod-clusterrolebinding.bats
+++ b/test/unit/connect-inject-authmethod-clusterrolebinding.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.bootstrapACLs=true' \
       . | tee /dev/stderr |

--- a/test/unit/connect-inject-authmethod-serviceaccount.bats
+++ b/test/unit/connect-inject-authmethod-serviceaccount.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-serviceaccount.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.bootstrapACLs=true' \
       . | tee /dev/stderr |

--- a/test/unit/connect-inject-clusterrole.bats
+++ b/test/unit/connect-inject-clusterrole.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-clusterrole.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)

--- a/test/unit/connect-inject-clusterrolebinding.bats
+++ b/test/unit/connect-inject-clusterrolebinding.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-clusterrolebinding.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)

--- a/test/unit/connect-inject-mutatingwebhook.bats
+++ b/test/unit/connect-inject-mutatingwebhook.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-mutatingwebhook.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/connect-inject-service.bats
+++ b/test/unit/connect-inject-service.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-service.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/connect-inject-serviceaccount.bats
+++ b/test/unit/connect-inject-serviceaccount.bats
@@ -16,6 +16,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-serviceaccount.yaml  \
       --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)

--- a/values.yaml
+++ b/values.yaml
@@ -167,9 +167,9 @@ client:
   image: null
   join: null
 
-  # grpc should be set to true if the gRPC listener should be enabled.
+  # If true, Consul's gRPC port will be exposed (see https://www.consul.io/docs/agent/options.html#grpc_port).
   # This should be set to true if connectInject or meshGateway is enabled.
-  grpc: false
+  grpc: true
 
   # Resource requests, limits, etc. for the client cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
@@ -308,7 +308,8 @@ ui:
 # enabled then set the node selection so that it chooses a node with a
 # Consul agent.
 syncCatalog:
-  # True if you want to enable the catalog sync. "-" for default.
+  # True if you want to enable the catalog sync. Set to "-" to inherit from
+  # global.enabled.
   enabled: false
   image: null
   default: true # true will sync by default, otherwise requires annotation
@@ -374,6 +375,8 @@ syncCatalog:
 
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
+  # True if you want to enable connect injection. Set to "-" to inherit from
+  # global.enabled.
   enabled: false
   image: null # image for consul-k8s that contains the injector
   default: false # true will inject by default, otherwise requires annotation


### PR DESCRIPTION
Connect injection requires clients to be enabled and the gRPC port to be
enabled. These requirements are documented on the website although not
in the values.yaml itself. If users do not enable clients, their init
pods will fail. If users do not enable gRPC, their sidecars will be
reported as unhealthy. Both these outcomes are hard to debug.

This change makes it harder to get into this misconfiguration. It will
cause a helm error if clients or grpc are not enabled when connect is
enabled.

It also defaults client.grpc to true. There are no downsides to having
the grpc port open even if not using connect inject. This change means
enabling connect simply requires setting connectInject to true rather
than also setting client.grpc to true (something that's unintuitive and
easy to miss).

This is a breaking change, however any users that had connect enabled
but clients or gRPC not enabled would be running into errors so it's
not going to break anything for anyone that isn't already in a broken
state.

The error users would see if using inject but not clients:
```
$ helm template ./ --set client.enabled=false --set connectInject.enabled=true
Error: render error in "consul/templates/connect-inject-deployment.yaml": template: \
consul/templates/connect-inject-deployment.yaml:3:169: executing \
 "consul/templates/connect-inject-deployment.yaml" at \
<fail "clients must be enabled for connect injection">:\
 error calling fail: clients must be enabled for connect injection
```