### PR TITLE
Support global.name

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,12 +1,14 @@
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to
-this (by the DNS naming spec). If release name contains chart name it will
-be used as a full name.
+this (by the DNS naming spec). Supports the legacy fullnameOverride setting
+as well as the global.name setting.
 */}}
 {{- define "consul.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.global.name -}}
+{{- .Values.global.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .Release.Name }}-consul-client-acl-token
+      - {{ template "consul.fullname" . }}-client-acl-token
     verbs:
       - get
 {{- end }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -228,7 +228,7 @@ spec:
           - "-ec"
           - |
             consul-k8s acl-init \
-              -secret-name="{{ .Release.Name }}-consul-client-acl-token" \
+              -secret-name="{{ template "consul.fullname" . }}-client-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="client"
         volumeMounts:

--- a/templates/client-snapshot-agent-clusterrole.yaml
+++ b/templates/client-snapshot-agent-clusterrole.yaml
@@ -27,7 +27,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .Release.Name }}-consul-client-snapshot-agent-acl-token
+      - {{ template "consul.fullname" . }}-client-snapshot-agent-acl-token
     verbs:
       - get
 {{- end }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Release.Name }}-consul-client-snapshot-agent-acl-token"
+                  name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
             {{- end}}
           command:
@@ -101,7 +101,7 @@ spec:
           - "-ec"
           - |
             consul-k8s acl-init \
-              -secret-name="{{ .Release.Name }}-consul-client-snapshot-agent-acl-token" \
+              -secret-name="{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="sync"
         volumeMounts:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
                 {{ else if .Values.global.bootstrapACLs }}
-                -acl-auth-method="{{ .Release.Name }}-consul-k8s-auth-method" \
+                -acl-auth-method="{{ template "consul.fullname" . }}-k8s-auth-method" \
                 {{- end }}
                 {{- if .Values.connectInject.centralConfig.enabled }}
                 -enable-central-config=true \

--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .Release.Name }}-consul-enterprise-license-acl-token
+      - {{ template "consul.fullname" . }}-enterprise-license-acl-token
     verbs:
       - get
 {{- end }}

--- a/templates/enterprise-license.yaml
+++ b/templates/enterprise-license.yaml
@@ -48,7 +48,7 @@ spec:
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Release.Name }}-consul-enterprise-license-acl-token"
+                  name: "{{ template "consul.fullname" . }}-enterprise-license-acl-token"
                   key: "token"
             {{- end}}
           command: 
@@ -65,7 +65,7 @@ spec:
           - "-ec"
           - |
             consul-k8s acl-init \
-              -secret-name="{{ .Release.Name }}-consul-enterprise-license-acl-token" \
+              -secret-name="{{ template "consul.fullname" . }}-enterprise-license-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="sync"
       {{- end }}

--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -24,7 +24,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .Release.Name }}-consul-mesh-gateway-acl-token
+      - {{ template "consul.fullname" . }}-mesh-gateway-acl-token
     verbs:
       - get
 {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - "-ec"
             - |
               consul-k8s acl-init \
-                -secret-name="{{ .Release.Name }}-consul-mesh-gateway-acl-token" \
+                -secret-name="{{ template "consul.fullname" . }}-mesh-gateway-acl-token" \
                 -k8s-namespace={{ .Release.Namespace }} \
                 -init-type="sync"
         {{- end }}
@@ -111,7 +111,7 @@ spec:
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Release.Name }}-consul-mesh-gateway-acl-token"
+                  name: "{{ template "consul.fullname" . }}-mesh-gateway-acl-token"
                   key: "token"
             {{- end}}
           command:

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -45,7 +45,8 @@ spec:
             - "-ec"
             - |
               consul-k8s server-acl-init \
-                -release-name={{ .Release.Name }} \
+                -server-label-selector=component=server,app={{ template "consul.name" . }},release={{ .Release.Name }} \
+                -resource-prefix={{ template "consul.fullname" . }} \
                 -k8s-namespace={{ .Release.Namespace }} \
                 {{- if .Values.syncCatalog.enabled }}
                 -create-sync-token=true \

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: server
 spec:
   serviceName: {{ template "consul.fullname" . }}-server
   podManagementPolicy: Parallel

--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -34,7 +34,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .Release.Name }}-consul-catalog-sync-acl-token
+      - {{ template "consul.fullname" . }}-catalog-sync-acl-token
     verbs:
       - get
 {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Release.Name }}-consul-catalog-sync-acl-token"
