### PR TITLE
Add ability to set `hostNetwork: true` on client daemonset.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 terraform.tfstate*
 terraform.tfvars
 values.dev.yaml
+.idea

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -55,6 +55,10 @@ spec:
       dnsPolicy: {{ .Values.client.dnsPolicy }}
       {{- end }}
 
+      {{- if .Values.client.enableHostNetworkMode }}
+      hostNetwork: true
+      {{- end }}
+
       volumes:
         - name: data
         {{- if .Values.client.dataDirectoryHostPath }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -779,7 +779,7 @@ load _helpers
 #--------------------------------------------------------------------
 # client.enableHostNetworkMode
 
-@test "client/DaemonSet: host network mode is node enabled by default" {
+@test "client/DaemonSet: host network mode is disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/client-daemonset.yaml  \

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -777,6 +777,31 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# client.enableHostNetworkMode
+
+@test "client/DaemonSet: host network mode is node enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+       yq '.spec.template.spec.hostNetwork == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: client uses host network namespace when client.enableHostNetworkMode=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.enableHostNetworkMode=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.hostNetwork' |
+      tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # dataDirectoryHostPath
 
 @test "client/DaemonSet: data directory is emptyDir by defaut" {

--- a/values.yaml
+++ b/values.yaml
@@ -293,7 +293,7 @@ client:
 
   # Setting this to true will enable hostNetwork mode on the client daemonset.
   # Note the pod shares a network namespace with the host in this mode.
-  # It is preferred to sue  exposeGossipPorts: true in most cases.
+  # It is preferred to use  exposeGossipPorts: true in most cases.
   # If your CNI plugin does not work with that setup this can be used as a fallback.
   enableHostNetworkMode: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -291,6 +291,12 @@ client:
   # also changes the clients' advertised IP to the hostIP rather than podIP.
   exposeGossipPorts: false
 
+  # Setting this to true will enable hostNetwork mode on the client daemonset.
+  # Note the pod shares a network namespace with the host in this mode.
+  # It is preferred to sue  exposeGossipPorts: true in most cases.
+  # If your CNI plugin does not work with that setup this can be used as a fallback.
+  enableHostNetworkMode: false
+
   # Resource requests, limits, etc. for the client cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request


### PR DESCRIPTION
Issue #389 contains more info.

UDP port 8301 is not correctly exposed when using hostPorts inside of our clusters on AWS EKS. Running the daemonset in `hostNetwork` mode is currently required for our UDP traffic to be properly exposed outside of the kubernetes cluster. The setting is disabled by default.

Please let me know if any changes are required and thanks for considering the PR!