### PR TITLE
Add namespace support to the connect injector

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -41,6 +41,35 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- /* An ACL token is only necessary for the connect injector if namespaces are enabled */}}
+            {{- if .Values.global.consulNamespacesEnabled }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- if (and .Values.connectInject.aclInjectToken.secretName .Values.connectInject.aclInjectToken.secretKey) }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.connectInject.aclInjectToken.secretName }}
+                  key: {{ .Values.connectInject.aclInjectToken.secretKey }}
+            {{- else if .Values.global.bootstrapACLs }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "consul.fullname" . }}-connect-injector-acl-token"
+                  key: "token"
+            {{- end }}
+            {{- if .Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+            {{- end }}
           command:
             - "/bin/sh"
             - "-ec"
@@ -68,6 +97,24 @@ spec:
                 {{- end }}
                 {{- if (and .Values.connectInject.centralConfig.enabled .Values.connectInject.centralConfig.defaultProtocol) }}
                 -default-protocol="{{ .Values.connectInject.centralConfig.defaultProtocol }}" \
+                {{- end }}
+                {{- range $value := .Values.connectInject.k8sAllowNamespaces }}
+                -allow-namespace="{{ $value }}" \
+                {{- end }}
+                {{- range $value := .Values.connectInject.k8sDenyNamespaces }}
+                -deny-namespace="{{ $value }}" \
+                {{- end }}
+                {{- if .Values.global.consulNamespacesEnabled }}
+                -enable-namespaces=true \
+                {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+                -consul-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \
+                {{- end }}
+                {{- if .Values.connectInject.consulNamespaces.mirrorK8S }}
+                -enable-namespace-mirroring=true \
+                {{- if .Values.connectInject.consulNamespaces.mirroringPrefix }}
+                -mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringPrefix }} \
+                {{- end }}
+                {{- end }}
                 {{- end }}
                 {{- if .Values.connectInject.certs.secretName }}
                 -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
@@ -121,6 +168,19 @@ spec:
           secret:
             secretName: {{ template "consul.fullname" . }}-ca-cert
         {{- end }}
+      {{- end }}
+      {{- if and .Values.global.bootstrapACLs .Values.global.consulNamespacesEnabled }}
+      initContainers:
+      - name: injector-acl-init
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s acl-init \
+              -secret-name="{{ template "consul.fullname" . }}-connect-inject-acl-token" \
+              -k8s-namespace={{ .Release.Namespace }} \
+              -init-type="sync"
       {{- end }}
       {{- if .Values.connectInject.nodeSelector }}
       nodeSelector:

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -28,6 +28,8 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: license
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-enterprise-license

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -409,3 +409,319 @@ load _helpers
       yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
   [ "${actual}" = "2" ]
 }
