### PR TITLE
Add replicas and disruptionBudget for connect-inject

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.connectInject.replicas }}
   selector:
     matchLabels:
       app: {{ template "consul.name" . }}

--- a/templates/connect-inject-disruptionbudget.yaml
+++ b/templates/connect-inject-disruptionbudget.yaml
@@ -1,0 +1,22 @@
+# PodDisruptionBudget to prevent degrading the injection of sidecars
+{{- if (and .Values.connectInject.disruptionBudget.enabled (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled))) }}
+{{- if (gt (int .Values.connectInject.replicas) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "consul.fullname" . }}-connect-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: {{ .Values.connectInject.disruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "consul.name" . }}
+      release: "{{ .Release.Name }}"
+      component: connect-injector
+{{- end }}
+{{- end }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -894,6 +894,32 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# replicas
+
+@test "connectInject/Deployment: replicas defaults to 2" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "connectInject/Deployment: replicas can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'connectInject.replicas=3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+#--------------------------------------------------------------------
 # resources
 
 @test "connectInject/Deployment: default resources" {

--- a/test/unit/connect-inject-disruptionbudget.bats
+++ b/test/unit/connect-inject-disruptionbudget.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "connectInject/DisruptionBudget: enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/DisruptionBudget: enabled with global.enabled=false and client.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/DisruptionBudget: disabled with connectInject.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/DisruptionBudget: disabled with connectInject.disruptionBudget.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.disruptionBudget.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/DisruptionBudget: disabled with global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'global.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/DisruptionBudget: disabled when connectInject.replicas=1" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.replicas=1' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# minUnavailable
+
+@test "connectInject/DisruptionBudget: minAvailable default to 1" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.minAvailable' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "connectInject/DisruptionBudget: minAvailable can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-disruptionbudget.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.replicas=3' \
+      --set 'connectInject.disruptionBudget.minAvailable=2' \
+      . | tee /dev/stderr |
+      yq '.spec.minAvailable' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -799,6 +799,18 @@ connectInject:
   # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.
   imageEnvoy: null
 
+  # Number of replicas for the Deployment.
+  replicas: 2
+
+  # disruptionBudget enables the creation of a PodDisruptionBudget to
+  # prevent voluntary degrading of the sidecar injection.
+  disruptionBudget:
+    enabled: true
+
+    # Default to 1 and should < replicas count
+    # If you'd like a custom value, you can specify an override here.
+    minAvailable: 1
+
   # namespaceSelector is the selector for restricting the webhook to only
   # specific namespaces. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector


### PR DESCRIPTION
This PR aims to make the connect-inject service highly available by default.
Only one pod to deliver pod injection for a service mesh is not enought for us.
We encountered injection problems when lots of pod are restarting during application upgrades in ours clusters.
I understand this PR change a default behavior.
If you think this is a breaking change, i can revert back the default replicas value.
Thanks