### PR TITLE
Support external-to-k8s Consul servers

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -77,13 +77,11 @@ spec:
             - name: ADVERTISE_IP
               valueFrom:
                 fieldRef:
-                  {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-                  # The server is enabled, which we make the assumption that this is a contained environment and  
-                  # the pods do not need to be exposed, and need to run on Pod IP's to talk to the server (also on pod ips)
+                  {{- if not .Values.client.exposeGossipPorts }}
                   fieldPath: status.podIP
                   {{- else }}
-                  # we are not going to be running a server on this cluster, so have the client listen on NodePorts
-                  # so that it can communicate bidirectionally with servers outside the cluster. 
+                  # Clients will be exposed on their node's hostPort for external-to-k8s communication,
+                  # so they need to advertise their host ip instead of their pod ip.
                   fieldPath: status.hostIP
                   {{- end }}
             - name: NAMESPACE
@@ -171,34 +169,20 @@ spec:
               hostPort: 8502
               name: grpc
             - containerPort: 8301
-              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-              # We are not installing server, take the host port which allows an external server to connect.
+              {{- if .Values.client.exposeGossipPorts }}
               hostPort: 8301
               {{- end }}
               protocol: "TCP"
               name: serflan-tcp
             - containerPort: 8301
-              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              {{- if .Values.client.exposeGossipPorts }}
               hostPort: 8301
               {{- end }}
               protocol: "UDP"
               name: serflan-udp
             - containerPort: 8302
-              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-              hostPort: 8302
-              {{- end }}
-              protocol: "TCP"
-              name: serfwan-tcp
-            - containerPort: 8302
-              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-              hostPort: 8302
-              {{- end }}
-              protocol: "UDP"
-              name: serfwan-udp
+              name: serfwan
             - containerPort: 8300
-              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-              hostPort: 8300
-              {{- end }}
               name: server
             - containerPort: 8600
               name: dns-tcp

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -74,10 +74,18 @@ spec:
         - name: consul
           image: "{{ default .Values.global.image .Values.client.image }}"
           env:
-            - name: POD_IP
+            - name: ADVERTISE_IP
               valueFrom:
                 fieldRef:
+                  {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+                  # The server is enabled, which we make the assumption that this is a contained environment and  
+                  # the pods do not need to be exposed, and need to run on Pod IP's to talk to the server (also on pod ips)
                   fieldPath: status.podIP
+                  {{- else }}
+                  # we are not going to be running a server on this cluster, so have the client listen on NodePorts
+                  # so that it can communicate bidirectionally with servers outside the cluster. 
+                  fieldPath: status.hostIP
+                  {{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -102,7 +110,7 @@ spec:
 
               exec /bin/consul agent \
                 -node="${NODE}" \
-                -advertise="${POD_IP}" \
+                -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
                 {{- if .Values.client.grpc }}
@@ -163,10 +171,34 @@ spec:
               hostPort: 8502
               name: grpc
             - containerPort: 8301
-              name: serflan
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              # We are not installing server, take the host port which allows an external server to connect.
+              hostPort: 8301
+              {{- end }}
+              protocol: "TCP"
+              name: serflan-tcp
+            - containerPort: 8301
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8301
+              {{- end }}
+              protocol: "UDP"
+              name: serflan-udp
             - containerPort: 8302
-              name: serfwan
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8302
+              {{- end }}
+              protocol: "TCP"
+              name: serfwan-tcp
+            - containerPort: 8302
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8302
+              {{- end }}
+              protocol: "UDP"
+              name: serfwan-udp
             - containerPort: 8300
+              {{- if not (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+              hostPort: 8300
+              {{- end }}
               name: server
             - containerPort: 8600
               name: dns-tcp

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -217,7 +217,7 @@ load _helpers
       --set 'client.extraVolumes[0].name=foo' \
       --set 'client.extraVolumes[0].load=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command | map(select(test("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].command | map(select(contains("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 
@@ -490,4 +490,66 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: When Server is enabled, client uses podIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
+      tee /dev/stderr)
+  [ "${actual}" = "status.podIP" ]
+}
+
+@test "client/DaemonSet: When Server is not enabled, client uses hostIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'server.enabled=false' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
+      tee /dev/stderr)
+  [ "${actual}" = "status.hostIP" ]
+}
+
+@test "client/DaemonSet: When Server is not enabled, client uses hostport" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'server.enabled=false' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
+      tee /dev/stderr)
+
+  local actual=$(echo $object |
+           yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
+  [ "${actual}" = "8301" ]
+  local actual=$(echo $object |
+           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
+  [ "${actual}" = "8302" ]
+
+}
+@test "client/DaemonSet: When Server is enable, client doesnt use hostport" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
+      tee /dev/stderr)
+
+  local actual=$(echo $object |
+           yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
+  echo "${actual}"           
+  [ "${actual}" = "null" ]
+  local actual=$(echo $object | 
+           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
+  [ "${actual}" = "null" ]
+
 }

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -492,64 +492,53 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: When Server is enabled, client uses podIP" {
+#--------------------------------------------------------------------
+# client.exposeGossipPorts
+
+@test "client/DaemonSet: client uses podIP when client.exposeGossipPorts=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'server.enabled=true' \
       --set 'client.enabled=true' \
+      --set 'client.exposeGossipPorts=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
       tee /dev/stderr)
   [ "${actual}" = "status.podIP" ]
 }
 
-@test "client/DaemonSet: When Server is not enabled, client uses hostIP" {
+@test "client/DaemonSet: client uses hostIP when client.exposeGossipPorts=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'server.enabled=false' \
       --set 'client.enabled=true' \
+      --set 'client.exposeGossipPorts=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers | map(select(.name=="consul")) | .[0].env | map(select(.name=="ADVERTISE_IP")) | .[0] | .valueFrom.fieldRef.fieldPath'  |
       tee /dev/stderr)
   [ "${actual}" = "status.hostIP" ]
 }
 
