### PR TITLE
Apply license until success

### DIFF
--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -65,9 +65,25 @@ spec:
             {{- end}}
           command:
             - "/bin/sh"
-            - "-ec"
+            - "-c"
             - |
-              consul license put "${ENTERPRISE_LICENSE}"
+                # Create a script that we can execute with the timeout command.
+                cat > apply-license.sh << 'EOF'
+                #!/bin/sh
+                while true; do
+                  echo "Applying license..."
+                  if consul license put "${ENTERPRISE_LICENSE}"; then
+                    echo "License applied successfully"
+                    break
+                  fi
+                  echo "Retrying in 2s..."
+                  sleep 2
+                done
+                EOF
+                chmod +x ./apply-license.sh
+
+                # Time out after 20 minutes.
+                timeout -t 1200 ./apply-license.sh
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: tls-ca-cert


### PR DESCRIPTION
Previously, if the leader wasn't elected, the consul license command
would be run once in each execution of the job and fail.
On clusters where the servers took a long time to come up,
the job would reach its maximum backoff limit and the license would
never be applied.

This change runs the license put command in a loop until it's
successful or it times out after 20 minutes.

Logs look like:
```
Applying license...
Error putting license: Put http://consul-server:8500/v1/operator/license: dial tcp: lookup consul-server on 10.35.240.10:53: no such host
Retrying in 2s...
Applying license...
Error putting license: Put http://consul-server:8500/v1/operator/license: dial tcp: lookup consul-server on 10.35.240.10:53: no such host
Retrying in 2s...
Applying license...
Retrying in 2s...
Error putting license: Put http://consul-server:8500/v1/operator/license: dial tcp: lookup consul-server on 10.35.240.10:53: no such host
Applying license...
Error putting license: Unexpected response code: 500 (No cluster leader)
Retrying in 2s...
Applying license...
License is valid
License ID: *************
Customer ID: *****************
Expires At: 2021-01-02 05:59:59.999 +0000 UTC
Terminates At: 2021-01-02 05:59:59.999 +0000 UTC
Datacenter: *
Package: premium
Licensed Features:
	Automated Backups
	Automated Upgrades
	Enhanced Read Scalability
	Network Segments
	Redundancy Zone
	Advanced Network Federation
	Namespaces
```