### PR TITLE
Allow setting your own CA as a kube secret

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -68,12 +68,26 @@ spec:
           configMap:
             name: {{ template "consul.fullname" . }}-client-config
         {{- if .Values.global.tls.enabled }}
-        - name: tls-ca-cert
+        - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
-        - name: tls-ca-key
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
+        - name: consul-ca-key
           secret:
+            {{- if .Values.global.tls.caKey.secretName }}
+            secretName: {{ .Values.global.tls.caKey.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-key
+            {{- end }}
+            items:
+            - key: {{ default "tls.key" .Values.global.tls.caKey.secretKey }}
+              path: tls.key
         - name: tls-client-cert
           emptyDir:
             # We're using tmpfs here so that
@@ -191,7 +205,7 @@ spec:
             - name: config
               mountPath: /consul/config
             {{- if .Values.global.tls.enabled }}
-            - name: tls-ca-cert
+            - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
             - name: tls-client-cert
@@ -304,10 +318,10 @@ spec:
         volumeMounts:
           - name: tls-client-cert
             mountPath: /consul/tls/client
-          - name: tls-ca-cert
+          - name: consul-ca-cert
             mountPath: /consul/tls/ca/cert
             readOnly: true
-          - name: tls-ca-key
+          - name: consul-ca-key
             mountPath: /consul/tls/ca/key
             readOnly: true
       {{- end }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -54,7 +54,14 @@ spec:
         {{- if .Values.global.tls.enabled }}
         - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
         {{- end }}
       {{- end }}
       containers:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -170,7 +170,14 @@ spec:
         {{- if .Values.global.tls.enabled }}
         - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
         {{- end }}
       {{- end }}
       {{- if and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces }}

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -35,9 +35,16 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-enterprise-license
       {{- if .Values.global.tls.enabled }}
       volumes:
-        - name: tls-ca-cert
+        - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
       {{- end }}
       containers:
         - name: apply-enterprise-license
@@ -72,7 +79,7 @@ spec:
               consul license put "${ENTERPRISE_LICENSE}"
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
-            - name: tls-ca-cert
+            - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
           {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -51,7 +51,14 @@ spec:
         {{- if .Values.global.tls.enabled }}
         - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
         {{- end }}
       {{- if .Values.meshGateway.hostNetwork }}
       hostNetwork: {{ .Values.meshGateway.hostNetwork }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -34,9 +34,16 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
       {{- if .Values.global.tls.enabled }}
       volumes:
-      - name: tls-ca-cert
+      - name: consul-ca-cert
         secret:
+          {{- if .Values.global.tls.caCert.secretName }}
+          secretName: {{ .Values.global.tls.caCert.secretName }}
+          {{- else }}
           secretName: {{ template "consul.fullname" . }}-ca-cert
+          {{- end }}
+          items:
+          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+            path: tls.crt
       {{- end }}
       containers:
         - name: post-install-job
@@ -48,7 +55,7 @@ spec:
                   fieldPath: metadata.namespace
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
-            - name: tls-ca-cert
+            - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
            {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -59,9 +59,16 @@ spec:
           configMap:
             name: {{ template "consul.fullname" . }}-server-config
         {{- if .Values.global.tls.enabled }}
-        - name: tls-ca-cert
+        - name: consul-ca-cert
           secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
             secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+              path: tls.crt
         - name: tls-server-cert
           secret:
             secretName: {{ template "consul.fullname" . }}-server-cert
@@ -157,7 +164,7 @@ spec:
             - name: config
               mountPath: /consul/config
             {{- if .Values.global.tls.enabled }}
-            - name: tls-ca-cert
+            - name: consul-ca-cert
               mountPath: /consul/tls/ca/
               readOnly: true
             - name: tls-server-cert

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -31,9 +31,16 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
       {{- if .Values.global.tls.enabled }}
       volumes:
-      - name: tls-ca-cert
+      - name: consul-ca-cert
         secret:
+          {{- if .Values.global.tls.caCert.secretName }}
+          secretName: {{ .Values.global.tls.caCert.secretName }}
+          {{- else }}
           secretName: {{ template "consul.fullname" . }}-ca-cert
+          {{- end }}
+          items:
+          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+            path: tls.crt
       {{- end }}
       containers:
         - name: consul-sync-catalog
@@ -72,7 +79,7 @@ spec:
             {{- end }}
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
-            - name: tls-ca-cert
+            - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
           {{- end }}

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -16,7 +16,14 @@ spec:
   volumes:
     - name: tls-ca-cert
       secret:
+        {{- if .Values.global.tls.caCert.secretName }}
+        secretName: {{ .Values.global.tls.caCert.secretName }}
+        {{- else }}
         secretName: {{ template "consul.fullname" . }}-ca-cert
+        {{- end }}
+        items:
+        - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+          path: tls.crt
   {{- end }}
   containers:
     - name: consul-test

--- a/templates/tls-init-cleanup-clusterrole.yaml
+++ b/templates/tls-init-cleanup-clusterrole.yaml
@@ -15,8 +15,10 @@ rules:
   resources:
     - secrets
   resourceNames:
+    {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
     - {{ template "consul.fullname" . }}-ca-cert
     - {{ template "consul.fullname" . }}-ca-key
+    {{- end }}
     - {{ template "consul.fullname" . }}-server-cert
   verbs:
     - delete

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -39,12 +39,14 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
+              {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
               curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-ca-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
               curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-ca-key \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
+              {{- end }}
               curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-server-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -29,6 +29,21 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init
+      {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
+      volumes:
+      - name: consul-ca-cert
+        secret:
+          secretName: {{ .Values.global.tls.caCert.secretName }}
+          items:
+          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+            path: tls.crt
+      - name: consul-ca-key
+        secret:
+          secretName: {{ .Values.global.tls.caKey.secretName }}
+          items:
+          - key: {{ default "tls.key" .Values.global.tls.caKey.secretKey }}
+            path: tls.key
+      {{- end }}
       containers:
         - name: tls-init
           image: "{{ .Values.global.image }}"
@@ -45,10 +60,28 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
+              {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
               consul tls ca create \
                 -domain={{ .Values.global.domain }}
+              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
+                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json" \
+                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.domain }}-agent-ca.pem | base64 | tr -d '\n' )\" }}" > /dev/null
+              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
+                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json" \
+                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-key\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.key\": \"$( cat {{ .Values.global.domain }}-agent-ca-key.pem | base64 | tr -d '\n' )\" }}" > /dev/null
+              {{- end }}
               consul tls cert create -server \
                 -days=730 \
+                {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
+                -ca=/consul/tls/ca/cert/tls.crt \
+                -key=/consul/tls/ca/key/tls.key \
+                {{- end }}
                 -additional-dnsname='{{ template "consul.fullname" . }}-server' \
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server' \
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}' \
@@ -66,18 +99,15 @@ spec:
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
                 -H "Content-Type: application/json" \
                 -H "Accept: application/json" \
-                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.domain }}-agent-ca.pem | base64 | tr -d '\n' )\" }}" > /dev/null
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
-                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
-                -H "Content-Type: application/json" \
-                -H "Accept: application/json" \
-                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-key\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.key\": \"$( cat {{ .Values.global.domain }}-agent-ca-key.pem | base64 | tr -d '\n' )\" }}" > /dev/null
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
-                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
-                -H "Content-Type: application/json" \
-                -H "Accept: application/json" \
                 -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-server-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"kubernetes.io/tls\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.datacenter }}-server-{{ .Values.global.domain }}-0.pem | base64 | tr -d '\n' )\", \"tls.key\": \"$( cat {{ .Values.global.datacenter }}-server-{{ .Values.global.domain }}-0-key.pem | base64 | tr -d '\n' )\" } }" > /dev/null
+          {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
+          volumeMounts:
+            - name: consul-ca-cert
+              mountPath: /consul/tls/ca/cert
+              readOnly: true
+            - name: consul-ca-key
+              mountPath: /consul/tls/ca/key
+              readOnly: true
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -410,6 +410,29 @@ load _helpers
   [ "${actual}" = "2" ]
 }
 
+@test "connectInject/Deployment: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local ca_cert_volume=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual
+  actual=$(echo $ca_cert_volume | jq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # check that the volume uses the provided secret key
+  actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+}
+
 #--------------------------------------------------------------------
 # k8sAllowNamespaces & k8sDenyNamespaces
 

--- a/test/unit/enterprise-license-job.bats
+++ b/test/unit/enterprise-license-job.bats
@@ -174,3 +174,28 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]
 }
+
+@test "server/EnterpriseLicense: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local ca_cert_volume=$(helm template \
+      -x templates/client-snapshot-agent-deployment.yaml  \
+      -x templates/enterprise-license-job.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual
+  actual=$(echo $ca_cert_volume | jq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # check that the volume uses the provided secret key
+  actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -234,6 +234,29 @@ load _helpers
     [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/Job: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local ca_cert_volume=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual
+  actual=$(echo $ca_cert_volume | jq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # check that the volume uses the provided secret key
+  actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+}
+
 #--------------------------------------------------------------------
 # namespaces
 

--- a/test/unit/tls-init-job.bats
+++ b/test/unit/tls-init-job.bats
@@ -75,3 +75,38 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-additional-dnsname=example.com"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "tlsInit/Job: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -x templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual
+  actual=$(echo $spec | jq -r '.volumes[] | select(.name=="consul-ca-cert") | .secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # uses the provided secret key for CA cert
+  actual=$(echo $spec | jq -r '.volumes[] | select(.name=="consul-ca-cert") | .secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+
+  # check that the provided ca key secret is attached as a volume
+  local actual
+  actual=$(echo $spec | jq -r '.volumes[] | select(.name=="consul-ca-key") | .secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-key" ]
+
+  # uses the provided secret key for CA cert
+  actual=$(echo $spec | jq -r '.volumes[] | select(.name=="consul-ca-key") | .secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+
+  # check that it doesn't generate the CA
+  actual=$(echo $spec | jq -r '.containers[0].command | join(" ") | contains("consul tls ca create")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,33 @@ global:
     # clients and servers and only accept HTTPS connections.
     httpsOnly: true
 
+    # caCert is a Kubernetes secret containing the certificate
+    # of the CA to use for TLS communication within the Consul cluster.
+    # If you have generated the CA yourself with the consul CLI,
+    # you could use the following command to create the secret in Kubernetes:
+    #
+    #   kubectl create secret generic consul-ca-cert \
+    #           --from-file='tls.crt=./consul-agent-ca.pem'
+    caCert:
+      secretName: null
+      secretKey: null
+
+    # caKey is a Kubernetes secret containing the private key
+    # of the CA to use for TLS communications within the Consul cluster.
+    # If you have generated the CA yourself with the consul CLI,
+    # you could use the following command to create the secret in Kubernetes:
+    #
+    #   kubectl create secret generic consul-ca-key \
+    #           --from-file='tls.key=./consul-agent-ca-key.pem'
+    #
+    # Note that we need the CA key so that we can generate server and client certificates.
+    # It is particularly important for the client certificates since they need to have host IPs
+    # as Subject Alternative Names. In the future, we may support bringing your own server
+    # certificates.
+    caKey:
+      secretName: null
+      secretKey: null
+
   # [Enterprise Only] enableConsulNamespaces indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would like to
   # make use of configuration beyond registering everything into the `default` Consul
@@ -202,7 +229,7 @@ server:
   # in a PodSpec.
   tolerations: ""
 
-  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # nodeSelector labels for server pod assignment, formatted as a multi-line string.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # Example:
   # nodeSelector: |
@@ -218,7 +245,7 @@ server:
   # the annotations to apply to the server pods
   annotations: null
 
-  # extraEnvVars is a list of extra enviroment variables to set with the stateful set. These could be
+  # extraEnvVars is a list of extra environment variables to set with the stateful set. These could be
   # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
   # custom consul parameters.
@@ -311,7 +338,7 @@ client:
   # the annotations to apply to the client pods
   annotations: null
 
-  # extraEnvVars is a list of extra enviroment variables to set with the pod. These could be
+  # extraEnvVars is a list of extra environment variables to set with the pod. These could be
   # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
   # custom consul parameters.
@@ -333,7 +360,7 @@ client:
   #    type: RollingUpdate
   updateStrategy: null
 
-  # snaphotAgent contains settings for setting up and running snapshot agents
+  # snapshotAgent contains settings for setting up and running snapshot agents
   # within the Consul clusters. They are required to be co-located with Consul
   # clients, so will inherit the clients' nodeSelector, tolerations and affinity.
   # This is an Enterprise feature only.
@@ -635,7 +662,7 @@ connectInject:
     certName: tls.crt
     keyName: tls.key
 
-  # nodeSelector labels for connectInject pod assignment, formatted as a muli-line string.
+  # nodeSelector labels for connectInject pod assignment, formatted as a multi-line string.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # Example:
   # nodeSelector: |


### PR DESCRIPTION
This PR adds the following values to the Helm chart to allow bringing your CA as a Kubernetes secret:
```yaml
tls:    
  caCert:
    secretName: ""
    secretKey: tls.crt
  caKey:
    secretName: ""
    secretKey: tls.key
```

It assumes the defaults for secret keys to follow the pattern of the Kubernetes TLS secrets. This also significantly simplifies the underlying implementation in that we don't need to check if the key is set and can instead assume it's always set.