### PR TITLE
Deprecate bootstrapACLs for acls.enabled

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -20,7 +20,7 @@ To learn more about the release if you are using Helm 3, run:
   $ helm get all {{ .Release.Name }}
 
 
-{{- if (and .Values.global.bootstrapACLs (gt (len .Values.server.extraConfig) 3)) }}
+{{- if (and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (gt (len .Values.server.extraConfig) 3)) }}
 Warning: Defining server extraConfig potentially disrupts the automatic ACL
          bootstrapping required settings. This may cause future issues if
          there are conflicts.

--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -18,7 +18,7 @@ rules:
     verbs:
     - use
 {{- end }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -105,7 +105,7 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
-        {{- if .Values.global.bootstrapACLs }}
+        {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
         - name: aclconfig
           emptyDir: {}
         {{- end }}
@@ -197,7 +197,7 @@ spec:
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
                 {{- end }}
-                {{- if .Values.global.bootstrapACLs}}
+                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
@@ -237,7 +237,7 @@ spec:
               readOnly: true
               mountPath: /consul/userconfig/{{ .name }}
             {{- end }}
-            {{- if .Values.global.bootstrapACLs}}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- end }}
@@ -297,9 +297,9 @@ spec:
           resources:
             {{ tpl .Values.client.resources . | nindent 12 | trim }}
           {{- end }}
-      {{- if (or .Values.global.bootstrapACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:
-      {{- if .Values.global.bootstrapACLs }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/client-snapshot-agent-clusterrole.yaml
+++ b/templates/client-snapshot-agent-clusterrole.yaml
@@ -9,11 +9,8 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if not (or .Values.global.enablePodSecurityPolicies .Values.global.bootstrapACLs) }}
-rules: []
-{{- else }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies) }}
 rules:
-{{- end }}
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
@@ -22,7 +19,7 @@ rules:
     verbs:
     - use
 {{- end }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   - apiGroups: [""]
     resources:
       - secrets
@@ -32,5 +29,7 @@ rules:
       - get
 {{- end }}
 {{- else }}
+rules: []
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
-      {{- if (or .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey)) }}
       volumes:
         {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
         - name: snapshot-config
@@ -47,7 +47,7 @@ spec:
             - key: {{ .Values.client.snapshotAgent.configSecret.secretKey }}
               path: snapshot-config.json
         {{- end }}
-        {{- if .Values.global.bootstrapACLs }}
+        {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
         - name: aclconfig
           emptyDir: {}
         {{- end }}
@@ -88,7 +88,7 @@ spec:
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
             {{- end }}
-            {{- if .Values.global.bootstrapACLs }}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -103,17 +103,17 @@ spec:
                 {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
                 -config-dir=/consul/config \
                 {{- end }}
-                {{- if .Values.global.bootstrapACLs}}
+                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
-          {{- if (or .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) ) }}
+          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) ) }}
           volumeMounts:
             {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
             - name: snapshot-config
               readOnly: true
               mountPath: /consul/config
             {{- end }}
-            {{- if .Values.global.bootstrapACLs}}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- end }}
@@ -127,9 +127,9 @@ spec:
               readOnly: true
           {{- end }}
           {{- end }}
-      {{- if (or .Values.global.bootstrapACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt)) }}
+      {{- if (or (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt)) }}
       initContainers:
-      {{- if .Values.global.bootstrapACLs }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
       - name: client-snapshot-agent-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/templates/connect-inject-authmethod-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
   verbs:
   - use
 {{- end }}
-{{- if and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces }}
+{{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces }}
 - apiGroups: [""]
   resources:
     - secrets

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connectInject.aclInjectToken.secretName }}
                   key: {{ .Values.connectInject.aclInjectToken.secretKey }}
