### PR TITLE
Add pod name as metadata to client nodes

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -126,6 +126,7 @@ spec:
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
+                -node-meta=pod-name:${HOSTNAME} \
                 {{- if .Values.client.grpc }}
                 -hcl="ports { grpc = 8502 }" \
                 {{- end }}


### PR DESCRIPTION
This will help users map the nodes in Consul to the underlying client pods