### PR TITLE
ACL replication changelog, remove federation.enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,151 @@
 ## Unreleased
 
+BREAKING CHANGES:
+
+* Mesh Gateways:
+  * `meshGateway.wanAddress` - The following values are no longer supported:
+  
+       ```yaml
+       meshGateway:
+         wanAddress:
+           useNodeIP: true
+           useNodeName: false
+           host: ""
+       ```
+    
+    Instead, if previously setting `useNodeIP: true`, now you must set:
+       ```yaml
+       meshGateway:
+         wanAddress:
+           source: "NodeIP"
+       ```
+    
+    If previously setting `useNodeName: true`, now you must set:
+       ```yaml
+       meshGateway:
+         wanAddress:
+           source: "NodeName"
+       ```
+    
+    If previously setting `host: "example.com"`, now you must set:
+       ```yaml
+       meshGateway:
+         wanAddress:
+           source: "Static"
+           static: "example.com"
+       ```
+    where `meshGateway.wanAddress.static` is set to the previous `host` value.
+  
+  * `meshGateway.service.enabled` now defaults to `true`. If
+    previously you were enabling mesh gateways but not enabling the service,
+    you must now explicitly set this to `false`:
+    
+    Previously:
+    ```yaml
+    meshGateway:
+      enabled: true
+    ```
+    
+    Now:
+    ```yaml
+    meshGateway:
+      enabled: true
+      service:
+        enabled: false
+    ```
+    
+  * `meshGateway.service.type` now defaults to `LoadBalancer` instead of `ClusterIP`.
+    To set to `ClusterIP` use:
+    ```yaml
+    meshGateway:
+      service:
+        type: ClusterIP
+    ```
+
+  * `meshGateway.containerPort` now defaults to `8443` instead of `443`. This is
+    to support running in Google Kubernetes Engine by default. This change should
+    have no effect because the service's targetPort will change accordingly so
+    you will still be able to route to the mesh gateway as before.
+    If you wish to keep the port as `443` you must set:
+    ```yaml
+    meshGateway:
+      containerPort: 443
+    ```
+
+FEATURES:
+
+* ACLs: Support ACL replication. ACL replication allows two or more Consul clusters
+  to be federated when ACLs are enabled. One cluster is designated the primary
+  and the rest are secondaries. The primary cluster replicates its ACLs to
+  the secondaries. [[GH-368](https://github.com/hashicorp/consul-helm/pull/368)]
+  
+  NOTE: This feature requires that the clusters are federated.
+  
+  Primary cluster:
+  
+  ```yaml
+  global:
+    acls:
+      manageSystemACLs: true
+      createReplicationToken: true
+  ```
+
+  The replication acl token Kubernetes secret is exported from the primary cluster
+  into the secondaries and then referenced in their Helm config:
+  
+  ```yaml
+  global:
+    acls:
+      manageSystemACLs: true
+      replicationToken:
+        secretName: name
+        secretKey: key
+  ```
+
+* Mesh Gateways: Automatically set mesh gateway addresses when using a Kubernetes
+  Load Balancer service. 
+  To use, set:
+  
+  ```yaml
+  meshGateway:
+    enabled: true
+    service:
+      enabled: true
+      type: "LoadBalancer"
+    wanAddress:
+      source: "Service"
+  ```
+  [[GH-388](https://github.com/hashicorp/consul-helm/pull/388)]
+
+IMPROVEMENTS:
+
+* Default to the latest version of consul-k8s: `hashicorp/consul-k8s:0.13.0`
+* Default to the latest version of Consul: `consul:1.7.2`
+* Allow setting specific secret keys in `server.extraVolumes` [[GH-395](https://github.com/hashicorp/consul-helm/pull/395)]
+
+BUGFIXES:
+
+* Mesh Gateways: Mesh gateways are no longer de-registered when their node's Consul
+  client restarts. [[GH-380](https://github.com/hashicorp/consul-helm/pull/380)]
+
+DEPRECATIONS:
+
+* `global.bootstrapACLs` is deprecated. Instead, set `global.acls.manageSystemACLs`.
+   `global.bootstrapACLs` will be supported for the next three releases.
+
+   Previously:
+   ```yaml
+   global:
+     bootstrapACLs: true
+   ```
+
+   Now:
+   ```yaml
+   global:
+     acls:
+       manageSystemACLs: true
+   ```
+
 ## 0.18.0 (Mar 18, 2020)
 
 IMPROVEMENTS:

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -160,10 +160,12 @@ spec:
                 service {
                   kind = "mesh-gateway"
                   name = "{{ default "mesh-gateway" .Values.meshGateway.consulServiceName }}"
+                  {{- if .Values.global.federation }}
                   {{- if .Values.global.federation.enabled }}
                   meta {
                     consul-wan-federation = "1"
                   }
+                  {{- end }}
                   {{- end }}
                   port = {{ .Values.meshGateway.containerPort }}
                   address = "${POD_IP}"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -168,8 +168,10 @@ spec:
                 {{- if .Values.server.connect }}
                 -hcl="connect { enabled = true }" \
                 {{- end }}
+                {{- if .Values.global.federation }}
                 {{- if .Values.global.federation.enabled }}
                 -hcl="connect { enable_mesh_gateway_wan_federation = true }" \
+                {{- end }}
                 {{- end }}
                 {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
                 -hcl="acl { tokens { agent = \"${ACL_REPLICATION_TOKEN}\", replication = \"${ACL_REPLICATION_TOKEN}\" } }" \

--- a/values.yaml
+++ b/values.yaml
@@ -149,15 +149,6 @@ global:
   # of both the catalog sync and connect injector.
   enableConsulNamespaces: false
 
-  # Configures Consul datacenter federation.
-  federation:
-    # If true, servers and mesh gateways will
-    # have mesh gateway federation enabled.
-    # Additional configuration will be needed to provide the addresses of the
-    # remote datacenter's mesh gateway to federate with.
-    # This setting must be true in both primary and secondary datacenters.
-    enabled: false
-
   # [DEPRECATED] Use acls.manageSystemACLs instead.
   bootstrapACLs: false
 


### PR DESCRIPTION
* Changelog for latest changes
* Remove `global.federation.enabled` from `values.yaml` since there's no Consul release  that currently supports it. Users that have a custom Docker image can still set it in their local config files and it will work.

In order to not break Helm since the `global.federation` key doesn't exist, I needed to wrap the check for `global.federation.enabled` with a check for `global.federation`. Otherwise we'd get an `<.Values.global.federation.enabled>: nil pointer evaluating interface {}.enabled` error. Gotemplate doesn't support short circuiting so I needed a separate `if` statement.