+                  name: "{{ template "consul.fullname" . }}-catalog-sync-acl-token"
                   key: "token"
             {{- end}}
           command:
@@ -126,7 +126,7 @@ spec:
           - "-ec"
           - |
             consul-k8s acl-init \
-              -secret-name="{{ .Release.Name }}-consul-catalog-sync-acl-token" \
+              -secret-name="{{ template "consul.fullname" . }}-catalog-sync-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="sync"
       {{- end }}

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# This file tests the helpers in _helpers.tpl.
+
+load _helpers
+
+#--------------------------------------------------------------------
+# consul.fullname
+# These tests use test-runner.yaml to test the consul.fullname helper
+# since we need an existing template that calls the consul.fullname helper.
+
+@test "helper/consul.fullname: defaults to release-name-consul" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-test" ]
+}
+
+@test "helper/consul.fullname: fullnameOverride overrides the name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set fullnameOverride=override \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "override-test" ]
+}
+
+@test "helper/consul.fullname: fullnameOverride is truncated to 63 chars" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set fullnameOverride=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk-test" ]
+}
+
+@test "helper/consul.fullname: fullnameOverride has trailing '-' trimmed" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set fullnameOverride=override- \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "override-test" ]
+}
+
+@test "helper/consul.fullname: global.name overrides the name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set global.name=override \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "override-test" ]
+}
+
+@test "helper/consul.fullname: global.name is truncated to 63 chars" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set global.name=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk-test" ]
+}
+
+@test "helper/consul.fullname: global.name has trailing '-' trimmed" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set global.name=override- \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "override-test" ]
+}
+
+@test "helper/consul.fullname: nameOverride is supported" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml \
+      --set nameOverride=override \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-override-test" ]
+}
+
+# This test ensures that we use {{ template "consul.fullname" }} everywhere instead of
+# {{ .Release.Name }} because that's required in order to support the name
+# override settings fullnameOverride and global.name. In some cases, we need to
+# use .Release.Name. In those cases, add your exception to this list.
+#
+# If this test fails, you're likely using {{ .Release.Name }} where you should
+# be using {{ template "consul.fullname" }}
+@test "helper/consul.fullname: used everywhere" {
+  cd `chart_dir`
+  # Grep for uses of .Release.Name that aren't using it as a label.
+  local actual=$(grep -r '{{ .Release.Name }}' templates/*.yaml | grep -v 'release: ' | tee /dev/stderr )
+  [ "${actual}" = 'templates/server-acl-init-job.yaml:                -server-label-selector=component=server,app={{ template "consul.name" . }},release={{ .Release.Name }} \' ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ global:
   # Note: support for the catalog sync's liveness and readiness probes was added
   # to consul-k8s 0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
-  # If using mesh gateways and bootstrapACLs then must be >= 0.9.0.
+  # If using bootstrapACLs then must be >= 0.10.1.
   imageK8S: "hashicorp/consul-k8s:0.9.5"
 
   # datacenter is the name of the datacenter that the agents should register
@@ -73,7 +73,7 @@ global:
 
   # bootstrapACLs will automatically create and assign ACL tokens within
   # the Consul cluster. This requires servers to be running inside Kubernetes.
-  # Additionally requires Consul >= 1.4 and consul-k8s >= 0.8.0.
+  # Additionally requires Consul >= 1.4 and consul-k8s >= 0.10.1.
   bootstrapACLs: false
 
 # Server, when enabled, configures a server cluster to run. This should

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,10 @@ global:
   # opt-in is required, such as by setting `server.enabled` to true.
   enabled: true
 
+  # name sets the prefix used for all resources in the helm chart.
+  # If not set, the prefix will be "<helm release name>-consul".
+  name: null
+
   # domain is the domain Consul will answer DNS queries for
   # (see https://www.consul.io/docs/agent/options.html#_domain) and the domain
   # services synced from Consul into Kubernetes will have,


### PR DESCRIPTION
There was a previously undocumented setting `fullnameOverride` that
would allow controlling the prefix added to each resource. There were
some places where this wasn't being used. Specifically in our
clusterrole's and when running server-acl-init.

This change fixes those locations and utilizes a new flag in
server-acl-init that will respect the override.

It also adds a new value: `global.name` and documents this
value. This value is the same as the `fullnameOverride` value, but it
lives under the global key which fits with the rest of our config
management philosophy (i.e. config that affects the whole chart lives
under the global key).

* Fixes https://github.com/hashicorp/consul-helm/issues/286
* Corresponding consul-k8s PR: https://github.com/hashicorp/consul-k8s/pull/174