### PR TITLE
Fix compatibility with Go 1.14

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -173,7 +173,7 @@ spec:
                 {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
                 -encrypt="${GOSSIP_KEY}" \
                 {{- end }}
-                {{- if (.Values.client.join) and (gt (len .Values.client.join) 0) }}
+                {{- if .Values.client.join }}
                 {{- range $value := .Values.client.join }}
                 -retry-join="{{ $value }}" \
                 {{- end }}


### PR DESCRIPTION
I got this error while installing the cluster using Go 1.14:

```
Error: template: consul/templates/client-daemonset.yaml:176:23: executing "consul/templates/client-daemonset.yaml" at <(.Values.client.join) and (gt (len .Values.client.join) 0)>: can't give argument to non-function .Values.client.join
```

The error is due to a change in the [`text/template` package](https://golang.org/doc/go1.14) in 1.14:

> The text/template package now correctly reports errors when a parenthesized argument is used as a function. This most commonly shows up in erroneous cases like {{if (eq .F "a") or (eq .F "b")}}. This should be written as {{if or (eq .F "a") (eq .F "b")}}. The erroneous case never worked as expected, and will now be reported with an error can't give argument to non-function.

To solve, I removed the `and` condition because the [text/template documentation](https://golang.org/pkg/text/template/) reports that they already check pipeline isn't empty:

> {{if pipeline}} T1 {{end}}
	If the value of the pipeline is empty, no output is generated;
	otherwise, T1 is executed. The empty values are false, 0, any
	nil pointer or interface value, and any array, slice, map, or
	string of length zero.
	Dot is unaffected.