### PR TITLE
tls-init-cleanup can run if pre-install fails

### DIFF
--- a/templates/tls-init-cleanup-clusterrole.yaml
+++ b/templates/tls-init-cleanup-clusterrole.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 rules:
 - apiGroups: [""]
   resources:

--- a/templates/tls-init-cleanup-clusterrolebinding.yaml
+++ b/templates/tls-init-cleanup-clusterrolebinding.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -13,6 +13,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    {{- /* Hook weight needs to be 1 so that the service account is provisioned first */}}
+    "helm.sh/hook-weight": "1"
 spec:
   template:
     metadata:

--- a/templates/tls-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/tls-init-cleanup-podsecuritypolicy.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/templates/tls-init-cleanup-serviceaccount.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy":  hook-succeeded
+    "helm.sh/hook-delete-policy":  hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:


### PR DESCRIPTION
If the pre-install hooks failed, then no non-hook resources get created.
This means that the tls-init-cleanup service account doesn't get
created. Then if the user runs helm delete, the tls-init-cleanup job
tries to run but never starts because it doesn't have its service
account. helm delete then hangs forever.

The fix is to ensure that the resources needed by the cleanup job get
created even if the pre-install hook failed. To do this, we mark them as
part of the pre-delete hook and Helm will ensure they get created.

Another snag is that Helm creates the Job before the service account. To
fix this, we set the weight of the job to 1 so that it is created after
the service account. This is a known helm issue: https://github.com/helm/helm/issues/7447

Also adds `before-hook-creation` to the deletion policy for the `tls-init-job` so that if a user does  run a helm delete, they can run a helm install and the job will get deleted instead of helm complaining that the job already exists.

Fixes https://github.com/hashicorp/consul-helm/issues/418

### Reproduction
To reproduce, you need to cause a failure in the pre-install hooks. An easy way to do this is to set the `tls-init-job`'s service account to one that doesn't exist:
```
# tls-init-job.yaml
      serviceAccountName: not-exist
```

Run `helm install` with a values file that has `tls.enabled=true`. The helm install will hang forever and eventually time out. Ctrl-C it so you don't have to wait.

Then run `helm delete`. You'll see the `tls-init-cleanup` job is created but it never completes. If you describe the job it'll say its service account doesn't exist. The helm delete will hang forever. If you Ctrl-C it and then try to run `helm install` you'll get an error that the release already exists. You have to manually delete the helm secret to fix the issue (or manually create the cleanup job's service account).

Now check out this branch and perform the same steps (you'll need to make sure you delete the init job's service account and job first). The `helm delete` should succeed.