-            {{- else if .Values.global.bootstrapACLs }}
+            {{- else if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -87,7 +87,7 @@ spec:
                 -listen=:8080 \
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
-                {{- else if .Values.global.bootstrapACLs }}
+                {{- else if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 -acl-auth-method="{{ template "consul.fullname" . }}-k8s-auth-method" \
                 {{- end }}
                 {{- if .Values.connectInject.centralConfig.enabled }}
@@ -113,7 +113,7 @@ spec:
                 -k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \
                 {{- end }}
                 {{- end }}
-                {{- if .Values.global.bootstrapACLs }}
+                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 -consul-cross-namespace-acl-policy=cross-namespace-policy \
                 {{- end }}
                 {{- end }}
@@ -188,9 +188,9 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if or (and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or (and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
-      {{- if and .Values.global.bootstrapACLs .Values.global.enableConsulNamespaces }}
+      {{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces }}
       - name: injector-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
+{{- if or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
 rules:
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -65,7 +65,7 @@ spec:
             - name:  CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end}}
-            {{- if .Values.global.bootstrapACLs }}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -99,7 +99,7 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
           {{- end }}
-      {{- if .Values.global.bootstrapACLs }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
       initContainers:
       - name: ent-license-acl-init
         image: {{ .Values.global.imageK8S }}

--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
-{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies (eq .Values.meshGateway.wanAddress.source "Service") }}
+{{- if or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies (eq .Values.meshGateway.wanAddress.source "Service") }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -19,7 +19,7 @@ rules:
     verbs:
       - use
 {{- end }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.meshGateway.enabled }}
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
-{{- if and .Values.global.bootstrapACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
+{{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1
@@ -118,7 +118,7 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
-                {{- if .Values.global.bootstrapACLs }}
+                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 consul-k8s acl-init \
                   -secret-name="{{ template "consul.fullname" . }}-mesh-gateway-acl-token" \
                   -k8s-namespace={{ .Release.Namespace }} \
@@ -189,7 +189,7 @@ spec:
                 EOF
 
                 consul services register \
-                  {{- if .Values.global.bootstrapACLs }}
+                  {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                   -token-file=/consul/service/acl-token \
                   {{- end }}
                   /consul/service/service.hcl
@@ -235,7 +235,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             {{- end }}
-            {{- if .Values.global.bootstrapACLs }}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -325,7 +325,7 @@ spec:
             - lifecycle-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/bin/consul
-            {{- if .Values.global.bootstrapACLs }}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - -token-file=/consul/service/acl-token
             {{- end }}
       {{- if .Values.meshGateway.priorityClassName }}

--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* See reason for this in server-acl-init-job.yaml */ -}}
 {{- if eq (int .Values.server.updatePartition) 0 }}
 # This job deletes the server-acl-init job once it completes successfully.

--- a/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
     the rollout is finished (which won't happen until the partition is 0).

--- a/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
-  {{- if .Values.global.bootstrapACLs }}
+  {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   acl-config.json: |-
     {
       "acl": {

--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -29,7 +29,7 @@ rules:
       - nodes
     verbs:
       - get
-{{- if .Values.global.bootstrapACLs }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -68,7 +68,7 @@ spec:
                   name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
                   key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
             {{- end }}
-            {{- if .Values.global.bootstrapACLs }}
+            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -152,7 +152,7 @@ spec:
                 -k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
                 {{- end }}
                 {{- end }}
-                {{- if .Values.global.bootstrapACLs }}
+                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                 -consul-cross-namespace-acl-policy=cross-namespace-policy \
                 {{- end }}
                 {{- end }}
@@ -176,9 +176,9 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
-      {{- if or .Values.global.bootstrapACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
-      {{- if .Values.global.bootstrapACLs }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
       - name: sync-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/test/unit/client-clusterrole.bats
+++ b/test/unit/client-clusterrole.bats
@@ -78,14 +78,14 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
 @test "client/ClusterRole: allows secret access with global.bootsrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-clusterrole.yaml  \
       --set 'client.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]
@@ -96,7 +96,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/client-clusterrole.yaml  \
       --set 'client.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules[1].resources[0]' | tee /dev/stderr)

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -546,12 +546,12 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: both ACL and TLS init containers are created when global.tls.enabled=true and global.bootstrapACLs=true" {
+@test "client/DaemonSet: both ACL and TLS init containers are created when global.tls.enabled=true and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local has_acl_init_container=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'global.tls.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[] | select(.name == "client-acl-init") | length > 0' | tee /dev/stderr)
 
@@ -560,7 +560,7 @@ load _helpers
   local has_tls_init_container=$(helm template \
       -x templates/client-daemonset.yaml  \
       --set 'global.tls.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[] | select(.name == "client-acl-init") | length > 0' | tee /dev/stderr)
 
@@ -757,23 +757,23 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
-@test "client/DaemonSet: aclconfig volume is created when global.bootstrapACLs=true" {
+@test "client/DaemonSet: aclconfig volume is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[2].name == "aclconfig"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: aclconfig volumeMount is created when global.bootstrapACLs=true" {
+@test "client/DaemonSet: aclconfig volumeMount is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts[2]' | tee /dev/stderr)
 
@@ -786,21 +786,21 @@ load _helpers
   [ "${actual}" = "/consul/aclconfig" ]
 }
 
-@test "client/DaemonSet: command includes aclconfig dir when global.bootstrapACLs=true" {
+@test "client/DaemonSet: command includes aclconfig dir when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("/consul/aclconfig"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: init container is created when global.bootstrapACLs=true" {
+@test "client/DaemonSet: init container is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/client-daemonset.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[] | select(.name == "client-acl-init")' | tee /dev/stderr)
 

--- a/test/unit/client-snapshot-agent-clusterrole.bats
+++ b/test/unit/client-snapshot-agent-clusterrole.bats
@@ -59,7 +59,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
 @test "client/SnapshotAgentClusterRole: allows secret access with global.bootsrapACLs=true" {
   cd `chart_dir`
@@ -67,7 +67,7 @@ load _helpers
       -x templates/client-snapshot-agent-clusterrole.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
       --set 'client.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]
@@ -79,7 +79,7 @@ load _helpers
       -x templates/client-snapshot-agent-clusterrole.yaml  \
       --set 'client.enabled=true' \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules[1].resources[0]' | tee /dev/stderr)

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -92,7 +92,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs and snapshotAgent.configSecret
+# global.acls.manageSystemACLs and snapshotAgent.configSecret
 
 @test "client/SnapshotAgentDeployment: no initContainer by default" {
   cd `chart_dir`
@@ -104,12 +104,12 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "client/SnapshotAgentDeployment: populates initContainer when global.bootstrapACLs=true" {
+@test "client/SnapshotAgentDeployment: populates initContainer when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -125,12 +125,12 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "client/SnapshotAgentDeployment: populates volumes when global.bootstrapACLs=true" {
+@test "client/SnapshotAgentDeployment: populates volumes when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -158,12 +158,12 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "client/SnapshotAgentDeployment: populates container volumeMounts when global.bootstrapACLs=true" {
+@test "client/SnapshotAgentDeployment: populates container volumeMounts when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -314,7 +314,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |

--- a/test/unit/connect-inject-authmethod-clusterrole.bats
+++ b/test/unit/connect-inject-authmethod-clusterrole.bats
@@ -18,7 +18,7 @@ load _helpers
       --set 'global.enabled=false' \
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -34,12 +34,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInjectAuthMethod/ClusterRole: enabled with global.bootstrapACLs.enabled=true" {
+@test "connectInjectAuthMethod/ClusterRole: enabled with global.acls.manageSystemACLs.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-clusterrole.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/connect-inject-authmethod-clusterrolebinding.bats
+++ b/test/unit/connect-inject-authmethod-clusterrolebinding.bats
@@ -18,7 +18,7 @@ load _helpers
       --set 'global.enabled=false' \
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -34,12 +34,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInjectAuthMethod/ClusterRoleBinding: enabled with global.bootstrapACLs.enabled=true" {
+@test "connectInjectAuthMethod/ClusterRoleBinding: enabled with global.acls.manageSystemACLs.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-clusterrolebinding.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/connect-inject-authmethod-serviceaccount.bats
+++ b/test/unit/connect-inject-authmethod-serviceaccount.bats
@@ -18,7 +18,7 @@ load _helpers
       --set 'global.enabled=false' \
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -34,12 +34,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInjectAuthMethod/ServiceAccount: enabled with global.bootstrapACLs.enabled=true" {
+@test "connectInjectAuthMethod/ServiceAccount: enabled with global.acls.manageSystemACLs.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-authmethod-serviceaccount.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/connect-inject-clusterrole.bats
+++ b/test/unit/connect-inject-clusterrole.bats
@@ -80,14 +80,14 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs for namespaces
+# global.acls.manageSystemACLs for namespaces
 
 @test "connectInject/ClusterRole: does not allow secret access with global.bootsrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-clusterrole.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
@@ -98,7 +98,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-clusterrole.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       . | tee /dev/stderr |
       yq -r '.rules[1].resources[0]' | tee /dev/stderr)
@@ -110,7 +110,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-clusterrole.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'global.enableConsulNamespaces=true' \
       . | tee /dev/stderr |

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -327,12 +327,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: -acl-auth-method is set when global.bootstrapACLs is true" {
+@test "connectInject/Deployment: -acl-auth-method is set when global.acls.manageSystemACLs is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"release-name-consul-k8s-auth-method\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -349,12 +349,12 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: -acl-auth-method is overridden by connectInject.overrideAuthMethodName if global.bootstrapACLs is true" {
+@test "connectInject/Deployment: -acl-auth-method is overridden by connectInject.overrideAuthMethodName if global.acls.manageSystemACLs is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.overrideAuthMethodName=override' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"override\""))' | tee /dev/stderr)
@@ -477,7 +477,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
@@ -720,15 +720,15 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# namespaces + global.bootstrapACLs
+# namespaces + global.acls.manageSystemACLs
 
-@test "connectInject/Deployment: CONSUL_HTTP_TOKEN env variable created when global.bootstrapACLs=true" {
+@test "connectInject/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '[.spec.template.spec.containers[0].env[].name] ' | tee /dev/stderr)
 
@@ -741,13 +741,13 @@ load _helpers
   [ "${actual}" = "1" ]
 }
 
-@test "connectInject/Deployment: init container is created when global.bootstrapACLs=true" {
+@test "connectInject/Deployment: init container is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
 
@@ -760,7 +760,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: cross namespace policy is not added when global.bootstrapACLs=false" {
+@test "connectInject/Deployment: cross namespace policy is not added when global.acls.manageSystemACLs=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml \
@@ -771,13 +771,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: cross namespace policy is added when global.bootstrapACLs=true" {
+@test "connectInject/Deployment: cross namespace policy is added when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-consul-cross-namespace-acl-policy"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/enterprise-license-clusterrole.bats
+++ b/test/unit/enterprise-license-clusterrole.bats
@@ -54,7 +54,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "enterpriseLicense/ClusterRole: rules are empty if global.bootstrapACLs and global.enablePodSecurityPolicies are false" {
+@test "enterpriseLicense/ClusterRole: rules are empty if global.acls.manageSystemACLs and global.enablePodSecurityPolicies are false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrole.yaml  \
@@ -66,15 +66,15 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
-@test "enterpriseLicense/ClusterRole: allows acl token when global.bootstrapACLs is true" {
+@test "enterpriseLicense/ClusterRole: allows acl token when global.acls.manageSystemACLs is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-clusterrole.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resourceNames[0] == "release-name-consul-enterprise-license-acl-token")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]

--- a/test/unit/enterprise-license-job.bats
+++ b/test/unit/enterprise-license-job.bats
@@ -55,27 +55,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
-@test "server/EnterpriseLicense: CONSUL_HTTP_TOKEN env variable created when global.bootstrapACLs=true" {
+@test "server/EnterpriseLicense: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/enterprise-license-job.yaml \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "server/EnterpriseLicense: init container is created when global.bootstrapACLs=true" {
+@test "server/EnterpriseLicense: init container is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
 

--- a/test/unit/mesh-gateway-clusterrole.bats
+++ b/test/unit/mesh-gateway-clusterrole.bats
@@ -36,14 +36,14 @@ load _helpers
   [ "${actual}" = "podsecuritypolicies" ]
 }
 
-@test "meshGateway/ClusterRole: rules for global.bootstrapACLs=true" {
+@test "meshGateway/ClusterRole: rules for global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-clusterrole.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]
@@ -83,7 +83,7 @@ load _helpers
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.type=LoadBalancer' \

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -340,7 +340,7 @@ key2: value2' \
 #--------------------------------------------------------------------
 # consulServiceName
 
-@test "meshGateway/Deployment: fails if consulServiceName is set and bootstrapACLs is true" {
+@test "meshGateway/Deployment: fails if consulServiceName is set and acls.manageSystemACLs is true" {
   cd `chart_dir`
   run helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -348,13 +348,13 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
       --set 'meshGateway.consulServiceName=override' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "if global.bootstrapACLs is true, meshGateway.consulServiceName cannot be set" ]]
+  [[ "$output" =~ "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" ]]
 }
 
-@test "meshGateway/Deployment: does not fail if consulServiceName is set to mesh-gateway and bootstrapACLs is true" {
+@test "meshGateway/Deployment: does not fail if consulServiceName is set to mesh-gateway and acls.manageSystemACLs is true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
@@ -362,7 +362,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
       --set 'meshGateway.consulServiceName=mesh-gateway' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr \
       | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
 
@@ -669,13 +669,13 @@ consul services register \
   [ "${actual}" = "${exp}" ]
 }
 
-@test "meshGateway/Deployment: service-init init container with global.bootstrapACLs=true" {
+@test "meshGateway/Deployment: service-init init container with acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
 

--- a/test/unit/server-acl-init-cleanup-clusterrole.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrole.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRole: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRole: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with client=true and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRole: enabled with client=true and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -50,7 +50,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)

--- a/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/Job: enabled with global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/Job: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/Job: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/Job: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/Job: enabled with client=true and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/Job: enabled with client=true and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -47,7 +47,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.updatePartition=1' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -58,7 +58,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -c '.spec.template.spec.containers[0].args' | tee /dev/stderr)
   [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","release-name-consul-server-acl-init"]' ]

--- a/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
+++ b/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
@@ -11,22 +11,22 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/PodSecurityPolicy: disabled with global.bootstrapACLs=true and global.enablePodSecurityPolicies=false" {
+@test "serverACLInitCleanup/PodSecurityPolicy: disabled with global.acls.manageSystemACLs=true and global.enablePodSecurityPolicies=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/PodSecurityPolicy: enabled with global.bootstrapACLs=true and global.enablePodSecurityPolicies=true" {
+@test "serverACLInitCleanup/PodSecurityPolicy: enabled with global.acls.manageSystemACLs=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ServiceAccount: enabled with global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ServiceAccount: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ServiceAccount: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ServiceAccount: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ServiceAccount: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInitCleanup/ServiceAccount: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-acl-init-clusterrole.bats
+++ b/test/unit/server-acl-init-clusterrole.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRole: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRole: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRole: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRole: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -50,7 +50,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "serviceaccounts")) | length' | tee /dev/stderr)
@@ -64,7 +64,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-clusterrolebinding.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/Job: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: enabled with client=false global.bootstrapACLs=true" {
+@test "serverACLInit/Job: enabled with client=false global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -47,7 +47,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.updatePartition=1' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -58,7 +58,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
       tee /dev/stderr)
@@ -69,7 +69,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
@@ -84,7 +84,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -94,7 +94,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'dns.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
@@ -105,7 +105,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'dns.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("allow-dns"))' | tee /dev/stderr)
@@ -113,7 +113,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# aclBindingRuleSelector/global.bootstrapACLs
+# aclBindingRuleSelector/global.acls.manageSystemACLs
 
 @test "serverACLInit/Job: no acl-binding-rule-selector flag by default" {
   cd `chart_dir`
@@ -130,7 +130,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.aclBindingRuleSelector="foo"' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-acl-binding-rule-selector=\"foo\""))' | tee /dev/stderr)
@@ -144,7 +144,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
@@ -156,7 +156,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
@@ -167,7 +167,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
@@ -181,7 +181,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-snapshot-agent-token"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -191,7 +191,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.snapshotAgent.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-snapshot-agent-token"))' | tee /dev/stderr)
@@ -202,7 +202,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
@@ -218,7 +218,7 @@ load _helpers
   cd `chart_dir`
   local command=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
@@ -238,7 +238,7 @@ load _helpers
   cd `chart_dir`
   local ca_cert_volume=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.caCert.secretName=foo-ca-cert' \
       --set 'global.tls.caCert.secretKey=key' \
@@ -264,7 +264,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
@@ -308,7 +308,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'syncCatalog.consulNamespaces.mirroringK8S=true' \
       --set 'syncCatalog.consulNamespaces.mirroringK8SPrefix=k8s-' \
@@ -352,7 +352,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
@@ -395,7 +395,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.consulNamespaces.mirroringK8S=true' \
@@ -439,7 +439,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.consulNamespaces.mirroringK8S=true' \
@@ -487,7 +487,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'connectInject.consulNamespaces.mirroringK8S=true' \
       --set 'connectInject.consulNamespaces.mirroringK8SPrefix=k8s-' \
@@ -531,7 +531,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
@@ -574,7 +574,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'connectInject.enabled=true' \
       --set 'connectInject.consulNamespaces.mirroringK8S=true' \
@@ -618,7 +618,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'connectInject.enabled=true' \
       --set 'connectInject.consulNamespaces.mirroringK8S=true' \
@@ -666,7 +666,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-acl-replication-token"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -676,7 +676,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.createReplicationToken=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-acl-replication-token"))' | tee /dev/stderr)
@@ -690,7 +690,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr)
 
   # Test the flag is not set.
@@ -713,7 +713,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretName=name' \
       . | tee /dev/stderr)
 
@@ -737,7 +737,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretKey=key' \
       . | tee /dev/stderr)
 
@@ -761,7 +761,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-acl-init-job.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretName=name' \
       --set 'global.acls.replicationToken.secretKey=key' \
       . | tee /dev/stderr)

--- a/test/unit/server-acl-init-podsecuritypolicy.bats
+++ b/test/unit/server-acl-init-podsecuritypolicy.bats
@@ -11,22 +11,22 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/PodSecurityPolicy: disabled with global.bootstrapACLs=true and global.enablePodSecurityPolicies=false" {
+@test "serverACLInit/PodSecurityPolicy: disabled with global.acls.manageSystemACLs=true and global.enablePodSecurityPolicies=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-podsecuritypolicy.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/PodSecurityPolicy: enabled with global.bootstrapACLs=true and global.enablePodSecurityPolicies=true" {
+@test "serverACLInit/PodSecurityPolicy: enabled with global.acls.manageSystemACLs=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-podsecuritypolicy.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -11,32 +11,32 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ServiceAccount: enabled with global.bootstrapACLs=true" {
+@test "serverACLInit/ServiceAccount: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ServiceAccount: disabled with server=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ServiceAccount: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ServiceAccount: enabled with client=false and global.bootstrapACLs=true" {
+@test "serverACLInit/ServiceAccount: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-serviceaccount.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -53,13 +53,13 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
-@test "server/ConfigMap: creates acl config with .global.bootstrapACLs enabled" {
+@test "server/ConfigMap: creates acl config with .global.acls.manageSystemACLs enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.data["acl-config.json"] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -173,7 +173,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -183,7 +183,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretName=name' \
       . | tee /dev/stderr |
       yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
@@ -194,7 +194,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretKey=key' \
       . | tee /dev/stderr |
       yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
@@ -205,7 +205,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-config-configmap.yaml  \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.replicationToken.secretName=name' \
       --set 'global.acls.replicationToken.secretKey=key' \
       . | tee /dev/stderr |

--- a/test/unit/sync-catalog-clusterrole.bats
+++ b/test/unit/sync-catalog-clusterrole.bats
@@ -67,14 +67,14 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
 @test "syncCatalog/ClusterRole: allows secret access with global.bootsrapACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-clusterrole.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules[2].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -341,25 +341,25 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
+# global.acls.manageSystemACLs
 
-@test "syncCatalog/Deployment: CONSUL_HTTP_TOKEN env variable created when global.bootstrapACLs=true" {
+@test "syncCatalog/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml \
       --set 'syncCatalog.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/Deployment: init container is created when global.bootstrapACLs=true" {
+@test "syncCatalog/Deployment: init container is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/sync-catalog-deployment.yaml \
       --set 'syncCatalog.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
 
@@ -480,7 +480,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       . | tee /dev/stderr |
@@ -668,9 +668,9 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# namespaces + global.bootstrapACLs
+# namespaces + global.acls.manageSystemACLs
 
-@test "syncCatalog/Deployment: cross namespace policy is not added when global.bootstrapACLs=false" {
+@test "syncCatalog/Deployment: cross namespace policy is not added when global.acls.manageSystemACLs=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml \
@@ -681,13 +681,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "syncCatalog/Deployment: cross namespace policy is added when global.bootstrapACLs=true" {
+@test "syncCatalog/Deployment: cross namespace policy is added when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-catalog-deployment.yaml \
       --set 'syncCatalog.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
-      --set 'global.bootstrapACLs=true' \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-consul-cross-namespace-acl-policy"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ global:
   # Note: support for the catalog sync's liveness and readiness probes was added
   # to consul-k8s 0.6.0. If using an older consul-k8s version, you may need to
   # remove these checks to make the sync work.
-  # If using bootstrapACLs then must be >= 0.10.1.
+  # If using acls.manageSystemACLs then must be >= 0.10.1.
   # If using connect inject then must be >= 0.10.1.
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.12.0"
@@ -72,11 +72,6 @@ global:
     # secretKey is the key within the Kubernetes secret that holds the gossip
     # encryption key.
     secretKey: ""
-
-  # bootstrapACLs will automatically create and assign ACL tokens within
-  # the Consul cluster. This requires servers to be running inside Kubernetes.
-  # Additionally requires Consul >= 1.4 and consul-k8s >= 0.10.1.
-  bootstrapACLs: false
 
   # Enables TLS encryption across the cluster to verify authenticity of the
   # servers and clients that connect. Note: It is HIGHLY recommended that you also
@@ -163,8 +158,17 @@ global:
     # This setting must be true in both primary and secondary datacenters.
     enabled: false
 
+  # [DEPRECATED] Use acls.manageSystemACLs instead.
+  bootstrapACLs: false
+
   # Configure ACLs.
   acls:
+
+    # If true, the Helm chart will automatically manage ACL tokens and policies
+    # for all Consul components. This requires servers to be running inside Kubernetes.
+    # Additionally requires Consul >= 1.4 and consul-k8s >= 0.10.1.
+    manageSystemACLs: false
+
     # If true, an ACL token will be created that can be used in secondary
     # datacenters for replication. This should only be set to true in the
     # primary datacenter since the replication token must be created from that
@@ -766,15 +770,16 @@ connectInject:
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
   aclBindingRuleSelector: "serviceaccount.name!=default"
 
-  # If not using global.bootstrapACLs and instead manually setting up an auth
-  # method for Connect inject, set this to the name of your auth method.
+  # If not using global.acls.manageSystemACLs and instead manually setting up an
+  # auth method for Connect inject, set this to the name of your auth method.
   overrideAuthMethodName: ""
 
   # aclInjectToken refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which allows the Connect injector the correct
   # permissions. This is only needed if Consul namespaces [Enterprise only] and ACLs
-  # are enabled on the Consul cluster and you are not setting `global.bootstrapACLs`
-  # to `true`. This token needs to have `operator = "write"` privileges to be able to
+  # are enabled on the Consul cluster and you are not setting
+  # `global.acls.manageSystemACLs` to `true`.
+  # This token needs to have `operator = "write"` privileges to be able to
   # create Consul namespaces.
   aclInjectToken:
     secretName: null
@@ -808,7 +813,8 @@ meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs
   # gateways and Consul Connect will be configured to use gateways.
   # See https://www.consul.io/docs/connect/mesh_gateway.html
-  # Requirements: consul >= 1.6.0 and consul-k8s >= 0.9.0 if using global.bootstrapACLs.
+  # Requirements: consul >= 1.6.0 and consul-k8s >= 0.9.0 if using
+  # global.acls.manageSystemACLs.
   enabled: false
 
   # Globally configure which mode the gateway should run in.
@@ -892,8 +898,8 @@ meshGateway:
   dnsPolicy: null
 
   # Override the default 'mesh-gateway' service name registered in Consul.
-  # Cannot be used if bootstrapACLs is true since the ACL token generated
-  # is only for the name 'mesh-gateway'.
+  # Cannot be used if global.acls.manageSystemACLs is true since the ACL token
+  # generated is only for the name 'mesh-gateway'.
   consulServiceName: ""
 
   # Port that the gateway will run on inside the container.


### PR DESCRIPTION
With the new `global.acls` setting, it was confusing to have bootstrapACLs
as a separate setting. Instead we create a new `global.acls.manageSystemACLs`
setting which can be used in place of global.bootstrapACLs.

For backwards compatibility, I've replaced all instances of `if .global.bootstrapACLs` with `if (or .global.acls.manageSystemACLs .global.bootstrapACLs)`. This means users previously setting `global.bootstrapACLs: true` will see no changes.

For testing, I've replaced all use of `global.bootstrapACLs` with `global.acls.manageSystemACLs` because creating a new test for each use would have ended up with 100 new tests.