### PR TITLE
Support ACL replication.

### DIFF
--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -32,18 +32,28 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
-      {{- if .Values.global.tls.enabled }}
+      {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey)) }}
       volumes:
-      - name: consul-ca-cert
-        secret:
-          {{- if .Values.global.tls.caCert.secretName }}
-          secretName: {{ .Values.global.tls.caCert.secretName }}
-          {{- else }}
-          secretName: {{ template "consul.fullname" . }}-ca-cert
-          {{- end }}
-          items:
-          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
-            path: tls.crt
+        {{- if .Values.global.tls.enabled }}
+        - name: consul-ca-cert
+          secret:
+            {{- if .Values.global.tls.caCert.secretName }}
+            secretName: {{ .Values.global.tls.caCert.secretName }}
+            {{- else }}
+            secretName: {{ template "consul.fullname" . }}-ca-cert
+            {{- end }}
+            items:
+              - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+                path: tls.crt
+        {{- end }}
+        {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+        - name: acl-replication-token
+          secret:
+            secretName: {{ .Values.global.acls.replicationToken.secretName }}
+            items:
+              - key: {{ .Values.global.acls.replicationToken.secretKey }}
+                path: acl-replication-token
+        {{- end }}
       {{- end }}
       containers:
         - name: post-install-job
@@ -53,11 +63,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- if .Values.global.tls.enabled }}
+          {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey)) }}
           volumeMounts:
+            {{- if .Values.global.tls.enabled }}
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
+            {{- end }}
+            {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+            - name: acl-replication-token
+              mountPath: /consul/acl/tokens
+              readOnly: true
+            {{- end }}
            {{- end }}
           command:
             - "/bin/sh"
@@ -95,6 +112,12 @@ spec:
                 {{- end }}
                 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
                 -create-client-token=false \
+                {{- end }}
+                {{- if .Values.global.acls.createReplicationToken }}
+                -create-acl-replication-token=true \
+                {{- end }}
+                {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+                -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
                 {{- end }}
                 {{- if .Values.global.enableConsulNamespaces }}
                 -enable-namespaces=true \

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -20,6 +20,9 @@ data:
         "enabled": true,
         "default_policy": "deny",
         "down_policy": "extend-cache",
+        {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+        "enable_token_replication": true,
+        {{- end }}
         "enable_token_persistence": true
       }
     }

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -110,6 +110,13 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
+            {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+            - name: ACL_REPLICATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.acls.replicationToken.secretName | quote }}
+                  key: {{ .Values.global.acls.replicationToken.secretKey | quote }}
+            {{- end }}
             {{- include "consul.extraEnvironmentVars" .Values.server | nindent 12 }}
           command:
             - "/bin/sh"
@@ -153,6 +160,9 @@ spec:
                 {{- end }}
                 {{- if .Values.global.federation.enabled }}
                 -hcl="connect { enable_mesh_gateway_wan_federation = true }" \
+                {{- end }}
+                {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+                -hcl="acl { tokens { agent = \"${ACL_REPLICATION_TOKEN}\", replication = \"${ACL_REPLICATION_TOKEN}\" } }" \
                 {{- end }}
                 {{- if .Values.ui.enabled }}
                 -ui \

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -165,3 +165,50 @@ load _helpers
       yq -r '.data["proxy-defaults-config.json"]' | yq -r '.config_entries.bootstrap[0].mesh_gateway.mode' | tee /dev/stderr)
   [ "${actual}" = "remote" ]
 }
+
+#--------------------------------------------------------------------
+# global.acls.replicationToken
+
+@test "server/ConfigMap: enable_token_replication is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: enable_token_replication is not set when acls.replicationToken.secretName is set but secretKey is not" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.replicationToken.secretName=name' \
+      . | tee /dev/stderr |
+      yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: enable_token_replication is not set when acls.replicationToken.secretKey is set but secretName is not" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.replicationToken.secretKey=key' \
+      . | tee /dev/stderr |
+      yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: enable_token_replication is set when acls.replicationToken.secretKey and secretName are set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml  \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.replicationToken.secretName=name' \
+      --set 'global.acls.replicationToken.secretKey=key' \
+      . | tee /dev/stderr |
+      yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -156,6 +156,23 @@ global:
     # This setting must be true in both primary and secondary datacenters.
     enabled: false
 
+  # Configure ACLs.
+  acls:
+    # If true, an ACL token will be created that can be used in secondary
+    # datacenters for replication. This should only be set to true in the
+    # primary datacenter since the replication token must be created from that
+    # datacenter.
+    # In secondary datacenters, the secret will be imported from the primary
+    # datacenter and referenced via global.acls.replicationToken.
+    createReplicationToken: false
+
+    # replicationToken references a secret containing the replication ACL token.
+    # This token will be used by secondary datacenters to perform ACL replication
+    # and create ACL tokens and policies
+    replicationToken:
+      secretName: null
+      secretKey: null
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.


### PR DESCRIPTION
Support creating an ACL replication token (for primary dcs) via `global.acls.createReplicationToken` and
referencing a pre-created ACL replication token (for secondary dcs) via `global.acls.replicationToken`.

One thing to review here is that we're using the existence of `global.acls.replicationToken` to determine whether we set other config flags that are required for replication. We *could* have had a separate setting, e.g. `global.acls.enableReplication`.