### PR TITLE
Support auto-encrypt

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -63,7 +63,8 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/*
-Get Consul client CA to use when auto-encrypt is enabled
+Get Consul client CA to use when auto-encrypt is enabled.
+This template is for an init container.
 */}}
 {{- define "consul.getAutoEncryptClientCA" -}}
 - name: get-auto-encrypt-client-ca
@@ -74,18 +75,18 @@ Get Consul client CA to use when auto-encrypt is enabled
     - |
       consul-k8s get-consul-client-ca \
         -output-file=/consul/tls/client/ca/tls.crt \
-        {{- if .Values.externalServer.enabled }}
-        {{- if not (or .Values.externalServer.https.address .Values.client.join)}}{{ fail "either client.join or externalServer.https.address must be set if externalServer.enabled is true" }}{{ end -}}
-        {{- if .Values.externalServer.https.address }}
-        -server-addr={{ .Values.externalServer.https.address }} \
+        {{- if .Values.externalServers.enabled }}
+        {{- if not (or .Values.externalServers.https.address .Values.client.join)}}{{ fail "either client.join or externalServers.https.address must be set if externalServers.enabled is true" }}{{ end -}}
+        {{- if .Values.externalServers.https.address }}
+        -server-addr={{ .Values.externalServers.https.address }} \
         {{- else }}
         -server-addr={{ quote (first .Values.client.join) }} \
         {{- end }}
-        -server-port={{ .Values.externalServer.https.port }} \
-        {{- if .Values.externalServer.https.tlsServerName }}
-        -tls-server-name={{ .Values.externalServer.https.tlsServerName }} \
+        -server-port={{ .Values.externalServers.https.port }} \
+        {{- if .Values.externalServers.https.tlsServerName }}
+        -tls-server-name={{ .Values.externalServers.https.tlsServerName }} \
         {{- end }}
-        {{- if not .Values.externalServer.https.useSystemRoots }}
+        {{- if not .Values.externalServers.https.useSystemRoots }}
         -ca-file=/consul/tls/ca/tls.crt
         {{- end }}
         {{- else }}
@@ -94,7 +95,7 @@ Get Consul client CA to use when auto-encrypt is enabled
         -ca-file=/consul/tls/ca/tls.crt
         {{- end }}
   volumeMounts:
