### PR TITLE
Add -consul-k8s-image flag to injector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 IMPROVEMENTS:
 
+  * Use latest version of consul-k8s ([0.10.1](https://github.com/hashicorp/consul-k8s/blob/master/CHANGELOG.md#0101-december-17-2019)).
+    This version fixes a Connect [bug](https://github.com/hashicorp/consul-k8s/issues/161)
+    where service instances on a node would be deregistered when the Consul
+    client pod for that node restarted.
+
+
+BREAKING CHANGES:
+
   * `connectInject.centralConfig` defaults to `true` now instead of `false`. This is to make it
      easier to configure Connect via `service-defaults` and other routing
      config [[GH-302](https://github.com/hashicorp/consul-helm/pull/302)].
@@ -10,6 +18,10 @@ IMPROVEMENTS:
      If you wish to disable central config, set `connectInject.centralConfig` to
      false in your local values file. NOTE: If `connectInject.enabled` is false,
      then central config is not enabled so this change will not affect you. 
+  
+  * Connect Inject: If using Connect Inject, you must also upgrade your `consul-k8s` version
+    to a version >= 0.10.1. A new flag is being passed in to `consul-k8s` which is not
+    supported in earlier versions.
 
 ## 0.14.0 (Dec 10, 2019)
 
@@ -21,6 +33,7 @@ IMPROVEMENTS:
     e.g. during a Consul version upgrade, it does not lose its Connect service
     registrations. In the next version, we plan to have services automatically
     re-register which will remove the need for this. [[GH-298](https://github.com/hashicorp/consul-helm/pull/298)]
+    (**Update:** 0.15.0 uses a version of consul-k8s that fixes this bug and so hostPath is longer necessary)
     
     **Security Warning:** If using this setting, Pod Security Policies *must* be enabled on your cluster
      and in this Helm chart (via the `global.enablePodSecurityPolicies` setting)

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -55,10 +55,6 @@ spec:
       dnsPolicy: {{ .Values.client.dnsPolicy }}
       {{- end }}
 
-      # Consul clients require a directory for data.
-      # We use a hostPath so that if a Pod is restarted it will retain its
-      # service and checks registrations. This is important for Consul Connect
-      # because each Connect Pod registers with the local Consul client.
       volumes:
         - name: data
         {{- if .Values.client.dataDirectoryHostPath }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -53,6 +53,7 @@ spec:
                 {{ if .Values.connectInject.imageEnvoy -}}
                 -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
                 {{ end -}}
+                -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -listen=:8080 \
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \

--- a/values.yaml
+++ b/values.yaml
@@ -39,7 +39,8 @@ global:
   # to consul-k8s 0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
   # If using bootstrapACLs then must be >= 0.10.1.
-  imageK8S: "hashicorp/consul-k8s:0.9.5"
+  # If using connect inject then must be >= 0.10.1.
+  imageK8S: "hashicorp/consul-k8s:0.10.1"
 
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
@@ -446,6 +447,7 @@ syncCatalog:
 connectInject:
   # True if you want to enable connect injection. Set to "-" to inherit from
   # global.enabled.
+  # Requires consul-k8s >= 0.10.1.
   enabled: false
   image: null # image for consul-k8s that contains the injector
   default: false # true will inject by default, otherwise requires annotation

--- a/values.yaml
+++ b/values.yaml
@@ -196,10 +196,6 @@ client:
   # to use as the Consul client data directory.
   # If set to the empty string or null, the Consul agent will store its data
   # in the Pod's local filesystem (which will be lost if the Pod is deleted).
-  # If using Consul Connect, this directory must be set. Otherwise when the Consul
-  # agent Pod is deleted, e.g. during an upgrade, all the Connect-injected Pods
-  # on that node will be de-registered and will need to be restarted to be
-  # re-registered.
   # Security Warning: If setting this, Pod Security Policies *must* be enabled on your cluster
   # and in this Helm chart (via the global.enablePodSecurityPolicies setting)
   # to prevent other Pods from mounting the same host path and gaining


### PR DESCRIPTION
Supports new required flag for https://github.com/hashicorp/consul-k8s/pull/176

This will require the latest version of consul-k8s. If users are using connectInject and try to upgrade their chart without upgrading the consul-k8s version then their injector deployment will fail because they'll be setting the `-consul-k8s-image` which doesn't exist in their version.

In this case, I think that's okay because we really do want users to upgrade their consul-k8s version since the latest fixes an important bug.

Assumes we're going to release consul-k8s 0.10.0.