### PR TITLE
Image pull secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ FEATURES:
   ```
   [[GH-388](https://github.com/hashicorp/consul-helm/pull/388)]
 
+* Support setting image pull secrets via service accounts [[GH-411](https://github.com/hashicorp/consul-helm/pull/411)].
+
 IMPROVEMENTS:
 
 * Default to the latest version of consul-k8s: `hashicorp/consul-k8s:0.13.0`

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,4 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,9 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -9,4 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -9,9 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -10,4 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -10,9 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,4 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,9 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -10,4 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -10,9 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/templates/tls-init-cleanup-serviceaccount.yaml
@@ -10,5 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/templates/tls-init-cleanup-serviceaccount.yaml
@@ -10,10 +10,11 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-serviceaccount.yaml
+++ b/templates/tls-init-serviceaccount.yaml
@@ -13,5 +13,10 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+  {{- if .Values.global.imagePullSecrets }}
+secrets:
+imagePullSecrets:
+- name: {{ .Values.global.imagePullSecrets }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-serviceaccount.yaml
+++ b/templates/tls-init-serviceaccount.yaml
@@ -13,10 +13,11 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
-  {{- if .Values.global.imagePullSecrets }}
-secrets:
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-- name: {{ .Values.global.imagePullSecrets }}
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/client-serviceaccount.bats
+++ b/test/unit/client-serviceaccount.bats
@@ -51,3 +51,23 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "client/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-serviceaccount.yaml  \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/client-snapshot-agent-serviceaccount.bats
+++ b/test/unit/client-snapshot-agent-serviceaccount.bats
@@ -42,3 +42,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "client/SnapshotAgentServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-snapshot-agent-serviceaccount.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/connect-inject-authmethod-serviceaccount.bats
+++ b/test/unit/connect-inject-authmethod-serviceaccount.bats
@@ -44,3 +44,26 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "connectInjectAuthMethod/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-authmethod-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+

--- a/test/unit/connect-inject-serviceaccount.bats
+++ b/test/unit/connect-inject-serviceaccount.bats
@@ -53,3 +53,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "connectInject/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/connect-inject-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/enterprise-license-serviceaccount.bats
+++ b/test/unit/enterprise-license-serviceaccount.bats
@@ -53,3 +53,26 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "enterpriseLicense/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/enterprise-license-serviceaccount.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -23,3 +23,25 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "meshGateway/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/mesh-gateway-serviceaccount.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -42,3 +42,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "serverACLInitCleanup/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -42,3 +42,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "serverACLInit/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -51,3 +51,23 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "server/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/sync-catalog-serviceaccount.bats
+++ b/test/unit/sync-catalog-serviceaccount.bats
@@ -51,3 +51,24 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "syncCatalog/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/sync-catalog-serviceaccount.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/tls-init-cleanup-serviceaccount.bats
+++ b/test/unit/tls-init-cleanup-serviceaccount.bats
@@ -53,3 +53,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "tlsInitCleanup/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/tls-init-cleanup-serviceaccount.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}

--- a/test/unit/tls-init-serviceaccount.bats
+++ b/test/unit/tls-init-serviceaccount.bats
@@ -53,3 +53,25 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "tlsInit/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/tls-init-serviceaccount.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,7 @@ global:
   #   # Consul Enterprise 1.5.0
   #   image: "hashicorp/consul-enterprise:1.5.0-ent"
   image: "consul:1.7.1"
+  imagePullSecrets: 
 
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as catalog sync. This can be overridden

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,18 @@ global:
   #   # Consul Enterprise 1.5.0
   #   image: "hashicorp/consul-enterprise:1.5.0-ent"
   image: "consul:1.7.1"
-  imagePullSecrets: 
+
+  # array of objects containing image pull secret names that will be applied to
+  # each service account.
+  # This can be used to reference image pull secrets if using
+  # a custom consul or consul-k8s Docker image.
+  # See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry.
+  #
+  # Example:
+  #   imagePullSecrets:
+  #   - name: pull-secret-name
+  #   - name: pull-secret-name-2
+  imagePullSecrets: []
 
   # imageK8S is the name (and tag) of the consul-k8s Docker image that
   # is used for functionality such as catalog sync. This can be overridden


### PR DESCRIPTION
Allow setting image pull secrets for service accounts to enable pulling the consul-k8s and consul images from private registries.

Kube docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account

Notes
* Refactors work from https://github.com/hashicorp/consul-helm/pull/402 (thanks!!)
* Closes https://github.com/hashicorp/consul-helm/pull/402
* Closes #270 