-    {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+    {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
     - name: consul-ca-cert
       mountPath: /consul/tls/ca
     {{- end }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -89,7 +89,7 @@ spec:
             items:
             - key: {{ default "tls.key" .Values.global.tls.caKey.secretKey }}
               path: tls.key
-        - name: tls-client-cert
+        - name: consul-client-cert
           emptyDir:
             # We're using tmpfs here so that
             # client certs are not written to disk
@@ -294,7 +294,7 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
-      {{- if (or .Values.global.bootstrapACLs .Values.global.tls.enabled) }}
+      {{- if (or .Values.global.bootstrapACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:
       {{- if .Values.global.bootstrapACLs }}
       - name: client-acl-init
@@ -338,11 +338,9 @@ spec:
           - name: consul-ca-cert
             mountPath: /consul/tls/ca/cert
             readOnly: true
-          {{- if not .Values.global.tls.enableAutoEncrypt }}
           - name: consul-ca-key
             mountPath: /consul/tls/ca/key
             readOnly: true
-          {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.client.nodeSelector }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -78,6 +78,7 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{ if not .Values.global.tls.enableAutoEncrypt }}
         - name: consul-ca-key
           secret:
             {{- if .Values.global.tls.caKey.secretName }}
@@ -93,6 +94,7 @@ spec:
             # We're using tmpfs here so that
             # client certs are not written to disk
             medium: "Memory"
+        {{- end }}
         {{- end }}
         {{- range .Values.client.extraVolumes }}
         - name: userconfig-{{ .name }}
@@ -129,6 +131,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
             - name: GOSSIP_KEY
               valueFrom:
@@ -139,8 +145,10 @@ spec:
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://localhost:8501
+            {{- if not .Values.global.tls.enableAutoEncrypt }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
+            {{- end }}
             {{- end }}
             {{- include "consul.extraEnvironmentVars" .Values.client | nindent 12 }}
           command:
@@ -158,12 +166,19 @@ spec:
                 -hcl='leave_on_terminate = true' \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
+                {{- if .Values.global.tls.enableAutoEncrypt }}
+                -hcl='auto_encrypt = {tls = true}' \
+                -hcl="auto_encrypt = {ip_san = [\"$HOST_IP\"]}" \
+                {{- else }}
                 -hcl='cert_file = "/consul/tls/client/tls.crt"' \
                 -hcl='key_file = "/consul/tls/client/tls.key"' \
+                {{- end }}
                 {{- if .Values.global.tls.verify }}
-                -hcl='verify_incoming_rpc = true' \
                 -hcl='verify_outgoing = true' \
+                {{- if not .Values.global.tls.enableAutoEncrypt }}
+                -hcl='verify_incoming_rpc = true' \
                 -hcl='verify_server_hostname = true' \
+                {{- end }}
                 {{- end }}
                 -hcl='ports { https = 8501 }' \
                 {{- if .Values.global.tls.httpsOnly }}
@@ -189,7 +204,7 @@ spec:
                 {{- end }}
                 {{- if (.Values.client.join) and (gt (len .Values.client.join) 0) }}
                 {{- range $value := .Values.client.join }}
-                -retry-join="{{ $value }}" \
+                -retry-join={{ quote $value }} \
                 {{- end }}
                 {{- else }}
                 {{- if .Values.server.enabled }}
@@ -208,9 +223,11 @@ spec:
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
-            - name: tls-client-cert
+            {{- if not .Values.global.tls.enableAutoEncrypt }}
+            - name: consul-client-cert
               mountPath: /consul/tls/client
               readOnly: true
+            {{- end }}
             {{- end }}
             {{- range .Values.client.extraVolumes }}
             - name: userconfig-{{ .name }}
@@ -267,7 +284,7 @@ spec:
                 - |
                   {{- if .Values.global.tls.enabled }}
                   curl \
-                    --cacert /consul/tls/ca/tls.crt \
+                    -k \
                     https://127.0.0.1:8501/v1/status/leader \
                   {{- else }}
                   curl http://127.0.0.1:8500/v1/status/leader \
@@ -294,7 +311,7 @@ spec:
           - name: aclconfig
             mountPath: /consul/aclconfig
       {{- end }}
-      {{- if .Values.global.tls.enabled }}
+      {{- if and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt) }}
       - name: client-tls-init
         image: "{{ default .Values.global.image .Values.client.image }}"
         env:
@@ -316,14 +333,16 @@ spec:
             mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0.pem tls.crt
             mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0-key.pem tls.key
         volumeMounts:
-          - name: tls-client-cert
+          - name: consul-client-cert
             mountPath: /consul/tls/client
           - name: consul-ca-cert
             mountPath: /consul/tls/ca/cert
             readOnly: true
+          {{- if not .Values.global.tls.enableAutoEncrypt }}
           - name: consul-ca-key
             mountPath: /consul/tls/ca/key
             readOnly: true
+          {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.client.nodeSelector }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -145,7 +145,10 @@ spec:
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://localhost:8501
-            {{- if not .Values.global.tls.enableAutoEncrypt }}
+            {{- if .Values.global.tls.enableAutoEncrypt }}
+            - name: CONSUL_HTTP_SSL_VERIFY
+              value: false
+            {{- else }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
-        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+        {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
         {{- if .Values.global.tls.enableAutoEncrypt }}
-        - name: consul-client-ca-cert
+        - name: consul-auto-encrypt-ca-cert
           emptyDir:
             medium: "Memory"
         {{- end }}
@@ -117,7 +117,7 @@ spec:
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt}}
-            - name: consul-client-ca-cert
+            - name: consul-auto-encrypt-ca-cert
             {{- else }}
             - name: consul-ca-cert
             {{- end }}
@@ -143,26 +143,7 @@ spec:
             mountPath: /consul/aclconfig
       {{- end }}
       {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
-      - name: get-consul-client-ca
-        image: {{ .Values.global.imageK8S }}
-        command:
-          - "/bin/sh"
-          - "-ec"
-          - |
-            consul-k8s get-consul-client-ca \
-              -output-file=/consul/tls/client/ca/tls.crt \
-              {{- if .Values.client.join }}
-              -server-addr={{ quote (first .Values.client.join) }} \
-              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
-              {{- else }}
-              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
-              {{- end }}
-              -ca-file=/consul/tls/ca/tls.crt
-        volumeMounts:
-          - name: consul-ca-cert
-            mountPath: /consul/tls/ca
-          - name: consul-client-ca-cert
-            mountPath: /consul/tls/client/ca
+      {{- include "consul.getAutoEncryptClientCA" . | nindent 6 }}
       {{- end }}
       {{- end }}
       {{- if .Values.client.nodeSelector }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -52,6 +52,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
+        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}
@@ -62,6 +63,7 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- end }}
         {{- if .Values.global.tls.enableAutoEncrypt }}
         - name: consul-auto-encrypt-ca-cert
           emptyDir:

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -62,6 +62,11 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- if .Values.global.tls.enableAutoEncrypt }}
+        - name: consul-client-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
         {{- end }}
       {{- end }}
       containers:
@@ -111,13 +116,18 @@ spec:
               mountPath: /consul/aclconfig
             {{- end }}
             {{- if .Values.global.tls.enabled }}
+            {{- if .Values.global.tls.enableAutoEncrypt}}
+            - name: consul-client-ca-cert
+            {{- else }}
             - name: consul-ca-cert
+            {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
-            {{- end }}
           {{- end }}
-      {{- if .Values.global.bootstrapACLs }}
+          {{- end }}
+      {{- if (or .Values.global.bootstrapACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt)) }}
       initContainers:
+      {{- if .Values.global.bootstrapACLs }}
       - name: client-snapshot-agent-acl-init
         image: {{ .Values.global.imageK8S }}
         command:
@@ -131,6 +141,29 @@ spec:
         volumeMounts:
           - name: aclconfig
             mountPath: /consul/aclconfig
+      {{- end }}
+      {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      - name: get-consul-client-ca
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s get-consul-client-ca \
+              -output-file=/consul/tls/client/ca/tls.crt \
+              {{- if .Values.client.join }}
+              -server-addr={{ quote (first .Values.client.join) }} \
+              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
+              {{- else }}
+              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
+              {{- end }}
+              -ca-file=/consul/tls/ca/tls.crt
+        volumeMounts:
+          - name: consul-ca-cert
+            mountPath: /consul/tls/ca
+          - name: consul-client-ca-cert
+            mountPath: /consul/tls/client/ca
+      {{- end }}
       {{- end }}
       {{- if .Values.client.nodeSelector }}
       nodeSelector:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -169,7 +169,7 @@ spec:
             secretName: {{ .Values.connectInject.certs.secretName }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
-        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+        {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -41,6 +41,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.global.tls.enabled }}
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- end }}
             {{- /* A Consul client and ACL token is only necessary for the connect injector if namespaces are enabled */}}
             {{- if .Values.global.enableConsulNamespaces }}
             - name: HOST_IP
@@ -60,15 +64,12 @@ spec:
                   name: "{{ template "consul.fullname" . }}-connect-inject-acl-token"
                   key: "token"
             {{- end }}
-            {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
+              {{- if .Values.global.tls.enabled }}
               value: https://$(HOST_IP):8501
-            - name: CONSUL_CACERT
-              value: /consul/tls/ca/tls.crt
-            {{- else }}
-            - name: CONSUL_HTTP_ADDR
+              {{- else }}
               value: http://$(HOST_IP):8500
-            {{- end }}
+              {{- end }}
             {{- end }}
           command:
             - "/bin/sh"
@@ -88,10 +89,6 @@ spec:
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
                 {{- else if .Values.global.bootstrapACLs }}
                 -acl-auth-method="{{ template "consul.fullname" . }}-k8s-auth-method" \
-                {{- end }}
-
-                {{- if .Values.global.tls.enabled }}
-                -consul-ca-cert=/consul/tls/ca/tls.crt \
                 {{- end }}
                 {{- if .Values.connectInject.centralConfig.enabled }}
                 -enable-central-config=true \
@@ -155,7 +152,11 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.global.tls.enabled }}
+            {{- if .Values.global.tls.enableAutoEncrypt }}
+            - name: consul-client-ca-cert
+            {{- else }}
             - name: consul-ca-cert
