### PR TITLE
Add custom annotation for service

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -15,6 +15,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
+    {{- if .Values.server.service.annotations }}
+    {{ tpl .Values.server.service.annotations . | nindent 4 | trim }}
+    {{- end }}
     # This must be set in addition to publishNotReadyAddresses due
     # to an open issue where it may not work:
     # https://github.com/kubernetes/kubernetes/issues/58662

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -103,3 +103,25 @@ load _helpers
       yq -r '.spec.ports[] | select(.name == "http") | .port' | tee /dev/stderr)
   [ "${actual}" == "" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "server/Service: one annotation by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/Service: can set annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml  \
+      --set 'server.service.annotations=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -245,6 +245,11 @@ server:
   # the annotations to apply to the server pods
   annotations: null
 
+  service:
+    # This should be a multi-line string mapping directly to the a map of
+    # the annotations to apply to the server service
+    annotations: null
+
   # extraEnvVars is a list of extra environment variables to set with the stateful set. These could be
   # used to include proxy settings required for cloud auto-join feature,
   # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure


### PR DESCRIPTION
This will allow users of [External DNS](https://github.com/kubernetes-sigs/external-dns) to create a record with the Pod IP of the servers.