-@test "client/DaemonSet: When Server is not enabled, client uses hostport" {
+@test "client/DaemonSet: client doesn't expose hostPorts when client.exposeGossipPorts=false" {
   cd `chart_dir`
-  local object=$(helm template \
-      -x templates/client-daemonset.yaml  \
-      --set 'server.enabled=false' \
-      --set 'client.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
-      tee /dev/stderr)
-
-  local actual=$(echo $object |
-           yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
-  [ "${actual}" = "8301" ]
-  local actual=$(echo $object |
-           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
-  [ "${actual}" = "8302" ]
-
-}
-@test "client/DaemonSet: When Server is enable, client doesnt use hostport" {
-  cd `chart_dir`
-  local object=$(helm template \
+  local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'server.enabled=true' \
       --set 'client.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports'  |
+      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports | map(select(.containerPort==8301)) | .[0].hostPort'  |
       tee /dev/stderr)
-
-  local actual=$(echo $object |
-           yq -r 'map(select(.containerPort==8301))| .[0].hostPort' | tee /dev/stderr  )
-  echo "${actual}"           
   [ "${actual}" = "null" ]
-  local actual=$(echo $object | 
-           yq -r 'map(select(.containerPort==8302))| .[0].hostPort' | tee /dev/stderr  )
-  [ "${actual}" = "null" ]
+}
 
+@test "client/DaemonSet: client exposes hostPorts when client.exposeGossipPorts=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.exposeGossipPorts=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers  | map(select(.name=="consul")) | .[0].ports | map(select(.containerPort==8301)) | .[0].hostPort'  |
+      tee /dev/stderr)
+  [ "${actual}" = "8301" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -171,6 +171,12 @@ client:
   # This should be set to true if connectInject or meshGateway is enabled.
   grpc: false
 
+  # exposeGossipPorts exposes the clients' gossip ports as hostPorts.
+  # This is only necessary if pod IPs in the k8s cluster are not directly
+  # routable and the Consul servers are outside of the k8s cluster. This
+  # also changes the clients' advertised IP to the hostIP rather than podIP.
+  exposeGossipPorts: false
+
   # Resource requests, limits, etc. for the client cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request


### PR DESCRIPTION
Allows Consul clients to expose their gossip ports as hostPorts. This allows them to connect to Consul servers that are external to Kubernetes in environments where pod ips are not directly accessible.

Builds on the work done in #256.