+            {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
@@ -178,10 +179,16 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- if .Values.global.tls.enableAutoEncrypt }}
+        - name: consul-client-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
         {{- end }}
       {{- end }}
-      {{- if and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces }}
+      {{- if or (and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
+      {{- if and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces }}
       - name: injector-acl-init
         image: {{ .Values.global.imageK8S }}
         command:
@@ -192,6 +199,29 @@ spec:
               -secret-name="{{ template "consul.fullname" . }}-connect-inject-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="sync"
+      {{- end }}
+      {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      - name: get-consul-client-ca
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s get-consul-client-ca \
+              -output-file=/consul/tls/client/ca/tls.crt \
+              {{- if .Values.client.join }}
+              -server-addr={{ quote (first .Values.client.join) }} \
+              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
+              {{- else }}
+              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
+              {{- end }}
+              -ca-file=/consul/tls/ca/tls.crt
+        volumeMounts:
+          - name: consul-ca-cert
+            mountPath: /consul/tls/ca
+          - name: consul-client-ca-cert
+            mountPath: /consul/tls/client/ca
+      {{- end }}
       {{- end }}
       {{- if .Values.connectInject.nodeSelector }}
       nodeSelector:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -169,6 +169,7 @@ spec:
             secretName: {{ .Values.connectInject.certs.secretName }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
+        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}
@@ -179,6 +180,7 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- end }}
         {{- if .Values.global.tls.enableAutoEncrypt }}
         - name: consul-auto-encrypt-ca-cert
           emptyDir:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -153,7 +153,7 @@ spec:
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt }}
-            - name: consul-client-ca-cert
+            - name: consul-auto-encrypt-ca-cert
             {{- else }}
             - name: consul-ca-cert
             {{- end }}
@@ -180,7 +180,7 @@ spec:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
         {{- if .Values.global.tls.enableAutoEncrypt }}
-        - name: consul-client-ca-cert
+        - name: consul-auto-encrypt-ca-cert
           emptyDir:
             medium: "Memory"
         {{- end }}
@@ -201,26 +201,7 @@ spec:
               -init-type="sync"
       {{- end }}
       {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
-      - name: get-consul-client-ca
-        image: {{ .Values.global.imageK8S }}
-        command:
-          - "/bin/sh"
-          - "-ec"
-          - |
-            consul-k8s get-consul-client-ca \
-              -output-file=/consul/tls/client/ca/tls.crt \
-              {{- if .Values.client.join }}
-              -server-addr={{ quote (first .Values.client.join) }} \
-              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
-              {{- else }}
-              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
-              {{- end }}
-              -ca-file=/consul/tls/ca/tls.crt
-        volumeMounts:
-          - name: consul-ca-cert
-            mountPath: /consul/tls/ca
-          - name: consul-client-ca-cert
-            mountPath: /consul/tls/client/ca
+      {{- include "consul.getAutoEncryptClientCA" . | nindent 6 }}
       {{- end }}
       {{- end }}
       {{- if .Values.connectInject.nodeSelector }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -59,6 +59,11 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- if .Values.global.tls.enableAutoEncrypt }}
+        - name: consul-client-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
         {{- end }}
       {{- if .Values.meshGateway.hostNetwork }}
       hostNetwork: {{ .Values.meshGateway.hostNetwork }}
