### PR TITLE
Added liveness probe for Consul agents

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -257,6 +257,24 @@ spec:
             - containerPort: 8600
               name: dns-udp
               protocol: "UDP"
+          livenessProbe:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  curl \
+                    -k -s --show-error --fail \
+                  {{- if .Values.global.tls.enabled }}
+                    https://127.0.0.1:8501/v1/health/node/$NODE
+                  {{- else }}
+                    http://127.0.0.1:8500/v1/health/node/$NODE
+                  {{- end }}
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           readinessProbe:
             # NOTE(mitchellh): when our HTTP status endpoints support the
             # proper status codes, we should switch to that. This is temporary.


### PR DESCRIPTION
This change adds a liveness probe for the Consul agents to ensure the Pod crashes if the Consul agent is unable to join the cluster. The [/health/node/:node](https://www.consul.io/api/health.html#list-checks-for-node) endpoint is able to be used only because the node name is set as an environment variable here:
* https://github.com/hashicorp/consul-helm/blob/v0.17.0/templates/client-daemonset.yaml#L114
* https://github.com/hashicorp/consul-helm/blob/v0.17.0/templates/client-daemonset.yaml#L139