### PR TITLE
Remove use of -init-type=sync as it has no effect

### DIFF
--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -126,8 +126,7 @@ spec:
           - |
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
-              -init-type="sync"
+              -k8s-namespace={{ .Release.Namespace }}
         volumeMounts:
           - name: aclconfig
             mountPath: /consul/aclconfig

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -190,8 +190,7 @@ spec:
           - |
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-connect-inject-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
-              -init-type="sync"
+              -k8s-namespace={{ .Release.Namespace }}
       {{- end }}
       {{- if .Values.connectInject.nodeSelector }}
       nodeSelector:

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -109,8 +109,7 @@ spec:
           - |
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-enterprise-license-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
-              -init-type="sync"
+              -k8s-namespace={{ .Release.Namespace }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -112,7 +112,6 @@ spec:
                 consul-k8s acl-init \
                   -secret-name="{{ template "consul.fullname" . }}-mesh-gateway-acl-token" \
                   -k8s-namespace={{ .Release.Namespace }} \
-                  -init-type="sync" \
                   -token-sink-file=/consul/service/acl-token
                 {{ end }}
 

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -175,8 +175,7 @@ spec:
           - |
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-catalog-sync-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
-              -init-type="sync"
+              -k8s-namespace={{ .Release.Namespace }}
       {{- end }}
       {{- if .Values.syncCatalog.nodeSelector }}
       nodeSelector:

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -624,7 +624,6 @@ consul services register \
   exp='consul-k8s acl-init \
   -secret-name="release-name-consul-mesh-gateway-acl-token" \
   -k8s-namespace=default \
-  -init-type="sync" \
   -token-sink-file=/consul/service/acl-token
 
 consul-k8s service-address \


### PR DESCRIPTION
As part of https://github.com/hashicorp/consul-k8s/pull/232 we removed
the docs about -init-type=sync. This does not break anything because if -init-type was set to sync it actually had no effect. Only -init-type=client had effect.