### PR TITLE
allow to override server's liveness and readiness probes

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -207,27 +207,14 @@ spec:
             - containerPort: 8600
               name: dns-udp
               protocol: "UDP"
+          {{- with .Values.server.readinessProbe }}
           readinessProbe:
-            # NOTE(mitchellh): when our HTTP status endpoints support the
-            # proper status codes, we should switch to that. This is temporary.
-            exec:
-              command:
-                - "/bin/sh"
-                - "-ec"
-                - |
-                  {{- if .Values.global.tls.enabled }}
-                  curl \
-                    --cacert /consul/tls/ca/tls.crt \
-                    https://127.0.0.1:8501/v1/status/leader \
-                  {{- else }}
-                  curl http://127.0.0.1:8500/v1/status/leader \
-                  {{- end }}
-                  2>/dev/null | grep -E '".+"'
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            successThreshold: 1
-            timeoutSeconds: 5
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.server.resources }}
           resources:
             {{ tpl .Values.server.resources . | nindent 12 | trim }}

--- a/values.yaml
+++ b/values.yaml
@@ -271,6 +271,32 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # server liveness probe
+  livenessProbe: null
+
+  # server readiness probe
+  readinessProbe:
+    # NOTE(mitchellh): when our HTTP status endpoints support the
+    # proper status codes, we should switch to that. This is temporary.
+    exec:
+      command:
+        - "/bin/sh"
+        - "-ec"
+        - |
+          {{- if .Values.global.tls.enabled }}
+          curl \
+            --cacert /consul/tls/ca/tls.crt \
+            https://127.0.0.1:8501/v1/status/leader \
+          {{- else }}
+          curl http://127.0.0.1:8500/v1/status/leader \
+          {{- end }}
+          2>/dev/null | grep -E '".+"'
+    failureThreshold: 2
+    initialDelaySeconds: 5
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+
 # Add configuration for Consul servers running externally,
 # i.e. outside of Kubernetes.
 # This information is required if Consul servers are running


### PR DESCRIPTION
Consul is unusable with GCE ingress because GCE expects an application to have http probes. This change allows to override probes when needed