### PR TITLE
Add new Helm value that enables mesh gateway federation

### DIFF
--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -165,6 +165,9 @@ spec:
                 {{- if and .Values.global.bootstrapACLs (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end }}
                 -service={{ .Values.meshGateway.consulServiceName | quote }} \
                 {{- end }}
+                {{- if .Values.global.federation.enabled }}
+                -expose-servers \
+                {{- end }}
           {{- if .Values.meshGateway.enableHealthChecks }}
           livenessProbe:
             tcpSocket:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -151,6 +151,9 @@ spec:
                 {{- if .Values.server.connect }}
                 -hcl="connect { enabled = true }" \
                 {{- end }}
+                {{- if .Values.global.federation.enabled }}
+                -hcl="connect { enable_mesh_gateway_wan_federation = true }" \
+                {{- end }}
                 {{- if .Values.ui.enabled }}
                 -ui \
                 {{- end }}

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -86,6 +86,7 @@ spec:
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server' \
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}' \
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc' \
+                -additional-dnsname='*.server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }}' \
                 {{- range .Values.global.tls.serverAdditionalIPSANs }}
                 -additional-ipaddress={{ . }} \
                 {{- end }}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -654,3 +654,30 @@ key2: value2' \
   actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
   [ "${actual}" = "key" ]
 }
+
+#--------------------------------------------------------------------
+# global.federation.enabled
+
+@test "meshGateway/Deployment: -expose-servers set when federation.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.federation.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("-expose-servers")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: -expose-servers not set when federation.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.federation.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("-expose-servers")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -335,7 +335,7 @@ key2: value2' \
       . | tee /dev/stderr \
       | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
 
-  [[ $(echo "$actual" | yq -r '.command[2]')  =~ '-address="${POD_IP}:443"' ]]
+  [ $(echo "$actual" | yq -r '.command | join(" ") | contains("-address=\"${POD_IP}:443\"")') = "true" ]
   [ $(echo "$actual" | yq -r '.ports[0].containerPort')  = "443" ]
   [ $(echo "$actual" | yq -r '.livenessProbe.tcpSocket.port')  = "443" ]
   [ $(echo "$actual" | yq -r '.readinessProbe.tcpSocket.port')  = "443" ]
@@ -352,7 +352,7 @@ key2: value2' \
       . | tee /dev/stderr \
       | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
 
-  [[ $(echo "$actual" | yq -r '.command[2]')  =~ '-address="${POD_IP}:8443"' ]]
+  [ $(echo "$actual" | yq -r '.command | join(" ") | contains("-address=\"${POD_IP}:8443\"")') = "true" ]
   [ $(echo "$actual" | yq -r '.ports[0].containerPort')  = "8443" ]
   [ $(echo "$actual" | yq -r '.livenessProbe.tcpSocket.port')  = "8443" ]
   [ $(echo "$actual" | yq -r '.readinessProbe.tcpSocket.port')  = "8443" ]
@@ -370,8 +370,8 @@ key2: value2' \
       --set 'client.grpc=true' \
       --set 'meshGateway.wanAddress.useNodeIP=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
-  [[ "${actual}" =~ '-wan-address="${HOST_IP}:443"' ]]
+      yq -r '.spec.template.spec.containers[0].command | join(" ") | contains("-wan-address=\"${HOST_IP}:443\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "meshGateway/Deployment: wanAddress uses NodeIP by default" {
@@ -382,8 +382,8 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
-  [[ "${actual}" =~ '-wan-address="${HOST_IP}:443"' ]]
+      yq -r '.spec.template.spec.containers[0].command | join(" ") | contains("-wan-address=\"${HOST_IP}:443\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "meshGateway/Deployment: wanAddress.useNodeIP" {
@@ -396,8 +396,8 @@ key2: value2' \
       --set 'meshGateway.wanAddress.useNodeIP=true' \
       --set 'meshGateway.wanAddress.port=4444' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
