### PR TITLE
feat: snapshot to persistentVolume and s3 bucket

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -61,3 +61,18 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Inject extra environment populated by secrets, if populated
+*/}}
+{{- define "consul.extraSecretEnvironmentVars" -}}
+{{- if .extraSecretEnvironmentVars -}}
+{{- range .extraSecretEnvironmentVars }}
+- name: {{ .envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/snapshot-clusterrole.yaml
+++ b/templates/snapshot-clusterrole.yaml
@@ -1,0 +1,33 @@
+{{- if (or (and (ne (.Values.snapshot.enabled | toString) "-") .Values.snapshot.enabled) (and (eq (.Values.snapshot.enabled | toString) "-") .Values.global.enabled)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
+rules:
+{{- if .Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+    - {{ template "consul.fullname" . }}-snapshot
+    verbs:
+    - use
+{{- end }}
+{{- if .Values.global.bootstrapACLs }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ template "consul.fullname" . }}-bootstrap-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- else}}
+rules: []
+{{- end }}
+{{- end }}

--- a/templates/snapshot-clusterrolebinding.yaml
+++ b/templates/snapshot-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (or (and (ne (.Values.snapshot.enabled | toString) "-") .Values.snapshot.enabled) (and (eq (.Values.snapshot.enabled | toString) "-") .Values.global.enabled)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "consul.fullname" . }}-snapshot
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-snapshot
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/snapshot-cronjob-podsecuritypolicy.yaml
+++ b/templates/snapshot-cronjob-podsecuritypolicy.yaml
@@ -1,0 +1,37 @@
+{{- if (and .Values.global.enablePodSecurityPolicies (or (and (ne (.Values.snapshot.enabled | toString) "-") .Values.snapshot.enabled) (and (eq (.Values.snapshot.enabled | toString) "-") .Values.global.enabled))) }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/templates/snapshot-cronjob.yaml
+++ b/templates/snapshot-cronjob.yaml
@@ -1,0 +1,235 @@
+# This CronJob will save snapshots to a PVC. It can also upload to s3 compatible storage
+{{- if (or (and (ne (.Values.snapshot.enabled | toString) "-") .Values.snapshot.enabled) (and (eq (.Values.snapshot.enabled | toString) "-") .Values.global.enabled)) }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}-snapshot
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  schedule: "{{ .Values.snapshot.schedule }}"
+  {{- with .Values.snapshot.concurrencyPolicy }}
+  concurrencyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.snapshot.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.snapshot.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ . }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        app: {{ template "consul.name" . }}-snapshot
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: snapshot
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.snapshot.annotations }}
+          {{- tpl .Values.snapshot.annotations . | nindent 8 }}
+        {{- end }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "consul.name" . }}-snapshot
+            chart: {{ template "consul.chart" . }}
+            release: {{ .Release.Name }}
+            component: snapshot
+          annotations:
+            "consul.hashicorp.com/connect-inject": "false"
+            {{- if .Values.snapshot.annotations }}
+              {{- tpl .Values.snapshot.annotations . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: snapshot
+              {{- if .Values.snapshot.storage.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ default (printf "%s-snapshot" (include "consul.fullname" .) ) .Values.snapshot.storage.existingClaim }}
+              {{- else }}
+              emptyDir:
+                medium: "Memory"
+              {{- end }}
+            {{- if .Values.global.tls.enabled }}
+            - name: tls-ca-cert
+              secret:
+                secretName: {{ template "consul.fullname" . }}-ca-cert
+            - name: tls-ca-key
+              secret:
+                secretName: {{ template "consul.fullname" . }}-ca-key
+            - name: tls-client-cert
+              emptyDir:
+                # We're using tmpfs here so that
+                # client certs are not written to disk
+                medium: "Memory"
+            {{- end }}
+            {{- if .Values.global.bootstrapACLs }}
+              # the snapshot command needs a management token if acls are being used
+            - name: bootstrap-acl-token
+              secret:
+                secretName: {{ template "consul.fullname" . }}-bootstrap-acl-token
+            {{- end }}
+          securityContext:
+            fsGroup: 1000
+            runAsGroup: 1000
+          serviceAccountName: {{ template "consul.fullname" . }}-snapshot
+          containers:
+            - name: consul
+              image: "{{ default .Values.global.imageSnapshot .Values.snapshot.image }}"
+              securityContext:
+                runAsUser: 100
+                allowPrivilegeEscalation: false
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                {{- include "consul.extraEnvironmentVars" .Values.snapshot | nindent 16 }}
+                {{- include "consul.extraSecretEnvironmentVars" .Values.snapshot | nindent 16 }}
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  CONSUL_FULLNAME="{{template "consul.fullname" . }}"
+                  YYYYMMDD="$(date --utc +%Y%m%d)"
+                  ISODATE="$(date --utc +%Y%m%dT%H%M%SZ)"
+                  SNAPSHOT_FILENAME="${CONSUL_FULLNAME}_${ISODATE}.tgz"
+                  FILENAME="${CONSUL_FULLNAME}/${YYYYMMDD}/${SNAPSHOT_FILENAME}"
+                  FILE="/consul/snapshot/${FILENAME}"
+
+                  if [ ! -d "/consul/snapshot/${CONSUL_FULLNAME}/${YYYYMMDD}" ]; then
+                    printf "creating directory: /consul/snapshot/${CONSUL_FULLNAME}/${YYYYMMDD}\n"
+                    mkdir -p "/consul/snapshot/${CONSUL_FULLNAME}/${YYYYMMDD}"
+                  fi
+
+                  {{- if .Values.global.tls.enabled }}
+                  : "${CONSUL_HTTP_ADDR:=https://${CONSUL_FULLNAME}-server:8501}"
+                  {{- else }}
+                  : "${CONSUL_HTTP_ADDR:=http://${CONSUL_FULLNAME}-server:8500}"
+                  {{- end }}
+
+                  printf "saving snapshot to ${FILE}\n"
+                  curl -f \
+                    ${CONSUL_HTTP_ADDR}/v1/snapshot?dc={{ .Values.global.datacenter }}{{- if .Values.snapshot.allow_stale}}&stale=true{{- end }} \
+                    {{- if .Values.global.bootstrapACLs }}
+                    --header "X-CONSUL-TOKEN: $(cat /consul/bootstrap-acl-token/token)" \
+                    {{- end }}
+                    {{- if .Values.global.tls.enabled }}
+                    --cacert "/consul/tls/ca/tls.crt" \
+                    --cert "/consul/tls/client/tls.crt" \
+                    --key "/consul/tls/client/tls.key" \
+                    {{- end }}
+                    -o "${FILE}"
+
+                  {{- if and (gt (len .Values.snapshot.s3) 0) .Values.snapshot.s3.bucket }}
+                  BUCKET="{{ .Values.snapshot.s3.bucket }}"
+                  {{- if .Values.snapshot.s3.region }}
+                  : "${AWS_DEFAULT_REGION:={{ .Values.snapshot.s3.region }}}"
+                  {{- end}}
+                  {{- if .Values.snapshot.s3.access_key }}
+                  : "${AWS_ACCESS_KEY_ID:={{ .Values.snapshot.s3.access_key }}}"
+                  {{- end }}
+
+                  printf "uploading snapshot to s3://${BUCKET}/${FILENAME}\n"
+                  aws \
+                    {{- if .Values.snapshot.s3.endpoint }}
+                    --endpoint "{{ .Values.snapshot.s3.endpoint }}" \
+                    {{- end }}
+                    s3 cp ${FILE} \
+                    "s3://${BUCKET}/${FILENAME}"
+                  {{- end }}
+                  #
+                  # delete old backups
+                  #
+                  {{- if .Values.snapshot.backup_retention }}
+                  find "/consul/snapshot/${CONSUL_FULLNAME}" \
+                    -type d \
+                    -mtime +{{ .Values.snapshot.backup_retention }} \
+                    -exec rm -r {} \;
+                  {{- end }}
+              volumeMounts:
+                - name: snapshot
+                  mountPath: /consul/snapshot
+                {{- if .Values.global.tls.enabled }}
+                - name: tls-ca-cert
+                  mountPath: /consul/tls/ca
+                  readOnly: true
+                - name: tls-client-cert
+                  mountPath: /consul/tls/client
+                  readOnly: true
+                {{- end }}
+                {{- if .Values.global.bootstrapACLs}}
+                - name: bootstrap-acl-token
+                  mountPath: /consul/bootstrap-acl-token
+                {{- end }}
+              {{- if .Values.snapshot.resources }}
+              resources:
+                {{ tpl .Values.snapshot.resources . | nindent 16 | trim }}
+              {{- end }}
+          initContainers:
+            - name: chown-snapshot-dir
+              image: {{ default .Values.global.imageSnapshot .Values.snapshot.image }}
+              securityContext:
+                runAsUser: 0
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  if [ ! -d /consul/snapshot]; then
+                    mkdir -p /consul/snapshot
+                  fi
+                  chown -R 100:1000 /consul/snapshot
+              volumeMounts:
+                - name: snapshot
+                  mountPath: /consul/snapshot
+            {{- if .Values.global.tls.enabled }}
+            - name: client-tls-init
+              image: "{{ default .Values.global.image .Values.server.image }}"
+              env:
+              - name: HOST_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  cd /consul/tls/client
+                  consul tls cert create -client \
+                    -additional-ipaddress=${HOST_IP} \
+                    -dc={{ .Values.global.datacenter }} \
+                    -domain={{ .Values.global.domain }} \
+                    -ca=/consul/tls/ca/cert/tls.crt \
+                    -key=/consul/tls/ca/key/tls.key
+                  mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0.pem tls.crt
+                  mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0-key.pem tls.key
+              volumeMounts:
+                - name: tls-client-cert
+                  mountPath: /consul/tls/client
+                - name: tls-ca-cert
+                  mountPath: /consul/tls/ca/cert
+                  readOnly: true
+                - name: tls-ca-key
+                  mountPath: /consul/tls/ca/key
+                  readOnly: true
+            {{- end }}
+        {{- if .Values.snapshot.nodeSelector }}
+          nodeSelector:
+            {{ tpl .Values.snapshot.nodeSelector . | nindent 10 | trim }}
+        {{- end }}
+        {{- if .Values.snapshot.affinity }}
+          affinity:
+            {{ tpl .Values.snapshot.affinity . | nindent 12 | trim }}
+        {{- end }}
+        {{- if .Values.snapshot.tolerations }}
+          tolerations:
+            {{ tpl .Values.snapshot.tolerations . | nindent 10 | trim }}
+        {{- end }}
+{{- end }}

--- a/templates/snapshot-persistent-volume-claim.yaml
+++ b/templates/snapshot-persistent-volume-claim.yaml
@@ -1,0 +1,19 @@
+{{- if (and (and .Values.snapshot.enabled .Values.snapshot.storage.enabled) (not .Values.snapshot.storage.existingClaim)) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - {{ .Values.snapshot.storage.accessMode | quote}}
+  storageClassName: {{ .Values.snapshot.storage.storageClassName | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.snapshot.storage.size }}
+{{- end }}

--- a/templates/snapshot-serviceaccount.yaml
+++ b/templates/snapshot-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if (or (and (ne (.Values.snapshot.enabled | toString) "-") .Values.snapshot.enabled) (and (eq (.Values.snapshot.enabled | toString) "-") .Values.global.enabled)) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "consul.fullname" . }}-snapshot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/test/unit/snapshot-clusterrole.bats
+++ b/test/unit/snapshot-clusterrole.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/ClusterRole: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+
+@test "snapshot/ClusterRole: disabled with global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=-' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ClusterRole: can be enabled with global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled="-"' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/ClusterRole: disabled with snapshot.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'snapshot.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ClusterRole: enabled with snapshot.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# global.enablePodSecurityPolicies
+
+@test "snapshot/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
+@test "snapshot/ClusterRole: allows secret access with global.bootsrapACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}
+
+@test "snapshot/ClusterRole: allows secret access with global.bootsrapACLs=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrole.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[1].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+}

--- a/test/unit/snapshot-clusterrolebinding.bats
+++ b/test/unit/snapshot-clusterrolebinding.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/ClusterRoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ClusterRoleBinding: disabled with global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=-' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ClusterRoleBinding: disabled with snapshot disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrolebinding.yaml  \
+      --set 'snapshot.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ClusterRoleBinding: enabled with snapshot enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrolebinding.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/ClusterRoleBinding: enabled with snapshot enabled and global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/snapshot-cronjob-podsecuritypolicy.bats
+++ b/test/unit/snapshot-cronjob-podsecuritypolicy.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob-podsecuritypolicy.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PodSecurityPolicy: disabled by default with snapshot enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob-podsecuritypolicy.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PodSecurityPolicy: disabled with snapshot disabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob-podsecuritypolicy.yaml  \
+      --set 'snapshot.enabled=false' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PodSecurityPolicy: enabled with snapshot enabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob-podsecuritypolicy.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/snapshot-cronjob.bats
+++ b/test/unit/snapshot-cronjob.bats
@@ -1,0 +1,564 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/CronJob: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/CronJob: enable with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: disable with snapshot.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/CronJob: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=-' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/CronJob: image defaults to global.imageSnapshot" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.imageSnapshot=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "snapshot/CronJob: image can be overridden with snapshot.image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.imageSnapshot=foo' \
+      --set 'snapshot.image=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# concurrencyPolicy
+
+@test "snapshot/CronJob: concurrencyPolicy Forbid by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.concurrencyPolicy == "Forbid"' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: concurrencyPolicy can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.concurrencyPolicy=Replace' \
+      . | tee /dev/stderr |
+      yq -r '.spec.concurrencyPolicy == "Replace"' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+
+#--------------------------------------------------------------------
+# jobHistory
+
+@test "snapshot/CronJob: failedJobsHistoryLimit is 3 by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.failedJobsHistoryLimit == 3' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: failedJobsHistoryLimit can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.failedJobsHistoryLimit=1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.failedJobsHistoryLimit == 1' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: successfulJobsHistoryLimit is 3 by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.successfulJobsHistoryLimit == 3' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: successfulJobsHistoryLimit can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.successfulJobsHistoryLimit=1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.successfulJobsHistoryLimit == 1' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+
+#--------------------------------------------------------------------
+# schedule
+
+@test "snapshot/CronJob: by default schedule is set to every 5 minutes" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.schedule == "*/5 * * * *"' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: schedule can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set "snapshot.schedule=*/2 * * * *" \
+      . | tee /dev/stderr |
+      yq -r '.spec.schedule == "*/2 * * * *"' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# s3 upload
+
+@test "snapshot/CronJob: renders script to upload to s3 if you set snapshot.s3.bucket" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.s3.bucket=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains("BUCKET=\"foo\""))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: renders s3 upload script with endpoint" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.s3.bucket=foo' \
+      --set 'snapshot.s3.endpoint=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains("--endpoint \"foo.com\""))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: will define AWS_DEFAULT_REGION in snapshot script" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.s3.bucket=foo' \
+      --set 'snapshot.s3.region=us-east-1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains(": \"${AWS_DEFAULT_REGION:=us-east-1}\""))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: renders s3 upload script with access_key" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.s3.bucket=foo' \
+      --set 'snapshot.s3.access_key=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains(": \"${AWS_ACCESS_KEY_ID:=bar}\""))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+#--------------------------------------------------------------------
+# allow_stale
+
+@test "snapshot/CronJob: will allow stale snapshots to be made" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.allow_stale=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains("&stale=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# backup_retention
+
+@test "snapshot/CronJob: will not cleanup up backups if backup_retention isn't set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.backup_retention=null' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains("-mtime"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/CronJob: backup_retention value will be used to delete old backups" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.backup_retention=20' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].command | any(contains("-mtime +20"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "snapshot/CronJob: no resources defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "snapshot/CronJob: resources can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.resources=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "snapshot/CronJob: nodeSelector is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "snapshot/CronJob: specified nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.nodeSelector=testing' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}
+
+#--------------------------------------------------------------------
+# affinity
+
+@test "snapshot/CronJob: affinity not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec | .affinity? == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: specified affinity" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.affinity=foobar' \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec | .affinity == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "snapshot/CronJob: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "snapshot/CronJob: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.annotations=foo: bar' \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# tolerations
+
+@test "snapshot/CronJob: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec | .tolerations? == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/CronJob: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.tolerations=foobar' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.tolerations == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# pvc
+
+@test "snapshot/CronJob: uses an existing pvc if set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.storage.enabled=true' \
+      --set 'snapshot.storage.existingClaim=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "snapshot")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.persistentVolumeClaim.claimName' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "snapshot/CronJob: uses a newly created pvc if storage is enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.storage.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "snapshot")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.persistentVolumeClaim.claimName' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-snapshot" ]
+}
+
+@test "snapshot/CronJob: does not use a pvc by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "snapshot")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.emptyDir.medium' | tee /dev/stderr)
+  [ "${actual}" = "Memory" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enabled
+
+@test "snapshot/CronJob: CA volume present when TLS is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "tls-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" != "" ]
+}
+
+@test "snapshot/CronJob: snapshot certificate volume present when TLS is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "tls-client-cert")' | tee /dev/stderr)
+  [ "${actual}" != "" ]
+}
+
+@test "snapshot/CronJob: init container is created when global.tls.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.initContainers[] | select(.name == "client-tls-init") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# extraEnvironmentVariables
+
+@test "snapshot/CronJob: custom environment variables" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.extraEnvironmentVars.custom_proxy=fakeproxy' \
+      --set 'snapshot.extraEnvironmentVars.no_proxy=custom_no_proxy' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[1].name' | tee /dev/stderr)
+  [ "${actual}" = "custom_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[1].value' | tee /dev/stderr)
+  [ "${actual}" = "fakeproxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "no_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "custom_no_proxy" ]
+}
+
+#--------------------------------------------------------------------
+# extraSecretEnvironmentVariables
+
+@test "snapshot/CronJob: mount a predefined secret env var" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.extraSecretEnvironmentVars[0].envName=AWS_SECRET_ACCESS_KEY' \
+      --set 'snapshot.extraSecretEnvironmentVars[0].secretName=consul-snapshot' \
+      --set 'snapshot.extraSecretEnvironmentVars[0].secretKey=AWS_SECRET_ACCESS_KEY' \
+      . | tee /dev/stderr |
+      yq -r '.spec.jobTemplate.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[1].name' | tee /dev/stderr)
+  [ "${actual}" = "AWS_SECRET_ACCESS_KEY" ]
+
+  local actual=$(echo $object |
+      yq -r '.[1].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-snapshot" ]
+
+   local actual=$(echo $object |
+      yq -r '.[1].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "AWS_SECRET_ACCESS_KEY" ]
+
+}
+
+#--------------------------------------------------------------------
+# global.bootstrapACLs
+
+@test "snapshot/CronJob: bootstrap-acl-token volume is created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.volumes[] | select(.name == "bootstrap-acl-token")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "bootstrap-acl-token" ]
+
+  local actual=$(echo $object |
+      yq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-bootstrap-acl-token" ]
+
+}
+
+@test "snapshot/CronJob: bootstrap-acl-token volumeMount is created when global.bootstrapACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/snapshot-cronjob.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[] | select(.name == "bootstrap-acl-token")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "bootstrap-acl-token" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/bootstrap-acl-token" ]
+}

