### PR TITLE
Enterprise License Job PodSecurityPolicy

### DIFF
--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -41,7 +41,6 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    # Require the container to run without root privileges.
     rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'

--- a/templates/client-snapshot-agent-podsecuritypolicy.yaml
+++ b/templates/client-snapshot-agent-podsecuritypolicy.yaml
@@ -28,7 +28,6 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    # Require the container to run without root privileges.
     rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'

--- a/templates/connect-inject-podsecuritypolicy.yaml
+++ b/templates/connect-inject-podsecuritypolicy.yaml
@@ -27,7 +27,6 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    # Require the container to run without root privileges.
     rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'

--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -1,6 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -11,7 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
 rules:
+{{- if .Values.global.bootstrapACLs }}
   - apiGroups: [""]
     resources:
       - secrets
@@ -20,6 +20,16 @@ rules:
     verbs:
       - get
 {{- end }}
+{{- if .Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      - {{ template "consul.fullname" . }}-enterprise-license
+    verbs:
+      - use
+{{- end }}
+{{- else }}
+rules: []
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license-clusterrolebinding.yaml
+++ b/templates/enterprise-license-clusterrolebinding.yaml
@@ -1,6 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -19,7 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-enterprise-license
     namespace: {{ .Release.Namespace }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -30,9 +30,7 @@ spec:
         component: license
     spec:
       restartPolicy: Never
-      {{- if .Values.global.bootstrapACLs }}
       serviceAccountName: {{ template "consul.fullname" . }}-enterprise-license
-      {{- end }}
       containers:
         - name: apply-enterprise-license
           image: "{{ default .Values.global.image .Values.server.image }}"

--- a/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/templates/enterprise-license-podsecuritypolicy.yaml
@@ -1,0 +1,37 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+{{- if .Values.global.enablePodSecurityPolicies }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-enterprise-license
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  privileged: false
+  # Allow core volume types.
+  volumes:
+    - 'secret'
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -1,6 +1,4 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
 apiVersion: v1
 kind: ServiceAccount
@@ -12,7 +10,5 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -28,7 +28,6 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    # Require the container to run without root privileges.
     rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'

--- a/templates/sync-catalog-podsecuritypolicy.yaml
+++ b/templates/sync-catalog-podsecuritypolicy.yaml
@@ -27,7 +27,6 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    # Require the container to run without root privileges.
     rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'

--- a/test/unit/enterprise-license-clusterrolebinding.bats
+++ b/test/unit/enterprise-license-clusterrolebinding.bats
@@ -11,35 +11,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: disabled with global.bootstrapACLs=true" {
+@test "enterpriseLicense/ClusterRoleBinding: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "enterpriseLicense/ClusterRoleBinding: disabled with server=false, global.bootstrapACLs=true, ent secret defined" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "enterpriseLicense/ClusterRoleBinding: disabled with client=false, global.bootstrapACLs=true, ent secret defined" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'client.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
@@ -51,7 +27,6 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -62,18 +37,16 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: can be enabled" {
+@test "enterpriseLicense/ClusterRoleBinding: enabled when ent license defined" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |

--- a/test/unit/enterprise-license-job.bats
+++ b/test/unit/enterprise-license-job.bats
@@ -87,26 +87,3 @@ load _helpers
       yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
-
-@test "server/EnterpriseLicense: no service account specified when global.bootstrapACLS=false" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}
-
-@test "server/EnterpriseLicense: service account specified when global.bootstrapACLS=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.serviceAccountName | contains("consul-enterprise-license")' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}

--- a/test/unit/enterprise-license-podsecuritypolicy.bats
+++ b/test/unit/enterprise-license-podsecuritypolicy.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "enterpriseLicense/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/PodSecurityPolicy: disabled with server=false, ent secret defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enabled=false' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/PodSecurityPolicy: disabled when ent secretName missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/PodSecurityPolicy: disabled when ent secretKey missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/PodSecurityPolicy: disabled when enablePodSecurityPolicies=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "enterpriseLicense/PodSecurityPolicy: enabled when ent license defined and enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/enterprise-license-serviceaccount.bats
+++ b/test/unit/enterprise-license-serviceaccount.bats
@@ -11,35 +11,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ServiceAccount: disabled with global.bootstrapACLs=true" {
+@test "enterpriseLicense/ServiceAccount: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "enterpriseLicense/ServiceAccount: disabled with server=false, global.bootstrapACLs=true, ent secret defined" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "enterpriseLicense/ServiceAccount: disabled with client=false, global.bootstrapACLs=true, ent secret defined" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
-      --set 'client.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
@@ -51,7 +27,6 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -62,18 +37,16 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ServiceAccount: can be enabled" {
+@test "enterpriseLicense/ServiceAccount: enabled when ent license defined" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |


### PR DESCRIPTION
- add podsecuritypolicy for enterprise license job following the pattern
for other psps
- set same requirements across resources for rendering: servers enabled
and enterprise license secret fully specified. The different resources
had different requirements before, for example that clients are running
or that bootstrapACLs are true
- always create a separate service account for the job, even if acls are
disabled. This is to match the pattern across the rest of the templates
where we always create a separate service account
- remove comment across our PSP's that `RunAsAny` prevented running as root. This is not correct.