@@ -79,6 +84,28 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+        {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+        - name: get-consul-client-ca
+          image: {{ .Values.global.imageK8S }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              consul-k8s get-consul-client-ca \
+                -output-file=/consul/tls/client/ca/tls.crt \
+                {{- if .Values.client.join }}
+                -server-addr={{ quote (first .Values.client.join) }} \
+                -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
+                {{- else }}
+                -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
+                {{- end }}
+                -ca-file=/consul/tls/ca/tls.crt
+          volumeMounts:
+            - name: consul-ca-cert
+              mountPath: /consul/tls/ca
+            - name: consul-client-ca-cert
+              mountPath: /consul/tls/client/ca
+        {{- end }}
         {{- if .Values.global.bootstrapACLs }}
         # Wait for secret containing acl token to be ready.
         # Doesn't do anything with it but when the main container starts we
@@ -105,7 +132,11 @@ spec:
           - name: consul-bin
             mountPath: /consul-bin
           {{- if .Values.global.tls.enabled }}
+          {{- if .Values.global.tls.enableAutoEncrypt }}
+          - name: consul-client-ca-cert
+          {{- else }}
           - name: consul-ca-cert
+          {{- end }}
             mountPath: /consul/tls/ca
             readOnly: true
           {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -49,6 +49,7 @@ spec:
         - name: consul-bin
           emptyDir: {}
         {{- if .Values.global.tls.enabled }}
+        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}
@@ -59,6 +60,7 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+        {{- end }}
         {{- if .Values.global.tls.enableAutoEncrypt }}
         - name: consul-auto-encrypt-ca-cert
           emptyDir:

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: consul-bin
           emptyDir: {}
         {{- if .Values.global.tls.enabled }}
-        {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+        {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
         - name: consul-ca-cert
           secret:
             {{- if .Values.global.tls.caCert.secretName }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
         {{- if .Values.global.tls.enableAutoEncrypt }}
-        - name: consul-client-ca-cert
+        - name: consul-auto-encrypt-ca-cert
           emptyDir:
             medium: "Memory"
         {{- end }}
@@ -85,26 +85,7 @@ spec:
           - name: consul-bin
             mountPath: /consul-bin
         {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
-        - name: get-consul-client-ca
-          image: {{ .Values.global.imageK8S }}
-          command:
-            - "/bin/sh"
-            - "-ec"
-            - |
-              consul-k8s get-consul-client-ca \
-                -output-file=/consul/tls/client/ca/tls.crt \
-                {{- if .Values.client.join }}
-                -server-addr={{ quote (first .Values.client.join) }} \
-                -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
-                {{- else }}
-                -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
-                {{- end }}
-                -ca-file=/consul/tls/ca/tls.crt
-          volumeMounts:
-            - name: consul-ca-cert
-              mountPath: /consul/tls/ca
-            - name: consul-client-ca-cert
-              mountPath: /consul/tls/client/ca
+        {{- include "consul.getAutoEncryptClientCA" . | nindent 8 }}
         {{- end }}
         {{- if .Values.global.bootstrapACLs }}
         # Wait for secret containing acl token to be ready.
@@ -133,7 +114,7 @@ spec:
             mountPath: /consul-bin
           {{- if .Values.global.tls.enabled }}
           {{- if .Values.global.tls.enableAutoEncrypt }}
-          - name: consul-client-ca-cert
+          - name: consul-auto-encrypt-ca-cert
           {{- else }}
           - name: consul-ca-cert
           {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
-        - name: tls-server-cert
+        - name: consul-server-cert
           secret:
             secretName: {{ template "consul.fullname" . }}-server-cert
         {{- end }}
@@ -125,6 +125,9 @@ spec:
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
                 -hcl='cert_file = "/consul/tls/server/tls.crt"' \
                 -hcl='key_file = "/consul/tls/server/tls.key"' \
+                {{- if .Values.global.tls.enableAutoEncrypt }}
+                -hcl='auto_encrypt = {allow_tls = true}' \
+                {{- end }}
                 {{- if .Values.global.tls.verify }}
                 -hcl='verify_incoming_rpc = true' \
                 -hcl='verify_outgoing = true' \
@@ -167,7 +170,7 @@ spec:
             - name: consul-ca-cert
               mountPath: /consul/tls/ca/
               readOnly: true
-            - name: tls-server-cert
+            - name: consul-server-cert
               mountPath: /consul/tls/server
               readOnly: true
             {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
             path: tls.crt
       {{- if .Values.global.tls.enableAutoEncrypt }}
-      - name: consul-client-ca-cert
+      - name: consul-auto-encrypt-ca-cert
         emptyDir:
           medium: "Memory"
       {{- end }}
@@ -85,7 +85,7 @@ spec:
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             {{- if .Values.global.tls.enableAutoEncrypt }}
-            - name: consul-client-ca-cert
+            - name: consul-auto-encrypt-ca-cert
             {{- else }}
             - name: consul-ca-cert
             {{- end }}
@@ -189,26 +189,7 @@ spec:
               -init-type="sync"
       {{- end }}
       {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
-      - name: get-consul-client-ca
-        image: {{ .Values.global.imageK8S }}
-        command:
-          - "/bin/sh"
-          - "-ec"
-          - |
-            consul-k8s get-consul-client-ca \
-              -output-file=/consul/tls/client/ca/tls.crt \
-              {{- if .Values.client.join }}
-              -server-addr={{ quote (first .Values.client.join) }} \
-              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
-              {{- else }}
-              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
-              {{- end }}
-              -ca-file=/consul/tls/ca/tls.crt
-        volumeMounts:
-          - name: consul-ca-cert
-            mountPath: /consul/tls/ca
-          - name: consul-client-ca-cert
-            mountPath: /consul/tls/client/ca
+      {{- include "consul.getAutoEncryptClientCA" . | nindent 6 }}
       {{- end }}
       {{- end }}
       {{- if .Values.syncCatalog.nodeSelector }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
       {{- if .Values.global.tls.enabled }}
       volumes:
-      {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+      {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
       - name: consul-ca-cert
         secret:
           {{- if .Values.global.tls.caCert.secretName }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
       {{- if .Values.global.tls.enabled }}
       volumes:
+      {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
       - name: consul-ca-cert
         secret:
           {{- if .Values.global.tls.caCert.secretName }}
@@ -41,6 +42,7 @@ spec:
           items:
           - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
             path: tls.crt
+      {{- end }}
       {{- if .Values.global.tls.enableAutoEncrypt }}
       - name: consul-auto-encrypt-ca-cert
         emptyDir:

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -41,6 +41,11 @@ spec:
           items:
           - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
             path: tls.crt
+      {{- if .Values.global.tls.enableAutoEncrypt }}
+      - name: consul-client-ca-cert
+        emptyDir:
+          medium: "Memory"
+      {{- end }}
       {{- end }}
       containers:
         - name: consul-sync-catalog
@@ -79,7 +84,11 @@ spec:
             {{- end }}
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
+            {{- if .Values.global.tls.enableAutoEncrypt }}
+            - name: consul-client-ca-cert
+            {{- else }}
             - name: consul-ca-cert
+            {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
           {{- end }}
@@ -165,8 +174,9 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
-      {{- if .Values.global.bootstrapACLs }}
+      {{- if or .Values.global.bootstrapACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
+      {{- if .Values.global.bootstrapACLs }}
       - name: sync-acl-init
         image: {{ .Values.global.imageK8S }}
         command:
@@ -177,6 +187,29 @@ spec:
               -secret-name="{{ template "consul.fullname" . }}-catalog-sync-acl-token" \
               -k8s-namespace={{ .Release.Namespace }} \
               -init-type="sync"
+      {{- end }}
+      {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      - name: get-consul-client-ca
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s get-consul-client-ca \
+              -output-file=/consul/tls/client/ca/tls.crt \
+              {{- if .Values.client.join }}
+              -server-addr={{ quote (first .Values.client.join) }} \
+              -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
+              {{- else }}
+              -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
+              {{- end }}
+              -ca-file=/consul/tls/ca/tls.crt
+        volumeMounts:
+          - name: consul-ca-cert
+            mountPath: /consul/tls/ca
+          - name: consul-client-ca-cert
+            mountPath: /consul/tls/client/ca
+      {{- end }}
       {{- end }}
       {{- if .Values.syncCatalog.nodeSelector }}
       nodeSelector:

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   {{- if .Values.global.tls.enabled }}
   volumes:
-    {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
+    {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
     - name: consul-ca-cert
       secret:
         {{- if .Values.global.tls.caCert.secretName }}

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   {{- if .Values.global.tls.enabled }}
   volumes:
+    {{- if not (and .Values.externalServer.enabled .Values.externalServer.https.useSystemRoots) }}
     - name: consul-ca-cert
       secret:
         {{- if .Values.global.tls.caCert.secretName }}
@@ -24,6 +25,7 @@ spec:
         items:
         - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
           path: tls.crt
+    {{- end }}
     - name: consul-auto-encrypt-ca-cert
       emptyDir:
         medium: "Memory"

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -24,32 +24,13 @@ spec:
         items:
         - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
           path: tls.crt
-    - name: consul-client-ca-cert
+    - name: consul-auto-encrypt-ca-cert
       emptyDir:
         medium: "Memory"
   {{- end }}
   {{- if and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt }}
   initContainers:
-  - name: get-consul-client-ca
-    image: {{ .Values.global.imageK8S }}
-    command:
-      - "/bin/sh"
-      - "-ec"
-      - |
-        consul-k8s get-consul-client-ca \
-          -output-file=/consul/tls/client/ca/tls.crt \
-          {{- if .Values.client.join }}
-          -server-addr={{ quote (first .Values.client.join) }} \
-          -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
-          {{- else }}
-          -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
-          {{- end }}
-          -ca-file=/consul/tls/ca/tls.crt
-    volumeMounts:
-      - name: consul-ca-cert
-        mountPath: /consul/tls/ca
-      - name: consul-client-ca-cert
-        mountPath: /consul/tls/client/ca
+  {{- include "consul.getAutoEncryptClientCA" . | nindent 2 }}
   {{- end }}
   containers:
     - name: consul-test
@@ -71,7 +52,7 @@ spec:
       {{- if .Values.global.tls.enabled }}
       volumeMounts:
       {{- if .Values.global.tls.enableAutoEncrypt }}
-      - name: consul-client-ca-cert
+      - name: consul-auto-encrypt-ca-cert
         mountPath: /consul/tls/ca
         readOnly: true
       {{- else }}

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   {{- if .Values.global.tls.enabled }}
   volumes:
-    - name: tls-ca-cert
+    - name: consul-ca-cert
       secret:
         {{- if .Values.global.tls.caCert.secretName }}
         secretName: {{ .Values.global.tls.caCert.secretName }}
@@ -24,6 +24,32 @@ spec:
         items:
         - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
           path: tls.crt
+    - name: consul-client-ca-cert
+      emptyDir:
+        medium: "Memory"
+  {{- end }}
+  {{- if and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt }}
+  initContainers:
+  - name: get-consul-client-ca
+    image: {{ .Values.global.imageK8S }}
+    command:
+      - "/bin/sh"
+      - "-ec"
+      - |
+        consul-k8s get-consul-client-ca \
+          -output-file=/consul/tls/client/ca/tls.crt \
+          {{- if .Values.client.join }}
+          -server-addr={{ quote (first .Values.client.join) }} \
+          -tls-server-name=server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }} \
+          {{- else }}
+          -server-addr=https://{{ template "consul.fullname" . }}-server:8501 \
+          {{- end }}
+          -ca-file=/consul/tls/ca/tls.crt
+    volumeMounts:
+      - name: consul-ca-cert
+        mountPath: /consul/tls/ca
+      - name: consul-client-ca-cert
+        mountPath: /consul/tls/client/ca
   {{- end }}
   containers:
     - name: consul-test
@@ -44,9 +70,15 @@ spec:
         {{- end }}
       {{- if .Values.global.tls.enabled }}
       volumeMounts:
-        - name: tls-ca-cert
-          mountPath: /consul/tls/ca
-          readOnly: true
+      {{- if .Values.global.tls.enableAutoEncrypt }}
+      - name: consul-client-ca-cert
+        mountPath: /consul/tls/ca
+        readOnly: true
+      {{- else }}
+      - name: consul-ca-cert
+        mountPath: /consul/tls/ca
+        readOnly: true
+      {{- end }}
       {{- end }}
       command:
         - "/bin/sh"

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -724,15 +724,15 @@ load _helpers
   [ "${actual}" == "" ]
 }
 
-@test "client/DaemonSet: doesn't set CONSUL_CACERT environment variable when global.tls.enabled and global.tls.enableAutoEncrypt=true" {
+@test "client/DaemonSet: sets CONSUL_HTTP_SSL_VERIFY environment variable to false when global.tls.enabled and global.tls.enableAutoEncrypt=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_CACERT")' | tee /dev/stderr)
-  [ "${actual}" == "" ]
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_SSL_VERIFY") | .value' | tee /dev/stderr)
+  [ "${actual}" == "false" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -270,7 +270,10 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "client/SnapshotAgentDeployment: consul-client-ca-cert volume is added whenTLS with auto-encrypt is enabled" {
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "client/SnapshotAgentDeployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
@@ -278,11 +281,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "client/SnapshotAgentDeployment: consul-client-ca-cert volumeMount is added whenTLS with auto-encrypt is enabled" {
+@test "client/SnapshotAgentDeployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
@@ -290,11 +293,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "client/SnapshotAgentDeployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+@test "client/SnapshotAgentDeployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
@@ -302,7 +305,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -321,3 +321,17 @@ load _helpers
       yq '.spec.template.spec.initContainers | length == 2' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "client/SnapshotAgentDeployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=foo.com' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -322,15 +322,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "client/SnapshotAgentDeployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+@test "client/SnapshotAgentDeployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.https.useSystemRoots=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
       --set 'global.tls.enabled=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=foo.com' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -433,7 +433,10 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "connectInject/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "connectInject/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
@@ -441,11 +444,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+@test "connectInject/Deployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
@@ -453,11 +456,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+@test "connectInject/Deployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
@@ -465,7 +468,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -486,6 +486,21 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=foo.com' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
 #--------------------------------------------------------------------
 # k8sAllowNamespaces & k8sDenyNamespaces
 

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -433,6 +433,56 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
+@test "connectInject/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: adds both init containers when TLS with auto-encrypt and ACLs + namespaces are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers | length == 2' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # k8sAllowNamespaces & k8sDenyNamespaces
 

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -486,16 +486,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+@test "connectInject/Deployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.https.useSystemRoots=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=foo.com' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -110,23 +110,151 @@ load _helpers
 
 @test "helper/consul.getAutoEncryptClientCA: get-auto-encrypt-client-ca uses server's stateful set address by default" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local command=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-server-addr=https://release-name-consul-server:8501")' | tee /dev/stderr)
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
+
+  # check server address
+  actual=$(echo $command | jq ' . | contains("-server-addr=release-name-consul-server")')
+  [ "${actual}" = "true" ]
+
+  # check server port
+  actual=$(echo $command | jq ' . | contains("-server-port=8501")')
+  [ "${actual}" = "true" ]
+
+  # check server's CA cert
+  actual=$(echo $command | jq ' . | contains("-ca-file=/consul/tls/ca/tls.crt")')
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: get-auto-encrypt-client-ca uses client.join value when provided" {
+@test "helper/consul.getAutoEncryptClientCA: uses client.join string if externalServer.enabled is true but the address is not provided" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'client.join[0]=consul-server.com' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
+
+  # check server address
+  actual=$(echo $command | jq ' . | contains("-server-addr=\"consul-server.com\"")')
+  [ "${actual}" = "true" ]
+
+  # check the default server port is 443 if not provided
+  actual=$(echo $command | jq ' . | contains("-server-port=443")')
+  [ "${actual}" = "true" ]
+
+  # check server's CA cert
+  actual=$(echo $command | jq ' . | contains("-ca-file=/consul/tls/ca/tls.crt")')
+  [ "${actual}" = "true" ]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: can set the provided server address if externalServer.enabled is true" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=consul.io' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
+
+  # check server address
+  actual=$(echo $command | jq ' . | contains("-server-addr=consul.io")')
+  [ "${actual}" = "true" ]
+
+  # check the default server port is 443 if not provided
+  actual=$(echo $command | jq ' . | contains("-server-port=443")')
+  [ "${actual}" = "true" ]
+
+  # check server's CA cert
+  actual=$(echo $command | jq ' . | contains("-ca-file=/consul/tls/ca/tls.crt")')
+  [ "${actual}" = "true" ]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: fails if externalServer.enabled is true but neither client.join nor externalServer.https.address are provided" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "either client.join or externalServer.https.address must be set if externalServer.enabled is true" ]]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: can set the provided port if externalServer.enabled is true" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=consul.io' \
+      --set 'externalServer.https.port=8501' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
+
+  # check server address
+  actual=$(echo $command | jq ' . | contains("-server-addr=consul.io")')
+  [ "${actual}" = "true" ]
+
+  # check the default server port is 443 if not provided
+  actual=$(echo $command | jq ' . | contains("-server-port=8501")')
+  [ "${actual}" = "true" ]
+
+  # check server's CA cert
+  actual=$(echo $command | jq ' . | contains("-ca-file=/consul/tls/ca/tls.crt")')
+  [ "${actual}" = "true" ]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: can set TLS server name if externalServer.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'client.join[0]=consul-server.com' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=consul.io' \
+      --set 'externalServer.https.tlsServerName=custom-server-name' \
       . | tee /dev/stderr |
-      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-server-addr=\"consul-server.com\"")' | tee /dev/stderr)
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-tls-server-name=custom-server-name")' | tee /dev/stderr)
+
   [ "${actual}" = "true" ]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: doesn't provide the CA if externalServer.enabled is true and externalServer.useSystemRoots is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=consul.io' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-ca-file=/consul/tls/ca/tls.crt")' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "helper/consul.getAutoEncryptClientCA: doesn't mount the consul-ca-cert volume if externalServer.enabled is true and externalServer.useSystemRoots is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=consul.io' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").volumeMounts[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  [ "${actual}" = "" ]
 }

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -130,13 +130,13 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: uses client.join string if externalServer.enabled is true but the address is not provided" {
+@test "helper/consul.getAutoEncryptClientCA: uses client.join string if externalServers.enabled is true but the address is not provided" {
   cd `chart_dir`
   local command=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
+      --set 'externalServers.enabled=true' \
       --set 'client.join[0]=consul-server.com' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
@@ -154,14 +154,14 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: can set the provided server address if externalServer.enabled is true" {
+@test "helper/consul.getAutoEncryptClientCA: can set the provided server address if externalServers.enabled is true" {
   cd `chart_dir`
   local command=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=consul.io' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=consul.io' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
 
@@ -178,26 +178,26 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: fails if externalServer.enabled is true but neither client.join nor externalServer.https.address are provided" {
+@test "helper/consul.getAutoEncryptClientCA: fails if externalServers.enabled is true but neither client.join nor externalServers.https.address are provided" {
   cd `chart_dir`
   run helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' .
+      --set 'externalServers.enabled=true' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "either client.join or externalServer.https.address must be set if externalServer.enabled is true" ]]
+  [[ "$output" =~ "either client.join or externalServers.https.address must be set if externalServers.enabled is true" ]]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: can set the provided port if externalServer.enabled is true" {
+@test "helper/consul.getAutoEncryptClientCA: can set the provided port if externalServers.enabled is true" {
   cd `chart_dir`
   local command=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=consul.io' \
-      --set 'externalServer.https.port=8501' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=consul.io' \
+      --set 'externalServers.https.port=8501' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
 
@@ -214,45 +214,45 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: can set TLS server name if externalServer.enabled is true" {
+@test "helper/consul.getAutoEncryptClientCA: can set TLS server name if externalServers.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=consul.io' \
-      --set 'externalServer.https.tlsServerName=custom-server-name' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=consul.io' \
+      --set 'externalServers.https.tlsServerName=custom-server-name' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-tls-server-name=custom-server-name")' | tee /dev/stderr)
 
   [ "${actual}" = "true" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: doesn't provide the CA if externalServer.enabled is true and externalServer.useSystemRoots is true" {
+@test "helper/consul.getAutoEncryptClientCA: doesn't provide the CA if externalServers.enabled is true and externalServers.useSystemRoots is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=consul.io' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=consul.io' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ") | contains("-ca-file=/consul/tls/ca/tls.crt")' | tee /dev/stderr)
 
   [ "${actual}" = "false" ]
 }
 
-@test "helper/consul.getAutoEncryptClientCA: doesn't mount the consul-ca-cert volume if externalServer.enabled is true and externalServer.useSystemRoots is true" {
+@test "helper/consul.getAutoEncryptClientCA: doesn't mount the consul-ca-cert volume if externalServers.enabled is true and externalServers.useSystemRoots is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=consul.io' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=consul.io' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").volumeMounts[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
 

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -696,3 +696,19 @@ key2: value2' \
       yq '.spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "meshGateway/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=foo.com' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -655,7 +655,10 @@ key2: value2' \
   [ "${actual}" = "key" ]
 }
 
-@test "meshGateway/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "meshGateway/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -664,11 +667,11 @@ key2: value2' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "meshGateway/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+@test "meshGateway/Deployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -677,11 +680,11 @@ key2: value2' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "meshGateway/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+@test "meshGateway/Deployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -690,6 +693,6 @@ key2: value2' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -654,3 +654,42 @@ key2: value2' \
   actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
   [ "${actual}" = "key" ]
 }
+
+@test "meshGateway/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -697,7 +697,7 @@ key2: value2' \
   [ "${actual}" = "true" ]
 }
 
-@test "meshGateway/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+@test "meshGateway/Deployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.https.useSystemRoots=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -705,9 +705,9 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=foo.com' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -662,3 +662,17 @@ load _helpers
   actual=$(echo $ca_cert_volume | jq -r '.secret.items[0].key' | tee /dev/stderr)
   [ "${actual}" = "key" ]
 }
+
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "server/StatefulSet: enables auto-encrypt for the servers when global.tls.enableAutoEncrypt is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("auto_encrypt = {allow_tls = true}")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -479,7 +479,7 @@ load _helpers
       -x templates/server-statefulset.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[] | select(.name == "tls-server-cert")' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-server-cert")' | tee /dev/stderr)
   [ "${actual}" != "" ]
 }
 
@@ -499,7 +499,7 @@ load _helpers
       -x templates/server-statefulset.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "tls-server-cert")' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-server-cert")' | tee /dev/stderr)
   [ "${actual}" != "" ]
 }
 

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -439,7 +439,7 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "syncCatalog/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+@test "syncCatalog/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
@@ -447,11 +447,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+@test "syncCatalog/Deployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
@@ -459,11 +459,11 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+@test "syncCatalog/Deployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
@@ -471,7 +471,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -439,6 +439,55 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
+@test "syncCatalog/Deployment: consul-client-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/Deployment: consul-client-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-client-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/Deployment: get-consul-client-ca init container is created when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[] | select(.name == "get-consul-client-ca") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/Deployment: adds both init containers when TLS with auto-encrypt and ACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.bootstrapACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers | length == 2' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # k8sAllowNamespaces & k8sDenyNamespaces
 

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -488,6 +488,21 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "syncCatalog/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServer.enabled=true' \
+      --set 'externalServer.https.address=foo.com' \
+      --set 'externalServer.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
 #--------------------------------------------------------------------
 # k8sAllowNamespaces & k8sDenyNamespaces
 

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -488,16 +488,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/Deployment: consul-ca-cert volume is not added if externalServer.enabled=true and externalServer.https.useSystemRoots=true" {
+@test "syncCatalog/Deployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.https.useSystemRoots=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServer.enabled=true' \
-      --set 'externalServer.https.address=foo.com' \
-      --set 'externalServer.https.useSystemRoots=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      --set 'externalServers.https.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]

--- a/values.yaml
+++ b/values.yaml
@@ -92,6 +92,7 @@ global:
     # clients and servers.
     # It also switches consul-k8s components to retrieve the CA
     # from the servers via the API.
+    # Requires Consul 1.7.1+ and consul-k8s 0.13.0
     enableAutoEncrypt: false
 
     # serverAdditionalDNSSANs is a list of additional DNS names to

--- a/values.yaml
+++ b/values.yaml
@@ -261,24 +261,23 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
-
 # Add configuration for Consul servers running externally,
 # i.e. outside of Kubernetes.
 # This information is required if Consul servers are running
 # outside of k8s and you’re setting global.tls.enableAutoEncrypt to true.
-externalServer:
+externalServers:
   enabled: false
 
   # HTTPS configuration for external servers.
   # Note: HTTP connections to the servers are
   # not supported.
   https:
-    # IP, DNS name, or Cloud auto-join string
-    # pointing to the external Consul servers.
-    # Note that if you’re providing the cloud
-    # auto-join string and multiple addresses
-    # can be returned, only the first address
-    # will be used.
+    # IP, DNS name, or Cloud auto-join string pointing to the external Consul servers.
+    # Note that if you’re providing the cloud auto-join string and multiple addresses
+    # can be returned, only the first address will be used.
+    # This value is required only if you would like to use
+    # a different server address from the one specified
+    # in the client.join property.
     address: null
 
     # The HTTPS port of the server.

--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,12 @@ global:
   tls:
     enabled: false
 
+    # enableAutoEncrypt turns on the auto-encrypt feature on
+    # clients and servers.
+    # It also switches consul-k8s components to retrieve the CA
+    # from the servers via the API.
+    enableAutoEncrypt: false
+
     # serverAdditionalDNSSANs is a list of additional DNS names to
     # set as Subject Alternative Names (SANs) in the server certificate.
     # This is useful when you need to access the Consul server(s) externally,

--- a/values.yaml
+++ b/values.yaml
@@ -260,6 +260,41 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+
+# Add configuration for Consul servers running externally,
+# i.e. outside of Kubernetes.
+# This information is required if Consul servers are running
+# outside of k8s and you’re setting global.tls.enableAutoEncrypt to true.
+externalServer:
+  enabled: false
+
+  # HTTPS configuration for external servers.
+  # Note: HTTP connections to the servers are
+  # not supported.
+  https:
+    # IP, DNS name, or Cloud auto-join string
+    # pointing to the external Consul servers.
+    # Note that if you’re providing the cloud
+    # auto-join string and multiple addresses
+    # can be returned, only the first address
+    # will be used.
+    address: null
+
+    # The HTTPS port of the server.
+    port: 443
+
+    # tlsServerName is the server name to use as the SNI
+    # host header when connecting with HTTPS.
+    # This property is useful in case ‘externalServers.https.address’
+    # is not or can not be included in the server certificate’s SANs.
+    tlsServerName: null
+
+    # If true, the Helm chart will ignore the CA set in
+    # global.tls.caCert and will rely on the container's
+    # system CAs for TLS verification when talking to Consul servers.
+    # Otherwise, the chart will use global.tls.caCert.
+    useSystemRoots: false
+
 # Client, when enabled, configures Consul clients to run on every node
 # within the Kube cluster. The current deployment model follows a traditional
 # DC where a single agent is deployed per node.


### PR DESCRIPTION
This PR makes the following changes:
- Adds a new property `global.tls.enableAutoEncrypt`
- Setting the `global.tls.enableAutoEncrypt` will enable auto-encrypt for clients and servers
- consul-k8s components that need to talk to the clients (connect injector,
mesh gateway, sync catalog, and snapshot agent) now get the CA through the API from the Consul server before they start.

Requires hashicorp/consul-k8s#211