-  [[ "${actual}" =~ '-wan-address="${HOST_IP}:4444"' ]]
+      yq -r '.spec.template.spec.containers[0].command | join(" ") | contains("-wan-address=\"${HOST_IP}:4444\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "meshGateway/Deployment: wanAddress.useNodeName" {
@@ -411,8 +411,8 @@ key2: value2' \
       --set 'meshGateway.wanAddress.useNodeName=true' \
       --set 'meshGateway.wanAddress.port=4444' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
-  [[ "${actual}" =~ '-wan-address="${NODE_NAME}:4444"' ]]
+      yq -r '.spec.template.spec.containers[0].command | join(" ") | contains("-wan-address=\"${NODE_NAME}:4444\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "meshGateway/Deployment: wanAddress.host" {
@@ -427,8 +427,8 @@ key2: value2' \
       --set 'meshGateway.wanAddress.host=myhost' \
       --set 'meshGateway.wanAddress.port=4444' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
-  [[ "${actual}" =~ '-wan-address="myhost:4444"' ]]
+      yq -r '.spec.template.spec.containers[0].command | join(" ") | contains("-wan-address=\"myhost:4444\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------
@@ -460,7 +460,7 @@ key2: value2' \
       . | tee /dev/stderr \
       | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
 
-  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ '-service="mesh-gateway"' ]]
+  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ "-service=\"mesh-gateway\"" ]]
   [[ $(echo "${actual}" | yq -r '.lifecycle.preStop.exec.command' ) =~ '-id=\"mesh-gateway\"' ]]
 }
 
@@ -475,7 +475,7 @@ key2: value2' \
       . | tee /dev/stderr \
       | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
 
-  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ '-service="overridden"' ]]
+  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ "-service=\"overridden\"" ]]
   [[ $(echo "${actual}" | yq -r '.lifecycle.preStop.exec.command' ) =~ '-id=\"overridden\"' ]]
 }
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -662,3 +662,26 @@ load _helpers
   actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
   [ "${actual}" = "key" ]
 }
+
+#--------------------------------------------------------------------
+# global.federation.enabled
+
+@test "server/StatefulSet: mesh gateway federation enabled when federation.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.federation.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("connect { enable_mesh_gateway_wan_federation = true }")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/StatefulSet: mesh gateway federation not enabled when federation.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.federation.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("connect { enable_mesh_gateway_wan_federation = true }")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -138,6 +138,15 @@ global:
       secretName: ""
       secretKey: ""
 
+  # Configures Consul datacenter federation.
+  federation:
+    # If true, servers and mesh gateways will
+    # have mesh gateway federation enabled.
+    # Additional configuration will be needed to provide the addresses of the
+    # remote datacenter's mesh gateway to federate with.
+    # This setting must be true in both primary and secondary datacenters.
+    enabled: false
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.


### PR DESCRIPTION
This does not yet support ACL replication.

DC1 values using pod ip for mesh gateways with azure cni and peering.
```yaml
global:
  image: lkysow/consul-dev:feb5-2020-wan
  tls:
    enabled: true
  federation:
    enabled: true
  name: consul
server:
  replicas: 1
  bootstrapExpect: 1
connectInject:
  enabled: true
meshGateway:
  enabled: true
  enableHealthChecks: false
  wanAddress:
    useNodeIP: false
```

DC2 (secondary) values using pod ip for mesh gateways with azure cni and peering.
```yaml
global:
  datacenter: dc2
  image: lkysow/consul-dev:feb5-2020-wan
  tls:
    enabled: true
    caCert:
      secretName: consul-ca-cert
      secretKey: tls.crt
    caKey:
      secretName: consul-ca-key
      secretKey: tls.key
  federation:
    enabled: true
  name: consul
server:
  replicas: 1
  bootstrapExpect: 1
  extraConfig: |
    {
      "primary_datacenter": "dc1",
      "primary_gateways": ["172.27.0.12:443"]
    }
connectInject:
  enabled: true
meshGateway:
  enabled: true
  enableHealthChecks: false
  wanAddress:
    useNodeIP: false
```