### PR TITLE
Run enterprise-license job on upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ IMPROVEMENTS:
       enableAutoEncrypt: true
   ```
 
+* Run the enterprise license job on Helm upgrades, as well as installs [[GH-407](https://github.com/hashicorp/consul-helm/pull/407)].
+
 FEATURES:
 
 * Add `externalServers` configuration to support configuring the Helm chart with Consul servers

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "100"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -169,6 +169,7 @@ server:
   # has been elected. If you are not using an enterprise image
   # or if you plan to introduce the license key via another route, then set
   # these fields to null.
+  # Note: the job to apply license runs on both Helm installs and upgrades.
   enterpriseLicense:
     secretName: null
     secretKey: null


### PR DESCRIPTION
I think running it on upgrades is a valid use case since someone could be `helm upgrade`ing from OSS to enterprise. The job is idempotent, so there is no risk in running it again.