### PR TITLE
Do not run server-acl-init during server rollout

### DIFF
--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,5 +1,7 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
+{{- /* See reason for this in server-acl-init-job.yaml */ -}}
+{{- if eq (int .Values.server.updatePartition) 0 }}
 # This job deletes the server-acl-init job once it completes successfully.
 # It runs as a helm hook because it only needs to run when the server-acl-init
 # Job gets recreated which only happens during an install or upgrade.
@@ -49,5 +51,6 @@ spec:
             - delete-completed-job
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,5 +1,13 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.bootstrapACLs }}
+{{- /* We don't render this job when server.updatePartition > 0 because that
+    means a server rollout is in progress and this job won't complete unless
+    the rollout is finished (which won't happen until the partition is 0).
+    If we ran it in this case, then the job would not complete which would cause
+    the server-acl-init-cleanup hook to run indefinitely which would cause the
+    helm upgrade command to hang.
+*/ -}}
+{{- if eq (int .Values.server.updatePartition) 0 }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -64,5 +72,6 @@ spec:
                 -create-client-token=false \
                 {{- end }}
                 -expected-replicas={{ .Values.server.replicas }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -43,6 +43,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInitCleanup/Job: disabled when server.updatePartition > 0" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.updatePartition=1' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "serverACLInitCleanup/Job: consul-k8s delete-completed-job is called with correct arguments" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -43,6 +43,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/Job: disabled when server.updatePartition > 0" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'server.updatePartition=1' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "serverACLInit/Job: does not set -create-client-token=false when client is enabled (the default)" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
Prior to this change, running helm upgrade with server.updatePartition >
0 and global.bootstrapACLs=true would cause the command to hang
indefinitely.

It would hang because it waited for the server-acl-init-cleanup hook to
complete. This hook would not complete until the server-acl-init job
finished. This job would not finish because it waits until the server
rollout is complete. The server rollout would not complete because the
updatePartition causes one server at a time to roll out.

In order for the server rollout to complete, the user needs to wait for
the first server to be upgraded, then they need to decrease the
updatePartition by one and then run helm upgrade again and repeat until
all the servers are upgraded.

In order to fix this, this change causes the server-acl-init job to only
run when the updatePartition is 0. This means during a server rollout,
i.e. updatePartition > 0, the job won't run and so the cleanup hook will
exit immediately and the helm upgrade command will exit cleanly.

Once the last server is ready to be upgraded, the updatePartition will
be set to 0. When helm upgrade runs, the server-acl-init Job will be
rendered but it will be able to complete successfully once that final
server comes up because the rollout will be complete.

It's worth noting that the reason we run server-acl-init during helm
upgrade is to help in the case when users have enabled a new feature,
for example mesh gateways, and need acl tokens for that feature.

Fixes #274