--- a/test/unit/snapshot-persistent-volume-claim.bats
+++ b/test/unit/snapshot-persistent-volume-claim.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/PersistentVolumeClaim: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-persistent-volume-claim.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PersistentVolumeClaim: enabled with snapshot storage enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-persistent-volume-claim.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.storage.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/PersistentVolumeClaim: disabled with snapshot disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-persistent-volume-claim.yaml  \
+      --set 'snapshot.enabled=false' \
+      --set 'snapshot.storage.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PersistentVolumeClaim: disabled with snapshot storage disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-persistent-volume-claim.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.storage.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/PersistentVolumeClaim: disabled with snapshot enabled and snapshot.existingClaim defined" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-persistent-volume-claim.yaml  \
+      --set 'snapshot.enabled=true' \
+      --set 'snapshot.storage.enabled=true' \
+      --set 'snapshot.storage.existingClaim=foobar' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/snapshot-serviceaccount.bats
+++ b/test/unit/snapshot-serviceaccount.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "snapshot/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ServiceAccount: disabled with global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-serviceaccount.yaml  \
+      --set 'snabled.enabled="-"' \
+      --set 'global.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ServiceAccount: disabled with snapshot disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-serviceaccount.yaml  \
+      --set 'snapshot.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "snapshot/ServiceAccount: enabled with snapshot enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-serviceaccount.yaml  \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/ServiceAccount: enabled with snapshot enabled and global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/snapshot-serviceaccount.yaml  \
+      --set 'global.enabled=false' \
+      --set 'snapshot.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,9 @@ global:
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.12.0"
 
