### PR TITLE
Use copied consul binary

### DIFF
--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -190,7 +190,7 @@ spec:
                 }
                 EOF
 
-                consul services register \
+                /consul-bin/consul services register \
                   {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                   -token-file=/consul/service/acl-token \
                   {{- end }}
@@ -198,6 +198,8 @@ spec:
           volumeMounts:
             - name: consul-service
               mountPath: /consul/service
+            - name: consul-bin
+              mountPath: /consul-bin
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt }}
             - name: consul-auto-encrypt-ca-cert
@@ -303,6 +305,8 @@ spec:
             - name: consul-service
               mountPath: /consul/service
               readOnly: true
+            - name: consul-bin
+              mountPath: /consul-bin
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt }}
             - name: consul-auto-encrypt-ca-cert
@@ -334,7 +338,7 @@ spec:
             - consul-k8s
             - lifecycle-sidecar
             - -service-config=/consul/service/service.hcl
-            - -consul-binary=/bin/consul
+            - -consul-binary=/consul-bin/consul
             {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
             - -token-file=/consul/service/acl-token
             {{- end }}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -663,7 +663,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -718,7 +718,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   -token-file=/consul/service/acl-token \
   /consul/service/service.hcl'
 
@@ -772,7 +772,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -820,7 +820,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -866,7 +866,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -912,7 +912,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -973,7 +973,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -1040,7 +1040,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -1089,7 +1089,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -1157,7 +1157,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -1206,7 +1206,7 @@ service {
 }
 EOF
 
-consul services register \
+/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]


### PR DESCRIPTION
Previously we were testing with a consul-k8s image that has consul in
its path but our regular consul-k8s image does not have the consul
binary included. Instead, we should use the consul binary that gets
copied into the shared volume by the consul-bin init container. init
containers run in order and wait until completion until running the next
init container so this is safe to do.