### PR TITLE
Fixed template newline issue in connect-inject deployment

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 -listen=:8080 \
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
-                {{ else if .Values.global.bootstrapACLs }}
+                {{- else if .Values.global.bootstrapACLs }}
                 -acl-auth-method="{{ template "consul.fullname" . }}-k8s-auth-method" \
                 {{- end }}
                 {{- if .Values.global.tls.enabled }}


### PR DESCRIPTION
Lack of template whitespace stripping in one particular line of connect-inject deployment was causing all the remaining command arguments to be ignored when using `connectInject.overrideAuthMethodName` option.

This was also incredibly hard to debug for a one-char fix. :)