### PR TITLE
Support LoadBalancerAddress for mesh gateways

### DIFF
--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
-{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
+{{- if or .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies (eq .Values.meshGateway.wanAddress.source "Service") }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -28,6 +28,15 @@ rules:
     verbs:
       - get
 {{- end }}
+{{- if eq .Values.meshGateway.wanAddress.source "Service" }}
+  - apiGroups: [""]
+    resources:
+      - services
+    resourceNames:
+      - {{ template "consul.fullname" . }}-mesh-gateway
+    verbs:
+      - get
+  {{- end }}
 {{- else }}
 rules: []
 {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -116,12 +116,35 @@ spec:
                   -token-sink-file=/consul/service/acl-token
                 {{ end }}
 
-                {{- if .Values.meshGateway.wanAddress.host }}
-                WAN_ADDR="{{ .Values.meshGateway.wanAddress.host }}"
-                {{- else if .Values.meshGateway.wanAddress.useNodeName }}
-                WAN_ADDR="${NODE_NAME}"
-                {{- else if .Values.meshGateway.wanAddress.useNodeIP }}
+                {{- $source := .Values.meshGateway.wanAddress.source }}
+                {{- $serviceType := .Values.meshGateway.service.type }}
+                {{- if and (eq $source "Service") (not .Values.meshGateway.service.enabled) }}{{ fail "if meshGateway.wanAddress.source=Service then meshGateway.service.enabled must be set to true" }}{{ end }}
+                {{- if or (eq $source "NodeIP") (and (eq $source "Service") (eq $serviceType "NodePort")) }}
                 WAN_ADDR="${HOST_IP}"
+                {{- else if eq $source "NodeName" }}
+                WAN_ADDR="${NODE_NAME}"
+                {{- else if and (eq $source "Service") (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
+                consul-k8s service-address \
+                  -k8s-namespace={{ .Release.Namespace }} \
+                  -name={{ template "consul.fullname" . }}-mesh-gateway \
+                  -output-file=address.txt
+                WAN_ADDR="$(cat address.txt)"
+                {{- else if eq $source "Static" }}
+                {{- if eq .Values.meshGateway.wanAddress.static "" }}{{ fail "if meshGateway.wanAddress.source=Static then meshGateway.wanAddress.static cannot be empty" }}{{ end }}
+                WAN_ADDR="{{ .Values.meshGateway.wanAddress.static }}"
+                {{- else }}
+                {{- fail "currently set meshGateway values for wanAddress.source and service.type are not supported" }}
+                {{- end }}
+
+                {{- if eq $source "Service" }}
+                {{- if eq $serviceType "NodePort" }}
+                {{- if not .Values.meshGateway.service.nodePort }}{{ fail "if meshGateway.wanAddress.source=Service and meshGateway.service.type=NodePort, meshGateway.service.nodePort must be set" }}{{ end }}
+                WAN_PORT="{{ .Values.meshGateway.service.nodePort }}"
+                {{- else }}
+                WAN_PORT="{{ .Values.meshGateway.service.port }}"
+                {{- end }}
+                {{- else }}
+                WAN_PORT="{{ .Values.meshGateway.wanAddress.port }}"
                 {{- end }}
 
                 cat > /consul/service/service.hcl << EOF
@@ -140,17 +163,9 @@ spec:
                       address = "${POD_IP}"
                       port = {{ .Values.meshGateway.containerPort }}
                     }
-                    lan_ipv4 {
-                      address = "${POD_IP}"
-                      port = {{ .Values.meshGateway.containerPort }}
-                    }
                     wan {
                       address = "${WAN_ADDR}"
-                      port = {{ .Values.meshGateway.wanAddress.port }}
-                    }
-                    wan_ipv4 {
-                      address = "${WAN_ADDR}"
-                      port = {{ .Values.meshGateway.wanAddress.port }}
+                      port = ${WAN_PORT}
                     }
                   }
                   checks = [

--- a/test/unit/mesh-gateway-service.bats
+++ b/test/unit/mesh-gateway-service.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/Service: disabled by default with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/Service: enabled by default with meshGateway, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-service.yaml  \
@@ -20,7 +20,7 @@ load _helpers
       --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "meshGateway/Service: enabled with meshGateway.enabled=true meshGateway.service.enabled" {
@@ -109,7 +109,7 @@ load _helpers
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
-  [ "${actual}" = "443" ]
+  [ "${actual}" = "8443" ]
 }
 
 @test "meshGateway/Service: uses targetPort from containerPort" {
@@ -120,10 +120,10 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
-      --set 'meshGateway.containerPort=8443' \
+      --set 'meshGateway.containerPort=9443' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
-  [ "${actual}" = "8443" ]
+  [ "${actual}" = "9443" ]
 }
 
 #--------------------------------------------------------------------
@@ -159,7 +159,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Service type
 
-@test "meshGateway/Service: defaults to type ClusterIP" {
+@test "meshGateway/Service: defaults to type LoadBalancer" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-service.yaml  \
@@ -169,7 +169,7 @@ load _helpers
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.type' | tee /dev/stderr)
-  [ "${actual}" = "ClusterIP" ]
+  [ "${actual}" = "LoadBalancer" ]
 }
 
 @test "meshGateway/Service: can set type" {
@@ -180,10 +180,10 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
-      --set 'meshGateway.service.type=LoadBalancer' \
+      --set 'meshGateway.service.type=ClusterIP' \
       . | tee /dev/stderr |
       yq -r '.spec.type' | tee /dev/stderr)
-  [ "${actual}" = "LoadBalancer" ]
+  [ "${actual}" = "ClusterIP" ]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -766,46 +766,53 @@ meshGateway:
   # Number of replicas for the Deployment.
   replicas: 2
 
-  # What gets registered as wan address for the gateway.
+  # What gets registered as WAN address for the gateway.
   wanAddress:
-    # Port that gets registered.
+    # source configures where to retrieve the WAN address (and possibly port)
+    # for the mesh gateway from.
+    # Can be set to either: Service, NodeIP, NodeName or Static.
+    #
+    # Service - Determine the address based on the service type.
+    #   If service.type=LoadBalancer use the external IP or hostname of
+    #   the service. Use the port set by service.port.
+    #   If service.type=NodePort use the Node IP. The port will be set to
+    #   service.nodePort so service.nodePort cannot be null.
+    #   If service.type=ClusterIP use the ClusterIP. The port will be set to
+    #   service.port.
+    #   service.type=ExternalName is not supported.
+    # NodeIP - The node IP as provided by the Kubernetes downward API.
+    # NodeName - The name of the node as provided by the Kubernetes downward
+    #   API. This is useful if the node names are DNS entries that
+    #   are routable from other datacenters.
+    # Static - Use the address hardcoded in meshGateway.wanAddress.static.
+    source: "Service"
+
+    # Port that gets registered for WAN traffic.
+    # If source is set to "Service" then this setting will have no effect.
+    # See the documentation for source as to which port will be used in that
+    # case.
     port: 443
 
-    # If true, each Gateway Pod will advertise its NodeIP
-    # (as provided by the Kubernetes downward API) as the wan address.
-    # This is useful if the node IPs are routable from other DCs.
-    # useNodeName and host must be false and "" respectively.
-    useNodeIP: true
-
-    # If true, each Gateway Pod will advertise its NodeName
-    # (as provided by the Kubernetes downward API) as the wan address.
-    # This is useful if the node names are DNS entries that are
-    # routable from other DCs.
-    # meshGateway.wanAddress.port will be used as the port for the wan address.
-    # useNodeIP and host must be false and "" respectively.
-    useNodeName: false
-
-    # If set, each gateway Pod will use this host as its wan address.
-    # Users must ensure that this address routes to the Gateway pods,
-    # for example via a DNS entry that routes to the Service fronting the Deployment.
-    # meshGateway.wanAddress.port will be used as the port for the wan address.
-    # useNodeIP and useNodeName must be false.
-    host: ""
+    # If source is set to "Static" then this value will be used as the WAN
+    # address of the mesh gateways. This is useful if you've configured a
+    # DNS entry to point to your mesh gateways.
+    static: ""
 
   # The service option configures the Service that fronts the Gateway Deployment.
   service:
     # Whether to create a Service or not.
-    enabled: false
+    enabled: true
 
     # Type of service, ex. LoadBalancer, ClusterIP.
-    type: ClusterIP
+    type: LoadBalancer
 
     # Port that the service will be exposed on.
     # The targetPort will be set to meshGateway.containerPort.
     port: 443
 
-    # Optional nodePort of the service. Can be used in conjunction with
-    # type: NodePort.
+    # Optionally hardcode the nodePort of the service if using type: NodePort.
+    # If not set and using type: NodePort, Kubernetes will automatically assign
+    # a port.
     nodePort: null
 
     # Optional YAML string for additional annotations.
@@ -829,7 +836,7 @@ meshGateway:
   consulServiceName: ""
 
   # Port that the gateway will run on inside the container.
-  containerPort: 443
+  containerPort: 8443
 
   # Optional hostPort for the gateway to be exposed on.
   # This can be used with wanAddress.port and wanAddress.useNodeIP


### PR DESCRIPTION
Add support for using the external address of Kubernetes load balancer
for the mesh gateway wan address.

This change uses the new consul-k8s load-balancer-address command to get
the address of the load balancer.

It also removes meshGateway.wanAddress.{useNodeIP, useNodeName, host}
config values in favour of meshGateway.wanAddress.{source, static}. The
new source value allows selecting NodeIP, NodeName, LoadBalancerAddress
or Static. This is more extensible than the previous boolean values.