### PR TITLE
Default centralConfig to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+IMPROVEMENTS:
+
+  * `connectInject.centralConfig` defaults to `true` now instead of `false`. This is to make it
+     easier to configure Connect via `service-defaults` and other routing
+     config [[GH-302](https://github.com/hashicorp/consul-helm/pull/302)].
+     See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+
+     If you wish to disable central config, set `connectInject.centralConfig` to
+     false in your local values file. NOTE: If `connectInject.enabled` is false,
+     then central config is not enabled so this change will not affect you. 
+
 ## 0.14.0 (Dec 10, 2019)
 
 IMPROVEMENTS:

--- a/test/unit/client-configmap.bats
+++ b/test/unit/client-configmap.bats
@@ -55,23 +55,23 @@ load _helpers
 #--------------------------------------------------------------------
 # connectInject.centralConfig
 
-@test "client/ConfigMap: centralConfig is disabled by default" {
+@test "client/ConfigMap: centralConfig is enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "client/ConfigMap: centralConfig can be enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/client-config-configmap.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       . | tee /dev/stderr |
       yq '.data["central-config.json"] | contains("enable_central_service_config")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "client/ConfigMap: centralConfig can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -270,25 +270,25 @@ load _helpers
 #--------------------------------------------------------------------
 # centralConfig
 
-@test "connectInject/Deployment: centralConfig is disabled by default" {
+@test "connectInject/Deployment: centralConfig is enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-enable-central-config"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "connectInject/Deployment: centralConfig can be enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-enable-central-config"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: centralConfig can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-central-config"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "connectInject/Deployment: defaultProtocol is disabled by default with centralConfig enabled" {

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -43,8 +43,7 @@ load _helpers
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'client.grpc=false' \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' .
+      --set 'connectInject.enabled=true' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "client.grpc must be true" ]]
 }
@@ -56,7 +55,6 @@ load _helpers
       --set 'meshGateway.enabled=true' \
       --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'global.enabled=false' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "clients must be enabled" ]]
@@ -69,7 +67,6 @@ load _helpers
       --set 'meshGateway.enabled=true' \
       --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'global.enabled=true' \
       --set 'client.enabled=false' .
   [ "$status" -eq 1 ]

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -68,25 +68,25 @@ load _helpers
 #--------------------------------------------------------------------
 # connectInject.centralConfig
 
-@test "server/ConfigMap: centralConfig is disabled by default" {
+@test "server/ConfigMap: centralConfig is enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "server/ConfigMap: centralConfig can be enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-config-configmap.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       . | tee /dev/stderr |
       yq '.data["central-config.json"] | contains("enable_central_service_config")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "server/ConfigMap: centralConfig can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.centralConfig.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "server/ConfigMap: proxyDefaults disabled by default" {
@@ -94,7 +94,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       . | tee /dev/stderr |
       yq '.data["proxy-defaults-config.json"] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -105,7 +104,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq '.data["proxy-defaults-config.json"] | match("world") | length' | tee /dev/stderr)
@@ -117,7 +115,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=remote' \
@@ -132,7 +129,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=' \
@@ -147,7 +143,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=null' \
@@ -162,7 +157,6 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.centralConfig.enabled=true' \
       --set 'connectInject.centralConfig.proxyDefaults=""' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=remote' \

--- a/values.yaml
+++ b/values.yaml
@@ -504,6 +504,9 @@ connectInject:
     # proxyDefaults is a raw json string that will be written as the value of
     # the "config" key of the global proxy-defaults config entry.
     # See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
+    # NOTE: Changes to this value after the chart is first installed have *no*
+    # effect. In order to change the proxy-defaults config after installation,
+    # you must use the Consul API.
     proxyDefaults: |
       {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -493,6 +493,10 @@ connectInject:
 
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
   centralConfig:
+    # enabled controls whether central config is enabled on all servers and clients.
+    # See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+    # If changing this after installation, servers and clients must be restarted
+    # for the change to take effect.
     enabled: true
 
     # defaultProtocol allows you to specify a convenience default protocol if

--- a/values.yaml
+++ b/values.yaml
@@ -493,18 +493,17 @@ connectInject:
 
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
   centralConfig:
-    enabled: false
+    enabled: true
 
     # defaultProtocol allows you to specify a convenience default protocol if
     # most of your services are of the same protocol type. The individual annotation
-    # on any given pod will override this value. A protocol must be provided,
-    # either through this setting or individual annotation, for a service to be
-    # registered correctly. Valid values are "http", "http2", "grpc" and "tcp".
+    # on any given pod will override this value.
+    # Valid values are "http", "http2", "grpc" and "tcp".
     defaultProtocol: null
 
-    # proxyDefaults is a raw json string that will be applied to all Connect
-    # proxy sidecar pods that can include any valid configuration for the
-    # configured proxy.
+    # proxyDefaults is a raw json string that will be written as the value of
+    # the "config" key of the global proxy-defaults config entry.
+    # See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
     proxyDefaults: |
       {}
 


### PR DESCRIPTION
This change will only affect users who have enabled connectInject
because we only enable central config if connectInject.enabled is true.
Users that are using connectInject are more likely than not going to
want to create L7 rules and service-defaults configs because that is
where most of the value of Consul Connect lies. Thus enabling this by
default makes sense.