+
+#--------------------------------------------------------------------
+# k8sAllowNamespaces & k8sDenyNamespaces
+
+@test "connectInject/Deployment: default is allow `*`, deny nothing" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'map(select(test("allow-namespace"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("allow-namespace=\"*\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'map(select(test("deny-namespace"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
+
+@test "connectInject/Deployment: can set allow and deny" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.k8sAllowNamespaces[0]=allowNamespace' \
+      --set 'connectInject.k8sDenyNamespaces[0]=denyNamespace' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'map(select(test("allow-namespace"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(echo $object |
+    yq 'map(select(test("deny-namespace"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("allow-namespace=\"allowNamespace\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("deny-namespace=\"denyNamespace\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces
+
+@test "connectInject/Deployment: namespace options disabled by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespaces"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("consul-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespace-mirroring"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("mirroring-prefix"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: namespace options set with .global.consulNamespacesEnabled=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespaces=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("consul-namespace=default"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespace-mirroring"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("mirroring-prefix"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: mirroring options set with .connectInject.consulNamespaces.mirrorK8S=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'connectInject.consulNamespaces.mirrorK8S=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespaces=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("consul-namespace=default"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespace-mirroring=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("mirroring-prefix"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: prefix can be set with .connectInject.consulNamespaces.mirroringPrefix" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'connectInject.consulNamespaces.mirrorK8S=true' \
+      --set 'connectInject.consulNamespaces.mirroringPrefix=k8s-' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespaces=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("consul-namespace=default"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("enable-namespace-mirroring=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("mirroring-prefix=k8s-"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces + acl token
+
+@test "connectInject/Deployment: aclInjectToken disabled when namespaces not enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.aclInjectToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: aclInjectToken disabled when secretName is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.aclInjectToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: aclInjectToken disabled when secretKey is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.aclInjectToken.secretName=foo' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: aclInjectToken enabled when secretName and secretKey is provided" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.aclInjectToken.secretName=foo' \
+      --set 'connectInject.aclInjectToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'map(select(test("CONSUL_HTTP_TOKEN"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces + global.bootstrapACLs
+
+@test "connectInject/Deployment: CONSUL_HTTP_TOKEN env variable created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] ' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'map(select(test("CONSUL_HTTP_TOKEN"))) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "connectInject/Deployment: init container is created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "injector-acl-init" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces + http address
+
+@test "connectInject/Deployment: CONSUL_HTTP_ADDR env variable set when namespaces are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_ADDR"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: CONSUL_HTTP_ADDR and CONSUL_CACERT env variables set when namespaces are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] ' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'any(contains("CONSUL_HTTP_ADDR"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'any(contains("CONSUL_CACERT"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces + host ip
+
+@test "connectInject/Deployment: HOST_IP env variable not set when namespaces are disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("HOST_IP"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: HOST_IP env variable set when namespaces are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.consulNamespacesEnabled=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("HOST_IP"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -40,6 +40,7 @@ global:
   # remove these checks to make the sync work.
   # If using bootstrapACLs then must be >= 0.10.1.
   # If using connect inject then must be >= 0.10.1.
+  # If using Consul namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.11.0"
 
   # datacenter is the name of the datacenter that the agents should register
@@ -110,6 +111,14 @@ global:
     # If httpsOnly is true, Consul will disable the HTTP port on both
     # clients and servers and only accept HTTPS connections.
     httpsOnly: true
+
+  # [Enterprise Only] consulNamespacesEnabled indicates that you are running
+  # Consul v1.7+ with a valid Consul Enterprise license and would like to make
+  # use of configuration beyond registering everything into the `default` Consul
+  # namespace. Requires consul-k8s v0.12+.
+  # Additional configuration options are found in the `consulNamespaces` section
+  # of both the catalog sync and connect injector.
+  consulNamespacesEnabled: false
 
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
@@ -499,6 +508,54 @@ connectInject:
   #     namespace-label: label-value
   namespaceSelector: null
 
+  # k8sAllowNamespaces is a list of k8s namespaces to allow Connect sidecar
+  # injection in. If a k8s namespace is not included or is listed in `k8sDenyNamespaces`,
+  # pods in that k8s namespace will not be injected even if they are explicitly
+  # annotated. Use ["*"] to automatically allow all k8s namespaces.
+  #
+  # For example, ["namespace1", "namespace2"] will only allow pods in the k8s
+  # namespaces `namespace1` and `namespace2` to have Connect sidecars injected
+  # and registered with Consul. All other k8s namespaces will be ignored.
+  # Note: `k8sDenyNamespaces` takes precedence over values defined here and
+  # `namespaceSelector` takes precedence over both since it is applied first.
+  # `kube-system` and `kube-public` are never injected, even if included here.
+  # Requires consul-k8s v0.12+
+  k8sAllowNamespaces: ["*"]
+
+  # k8sDenyNamespaces is a list of k8s namespaces that should not allow Connect
+  # sidecar injection. This list takes precedence over `k8sAllowNamespaces`.
+  # `*` is not supported because then nothing would be allowed to be injected.
+  #
+  # For example, if `k8sAllowNamespaces is `["*"]` and k8sDenyNamespaces is
+  # `["namespace1", "namespace2"]`, then all k8s namespaces besides "namespace1"
+  # and "namespace2" will be injected.
+  # Note: `namespaceSelector` takes precedence over this since it is applied first.
+  # `kube-system` and `kube-public` are never injected.
+  # Requires consul-k8s v0.12+.
+  k8sDenyNamespaces: []
+
+  # [Enterprise Only] These settings manage the connect injector's interaction with
+  # Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+  # Also, `global.consulNamespacesEnabled` must be true.
+  consulNamespaces:
+    # consulDestinationNamespace is the name of the Consul namespace to register all
+    # k8s services into. If the Consul namespace does not already exist,
+    # it will be created. This will be ignored if `mirrorK8S` is true.
+    consulDestinationNamespace: "default"
+
+    # mirrorK8S causes k8s services to be registered into a Consul namespace
+    # of the same name as their k8s namespace, optionally prefixed if
+    # `mirroringPrefix` is set below. If the Consul namespace does not
+    # already exist, it will be created. Turning this on overrides the
+    # `consulDestinationNamespace` setting.
+    mirrorK8S: false
+
+    # If `mirrorK8S` is set to true, `mirroringPrefix` allows each Consul namespace
+    # to be given a prefix. For example, if `mirroringPrefix` is set to "k8s-", a
+    # service in the k8s `staging` namespace will be registered into the
+    # `k8s-staging` Consul namespace.
+    mirroringPrefix: ""
+
   # The certs section configures how the webhook TLS certs are configured.
   # These are the TLS certs for the Kube apiserver communicating to the
   # webhook. By default, the injector will generate and manage its own certs,
@@ -546,6 +603,15 @@ connectInject:
   # If not using global.bootstrapACLs and instead manually setting up an auth
   # method for Connect inject, set this to the name of your auth method.
   overrideAuthMethodName: ""
+
+  # aclInjectToken refers to a Kubernetes secret that you have created that contains
+  # an ACL token for your Consul cluster which allows the Connect injector the correct
+  # permissions. This is only needed if Consul namespaces and ACLs are enabled on the
+  # Consul cluster and you are not setting `global.bootstrapACLs` to `true`.
+  # This token needs to have `operator = "write"` privileges.
+  aclInjectToken:
+    secretName: null
+    secretKey: null
 
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
   centralConfig:


### PR DESCRIPTION
Add the global namespace variables but only pipes them through the
connect injector. Adds connect injector allow/deny namespace lists.
Adds an ACL token for the connect injector that is necessary for
it to create namespaces/binding rules.