### PR TITLE
Remove meshGateway.consulServiceName value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+BREAKING CHANGES:
+
+* `meshGateway.consulServiceName` is no longer supported. If you have been
+  setting this name, on `helm upgrade` the mesh gateways will be redeployed
+  with the name `mesh-gateway` instead of the name you set.
+  This change was made because some features were not supported when this value
+  was set. If you were using this value please open an issue describing
+  your use-case and we can re-evaluate its removal.
+
 ## 0.17.0 (Feb 21, 2020)
 
 BREAKING CHANGES:

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -161,10 +161,6 @@ spec:
                 {{- else if .Values.meshGateway.wanAddress.useNodeIP }}
                 -wan-address="${HOST_IP}:{{ .Values.meshGateway.wanAddress.port }}" \
                 {{- end }}
-                {{- if and .Values.meshGateway.consulServiceName }}
-                {{- if and .Values.global.bootstrapACLs (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end }}
-                -service={{ .Values.meshGateway.consulServiceName | quote }} \
-                {{- end }}
           {{- if .Values.meshGateway.enableHealthChecks }}
           livenessProbe:
             tcpSocket:
@@ -192,7 +188,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ default "mesh-gateway" .Values.meshGateway.consulServiceName }}\""]
+                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"mesh-gateway\""]
 
       {{- if .Values.meshGateway.priorityClassName }}
       priorityClassName: {{ .Values.meshGateway.priorityClassName | quote }}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -432,54 +432,6 @@ key2: value2' \
 }
 
 #--------------------------------------------------------------------
-# consulServiceName
-
-@test "meshGateway/Deployment: fails if consulServiceName is set and bootstrapACLs is true" {
-  cd `chart_dir`
-  run helm template \
-      -x templates/mesh-gateway-deployment.yaml  \
-      --set 'meshGateway.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'meshGateway.consulServiceName=override' \
-      --set 'global.bootstrapACLs=true' \
-      .
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" ]]
-}
-
-@test "meshGateway/Deployment: does not fail if consulServiceName is set to mesh-gateway and bootstrapACLs is true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/mesh-gateway-deployment.yaml  \
-      --set 'meshGateway.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'meshGateway.consulServiceName=mesh-gateway' \
-      --set 'global.bootstrapACLs=true' \
-      . | tee /dev/stderr \
-      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
-
-  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ '-service="mesh-gateway"' ]]
-  [[ $(echo "${actual}" | yq -r '.lifecycle.preStop.exec.command' ) =~ '-id=\"mesh-gateway\"' ]]
-}
-
-@test "meshGateway/Deployment: consulServiceName can be set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/mesh-gateway-deployment.yaml  \
-      --set 'meshGateway.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'meshGateway.consulServiceName=overridden' \
-      . | tee /dev/stderr \
-      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
-
-  [[ $(echo "${actual}" | yq -r '.command[2]' ) =~ '-service="overridden"' ]]
-  [[ $(echo "${actual}" | yq -r '.lifecycle.preStop.exec.command' ) =~ '-id=\"overridden\"' ]]
-}
-
-#--------------------------------------------------------------------
 # healthchecks
 
 @test "meshGateway/Deployment: healthchecks are on by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -817,11 +817,6 @@ meshGateway:
   # dnsPolicy to use.
   dnsPolicy: null
 
-  # Override the default 'mesh-gateway' service name registered in Consul.
-  # Cannot be used if bootstrapACLs is true since the ACL token generated
-  # is only for the name 'mesh-gateway'.
-  consulServiceName: ""
-
   # Port that the gateway will run on inside the container.
   containerPort: 443
 


### PR DESCRIPTION
The value was not supported when ACLs were enabled and we didn't see the
need for it at this time.