### PR TITLE
Use /home/consul-k8s as working dir

### DIFF
--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -136,8 +136,8 @@ spec:
                 consul-k8s service-address \
                   -k8s-namespace={{ .Release.Namespace }} \
                   -name={{ template "consul.fullname" . }}-mesh-gateway \
-                  -output-file=address.txt
-                WAN_ADDR="$(cat address.txt)"
+                  -output-file=/tmp/address.txt
+                WAN_ADDR="$(cat /tmp/address.txt)"
                 {{- else if eq $source "Static" }}
                 {{- if eq .Values.meshGateway.wanAddress.static "" }}{{ fail "if meshGateway.wanAddress.source=Static then meshGateway.wanAddress.static cannot be empty" }}{{ end }}
                 WAN_ADDR="{{ .Values.meshGateway.wanAddress.static }}"

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -632,8 +632,8 @@ key2: value2' \
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF
@@ -687,8 +687,8 @@ EOF
 consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF
@@ -738,8 +738,8 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF
@@ -1009,8 +1009,8 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF
@@ -1126,8 +1126,8 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF
@@ -1175,8 +1175,8 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-mesh-gateway \
-  -output-file=address.txt
-WAN_ADDR="$(cat address.txt)"
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
 
 cat > /consul/service/service.hcl << EOF


### PR DESCRIPTION
consul-k8s runs as the consul-k8s user who doesn't have permissions to
write to / since that's owned by root. Instead we use our home directory
where we have permissions to write address.txt and service.hcl files.