### PR TITLE
Use auto-encrypt CA volume for service-init when auto-encrypt is enabled

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -147,7 +147,7 @@ spec:
               value: https://localhost:8501
             {{- if .Values.global.tls.enableAutoEncrypt }}
             - name: CONSUL_HTTP_SSL_VERIFY
-              value: false
+              value: "false"
             {{- else }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -197,7 +197,11 @@ spec:
             - name: consul-service
               mountPath: /consul/service
             {{- if .Values.global.tls.enabled }}
+            {{- if .Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
             - name: consul-ca-cert
+            {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
@@ -298,7 +302,11 @@ spec:
               mountPath: /consul/service
               readOnly: true
             {{- if .Values.global.tls.enabled }}
+            {{- if .Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
             - name: consul-ca-cert
+            {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}


### PR DESCRIPTION
It also adds a small fix to string-ify the value of `CONSUL_HTTP_SSL_VERIFY`.