+  # This image is used for creating snapshots with cronjob. It creates snapshot using te consul http api. The cronjob can upload to s3 compatible storage.
+  imageSnapshot: "xueshanf/awscli:3.10-alpine"
+
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value
@@ -226,6 +229,52 @@ server:
     # http_proxy: http://localhost:3128,
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
+
+# This will install a CronJob that will create snapshots of the consul leader, via the http API. Snapshots can be saved to a PVC if you configure storage. It will also upload it to s3 compatible storage if you provide, at a minimum, a bucket name.
+snapshot:
+  enabled: false
+  image: null
+  annotations: null
+
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+
+  nodeSelector: null
+  affinity: null
+  tolerations: ""
+  resources: null
+
+  # You need to at least provide a bucket name
+  s3:
+    endpoint: null
+    region: null
+    bucket: null
+    access_key: null
+
+  extraEnvironmentVars: {}
+    # AWS_ACCESS_KEY: foo
+    # AWS_DEFAULT_REGION: us-east-1
+
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: consul-snapshot
+    #   secretKey: AWS_SECRET_ACCESS_KEY
+
+  # Start cleaning up backups from the pvc after this many days:
+  backup_retention: 30
+
+  # https://www.consul.io/docs/commands/snapshot/save.html#stale
+  allow_stale: false
+
+  # Provide an existing claim. If you leave it as null, one will be created for you, depending on the values passed to storage, storageClassName, and accessMode
+  storage:
+    enabled: false
+    existingClaim: null
+    size: 10Gi
+    storageClassName: null
+    accessMode: ReadWriteMany
 
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional


### PR DESCRIPTION
This PR adds a cronjob that creates a snapshot using the consul http api. The snapshot can be saved to a pvc, or uploaded to an s3 bucket.

Tested with global.bootstrapACLs=true and global.tls.enabled=true. Since snapshotting requires a management acl token, I decided to use the bootstrap token that is generated.

Unit tests have been provided

Closes #344 
Closes #257