### PR TITLE
Add server.exposeWANPorts option for federation

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -89,6 +89,12 @@ spec:
                   name: {{ .Values.global.gossipEncryption.secretName }}
                   key: {{ .Values.global.gossipEncryption.secretKey }}
             {{- end }}
+            {{ if .Values.server.exposeWANPorts }}
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
             {{- include "consul.extraEnvironmentVars" .Values.server | nindent 12 }}
           command:
             - "/bin/sh"
@@ -98,6 +104,9 @@ spec:
 
               exec /bin/consul agent \
                 -advertise="${POD_IP}" \
+                {{- if .Values.server.exposeWANPorts }}
+                -advertise-wan="${NODE_IP}" \
+                {{- end }}
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ .Values.server.bootstrapExpect }} \
                 -client=0.0.0.0 \
@@ -146,9 +155,22 @@ spec:
             - containerPort: 8301
               name: serflan
             - containerPort: 8302
-              name: serfwan
+              name: serfwan-tcp
+              protocol: "TCP"
+              {{- if .Values.server.exposeWANPorts }}
+              hostPort: 8302
+              {{- end }}
+            - containerPort: 8302
+              name: serfwan-udp
+              protocol: "UDP"
+              {{- if .Values.server.exposeWANPorts }}
+              hostPort: 8302
+              {{- end }}
             - containerPort: 8300
               name: server
+              {{- if .Values.server.exposeWANPorts }}
+              hostPort: 8300
+              {{- end }}
             - containerPort: 8600
               name: dns-tcp
               protocol: "TCP"

--- a/values.yaml
+++ b/values.yaml
@@ -108,6 +108,14 @@ server:
   # via the extraConfig setting.
   connect: true
 
+  # exposeWANPorts exposes servers' wan ports as hostPorts.
+  # This is required if federating Consul datacenters since it makes the
+  # server WAN addresses routable from other datacenters.
+  # In order for this to work, the node IPs must be routable from the other
+  # datacenters.
+  # Also changes the servers' advertised IP to the hostIP rather than podIP.
+  exposeWANPorts: false
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request


### PR DESCRIPTION
Will expose the server's WAN ports (serf and rpc) as host ports and will
advertise the host IP as the wan address. This is needed for federation
if users can make their host ips routable.