### PR TITLE
ACLs: Support external servers

### DIFF
--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* See reason for this in server-acl-init-job.yaml */ -}}

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* See reason for this in server-acl-init-job.yaml */ -}}
 {{- if eq (int .Values.server.updatePartition) 0 }}

--- a/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -1,5 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1

--- a/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1
 kind: ServiceAccount

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -31,11 +31,8 @@ rules:
   - apiGroups: [""]
     resources:
       - serviceaccounts
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - services
+    resourceNames:
+      - {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
     verbs:
       - get
 {{- end }}

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
@@ -32,7 +33,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
-      {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey)) }}
+      {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
       volumes:
         {{- if .Values.global.tls.enabled }}
         - name: consul-ca-cert
@@ -46,7 +47,14 @@ spec:
               - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
                 path: tls.crt
         {{- end }}
-        {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+        {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+        - name: bootstrap-token
+          secret:
+            secretName: {{ .Values.global.acls.bootstrapToken.secretName }}
+            items:
+              - key: {{ .Values.global.acls.bootstrapToken.secretKey }}
+                path: bootstrap-token
+        {{- else if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
         - name: acl-replication-token
           secret:
             secretName: {{ .Values.global.acls.replicationToken.secretName }}
@@ -63,14 +71,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey)) }}
+          {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
           volumeMounts:
             {{- if .Values.global.tls.enabled }}
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-            {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+            {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+            - name: bootstrap-token
+              mountPath: /consul/acl/tokens
+              readOnly: true
+            {{- else if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
             - name: acl-replication-token
               mountPath: /consul/acl/tokens
               readOnly: true
@@ -83,15 +95,31 @@ spec:
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
               consul-k8s server-acl-init \
+                {{- if .Values.externalServers.enabled }}
+                {{- if not (or .Values.externalServers.https.address .Values.client.join)}}{{ fail "either client.join or externalServers.https.address must be set if externalServers.enabled is true" }}{{ end -}}
+                {{- if .Values.externalServers.https.address }}
+                -server-address={{ .Values.externalServers.https.address }} \
+                {{- else }}
+                {{- range .Values.client.join }}
+                -server-address={{ . }} \
+                {{- end }}
+                {{- end }}
+                -server-port={{ .Values.externalServers.https.port }} \
+                {{- else }}
                 {{- range $index := until (.Values.server.replicas | int) }}
                 -server-address="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
                 {{- end }}
-                -resource-prefix={{ template "consul.fullname" . }} \
+                {{- end }}
+                -resource-prefix=${CONSUL_FULLNAME} \
                 -k8s-namespace={{ .Release.Namespace }} \
                 {{- if .Values.global.tls.enabled }}
                 -use-https \
+                {{- if not (and .Values.externalServers.enabled .Values.externalServers.https.useSystemRoots) }}
                 -consul-ca-cert=/consul/tls/ca/tls.crt \
+                {{- end }}
+                {{- if not .Values.externalServers.enabled }}
                 -server-port=8501 \
+                {{- end }}
                 {{- end }}
                 {{- if .Values.syncCatalog.enabled }}
                 -create-sync-token=true \
@@ -120,7 +148,9 @@ spec:
                 {{- if .Values.global.acls.createReplicationToken }}
                 -create-acl-replication-token=true \
                 {{- end }}
-                {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
+                {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+                -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
+                {{- else if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
                 -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
                 {{- end }}
                 {{- if .Values.global.enableConsulNamespaces }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -129,6 +129,8 @@ spec:
                 {{- end }}
                 {{- if .Values.connectInject.enabled }}
                 -create-inject-auth-method=true \
+                -inject-auth-method-host={{ .Values.connectInject.authMethodConfig.host }} \
+                -inject-auth-method-ca-cert={{ .Values.connectInject.authMethodConfig.caCert | quote }} \
                 {{- end }}
                 {{- if .Values.meshGateway.enabled }}
                 -create-mesh-gateway-token=true \

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- /* We don't render this job when server.updatePartition > 0 because that
@@ -129,8 +130,9 @@ spec:
                 {{- end }}
                 {{- if .Values.connectInject.enabled }}
                 -create-inject-auth-method=true \
-                -inject-auth-method-host={{ .Values.connectInject.authMethodConfig.host }} \
-                -inject-auth-method-ca-cert={{ .Values.connectInject.authMethodConfig.caCert | quote }} \
+                {{- if .Values.connectInject.overrideAuthMethodHost }}
+                -inject-auth-method-host={{ .Values.connectInject.overrideAuthMethodHost }} \
+                {{- end }}
                 {{- end }}
                 {{- if .Values.meshGateway.enabled }}
                 -create-mesh-gateway-token=true \

--- a/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}

--- a/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1
 kind: ServiceAccount

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: v1

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -138,6 +138,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'client.join[0]=consul-server.com' \
       . | tee /dev/stderr |
@@ -162,6 +163,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=consul.io' \
       . | tee /dev/stderr |
@@ -197,6 +199,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=consul.io' \
       --set 'externalServers.https.port=8501' \
@@ -222,6 +225,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=consul.io' \
       --set 'externalServers.https.tlsServerName=custom-server-name' \
@@ -237,6 +241,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=consul.io' \
       --set 'externalServers.https.useSystemRoots=true' \
@@ -252,6 +257,7 @@ load _helpers
       -x templates/tests/test-runner.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=consul.io' \
       --set 'externalServers.https.useSystemRoots=true' \

--- a/test/unit/server-acl-init-cleanup-clusterrole.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrole.bats
@@ -43,6 +43,18 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInitCleanup/ClusterRole: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 

--- a/test/unit/server-acl-init-cleanup-clusterrole.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrole.bats
@@ -43,16 +43,36 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/ClusterRole: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ClusterRole: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInitCleanup/ClusterRole: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
@@ -43,14 +43,34 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ClusterRoleBinding: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInitCleanup/ClusterRoleBinding: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }

--- a/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-clusterrolebinding.bats
@@ -42,3 +42,15 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInitCleanup/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -64,14 +64,34 @@ load _helpers
   [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","release-name-consul-server-acl-init"]' ]
 }
 
-@test "serverACLInitCleanup/Job: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/Job: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/Job: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInitCleanup/Job: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -63,3 +63,15 @@ load _helpers
       yq -c '.spec.template.spec.containers[0].args' | tee /dev/stderr)
   [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","release-name-consul-server-acl-init"]' ]
 }
+
+@test "serverACLInitCleanup/Job: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
+++ b/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
@@ -33,10 +33,11 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/PodSecurityPolicy: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/PodSecurityPolicy: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'externalServers.enabled=true' \
@@ -44,4 +45,25 @@ load _helpers
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/PodSecurityPolicy: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInitCleanup/PodSecurityPolicy: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }

--- a/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
+++ b/test/unit/server-acl-init-cleanup-podsecuritypolicy.bats
@@ -32,3 +32,16 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInitCleanup/PodSecurityPolicy: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-podsecuritypolicy.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -43,16 +43,36 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/ServiceAccount: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInitCleanup/ServiceAccount: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }
 
 #--------------------------------------------------------------------
@@ -75,4 +95,3 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
-

--- a/test/unit/server-acl-init-cleanup-serviceaccount.bats
+++ b/test/unit/server-acl-init-cleanup-serviceaccount.bats
@@ -43,6 +43,18 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInitCleanup/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-cleanup-serviceaccount.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # global.imagePullSecrets
 
@@ -63,3 +75,4 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -43,14 +43,34 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-clusterrolebinding.yaml \
+      --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ClusterRoleBinding: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInit/ClusterRoleBinding: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }

--- a/test/unit/server-acl-init-clusterrolebinding.bats
+++ b/test/unit/server-acl-init-clusterrolebinding.bats
@@ -42,3 +42,15 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInit/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1108,7 +1108,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-inject-auth-method-host=foo.com"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-inject-auth-method-host"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -890,17 +890,17 @@ load _helpers
 
   # Test the flag is not set.
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   # Test the volume doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # Test the volume mount doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -914,17 +914,17 @@ load _helpers
 
   # Test the flag is not set.
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   # Test the volume doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # Test the volume mount doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -943,12 +943,12 @@ load _helpers
 
   # Test the volume doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # Test the volume mount doesn't exist
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -963,16 +963,38 @@ load _helpers
 
   # Test the -bootstrap-token-file flag is set.
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file=/consul/acl/tokens/bootstrap-token"))' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file=/consul/acl/tokens/bootstrap-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # Test the volume exists
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.volumes | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
+  yq '.spec.template.spec.volumes | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # Test the volume mount exists
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].volumeMounts | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
+  yq '.spec.template.spec.containers[0].volumeMounts | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# connectInject.authMethodConfig
+
+@test "serverACLInit/Job: can provide custom auth method configuration" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.authMethodConfig.host=foo.com' \
+      --set 'connectInject.authMethodConfig.caCert=ca-cert' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+  yq '.spec.template.spec.containers[0].command | any(contains("-inject-auth-method-host=foo.com"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$object" |
+  yq '.spec.template.spec.containers[0].command | any(contains("-inject-auth-method-ca-cert=\"ca-cert\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -800,3 +800,179 @@ load _helpers
     yq '.spec.template.spec.containers[0].volumeMounts | map(select(.name == "acl-replication-token")) | length == 1' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# externalServers.enabled
+
+@test "serverACLInit/Job: fails if external servers are enabled but neither externalServers.https.address nor client.join are set" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "either client.join or externalServers.https.address must be set if externalServers.enabled is true" ]]
+}
+
+@test "serverACLInit/Job: sets server address if externalServers.https.address is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-address=foo.com"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: sets server address to the client.join value if externalServers.https.address is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.join[0]=1.1.1.1' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-address=1.1.1.1"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: can override externalServers.https.port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.join[0]=1.1.1.1' \
+      --set 'externalServers.https.port=8501' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-port=8501"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: doesn't set server port to 8501 if TLS is enabled and externalServers.enabled is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.join[0]=1.1.1.1' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-port=8501"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: doesn't set the CA cert if TLS is enabled and externalServers.https.useSystemRoots is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.join[0]=1.1.1.1' \
+      --set 'externalServers.https.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-ca-cert=/consul/tls/ca/tls.crt"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# global.acls.bootstrapToken
+
+@test "serverACLInit/Job: -bootstrap-token-file is not set by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr)
+
+  # Test the flag is not set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  # Test the volume doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  # Test the volume mount doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: -bootstrap-token-file is not set when acls.bootstrapToken.secretName is set but secretKey is not" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=name' \
+      . | tee /dev/stderr)
+
+  # Test the flag is not set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  # Test the volume doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  # Test the volume mount doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: -bootstrap-token-file is not set when acls.bootstrapToken.secretKey is set but secretName is not" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretKey=key' \
+      . | tee /dev/stderr)
+
+  # Test the flag is not set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  # Test the volume doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  # Test the volume mount doesn't exist
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: -bootstrap-token-file is set when acls.bootstrapToken.secretKey and secretName are set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=name' \
+      --set 'global.acls.bootstrapToken.secretKey=key' \
+      . | tee /dev/stderr)
+
+  # Test the -bootstrap-token-file flag is set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file=/consul/acl/tokens/bootstrap-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  # Test the volume exists
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.volumes | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  # Test the volume mount exists
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[0].volumeMounts | map(select(.name == "bootstrap-token")) | length == 1' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-podsecuritypolicy.bats
+++ b/test/unit/server-acl-init-podsecuritypolicy.bats
@@ -32,3 +32,16 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "serverACLInit/PodSecurityPolicy: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-podsecuritypolicy.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -43,6 +43,18 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.https.address=foo.com' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # global.imagePullSecrets
 

--- a/test/unit/server-acl-init-serviceaccount.bats
+++ b/test/unit/server-acl-init-serviceaccount.bats
@@ -43,16 +43,36 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/ServiceAccount: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-acl-init-serviceaccount.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.https.address=foo.com' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/ServiceAccount: fails if both externalServers.enabled=true and server.enabled=true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-serviceaccount.yaml  \
+      --set 'server.enabled=true' \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
+}
+
+@test "serverACLInit/ServiceAccount: fails if both externalServers.enabled=true and server.enabled not set to false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-serviceaccount.yaml \
+      --set 'externalServers.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "only one of server.enabled or externalServers.enabled can be set" ]]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -172,6 +172,15 @@ global:
     # Additionally, requires Consul >= 1.4 and consul-k8s >= 0.14.0.
     manageSystemACLs: false
 
+    # bootstrapToken references a Kubernetes secret containing the bootstrap token to use
+    # for creating policies and tokens for all Consul and consul-k8s components.
+    # If set, we will skip ACL bootstrapping of the servers and will only initialize
+    # ACLs for the Consul and consul-k8s system components.
+    # Requires consul-k8s >= 0.14.0
+    bootstrapToken:
+      secretName: null
+      secretKey: null
+
     # If true, an ACL token will be created that can be used in secondary
     # datacenters for replication. This should only be set to true in the
     # primary datacenter since the replication token must be created from that
@@ -307,10 +316,10 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
-# Add configuration for Consul servers running externally,
-# i.e. outside of Kubernetes.
-# This information is required if Consul servers are running
-# outside of k8s and you’re setting global.tls.enableAutoEncrypt to true.
+# Add configuration for Consul servers running outside of Kubernetes.
+# This configuration is recommended if setting global.tls.enableAutoEncrypt to true (requires consul-k8s >= 0.13.0)
+# or global.acls.manageSystemACLs to true (requires consul-k8s >= 0.14.0) and running
+# Consul servers outside of the current Kubernetes cluster.
 externalServers:
   enabled: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -325,6 +325,7 @@ server:
 externalServers:
   # If true, the Helm chart will be configured to talk to the external servers.
   # If setting this to true, you must also set server.enabled to false.
+  # Note that if you are setting client.join property, https.address property is not required.
   enabled: false
 
   # HTTPS configuration for external servers.

--- a/values.yaml
+++ b/values.yaml
@@ -192,7 +192,7 @@ global:
     # replicationToken references a secret containing the replication ACL token.
     # This token will be used by secondary datacenters to perform ACL replication
     # and create ACL tokens and policies.
-    # # This value is ignored if bootstrapToken is also set.
+    # This value is ignored if bootstrapToken is also set.
     # Requires consul-k8s >= 0.13.0
     replicationToken:
       secretName: null

--- a/values.yaml
+++ b/values.yaml
@@ -790,6 +790,21 @@ connectInject:
   # auth method for Connect inject, set this to the name of your auth method.
   overrideAuthMethodName: ""
 
+  # Custom configuration for the Kubernetes auth method to be used when
+  # global.acls.manageSystemACLs is set to true. Please see
+  # https://www.consul.io/docs/acl/auth-methods/kubernetes.html.
+  #
+  # This is useful when Consul servers are deployed outside of
+  # the Kubernetes cluster. Requires consul-k8s >= 0.14.0.
+  authMethodConfig:
+    # host corresponds to the Consul's Host configuration parameter
+    # ref: https://www.consul.io/docs/acl/auth-methods/kubernetes.html#host.
+    host: ""
+
+    # caCert is the base64-encoded PEM-encoded CA certificate string
+    # for this Kubernetes cluster.
+    caCert: ""
+
   # aclInjectToken refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which allows the Connect injector the correct
   # permissions. This is only needed if Consul namespaces [Enterprise only] and ACLs

--- a/values.yaml
+++ b/values.yaml
@@ -332,6 +332,7 @@ externalServers:
   # not supported.
   https:
     # IP, DNS name, or Cloud auto-join string pointing to the external Consul servers.
+    # Port must be provided separately with the externalServers.https.port property.
     # Note that if you’re providing the cloud auto-join string and multiple addresses
     # can be returned, only the first address will be used.
     # This value is required only if you would like to use

--- a/values.yaml
+++ b/values.yaml
@@ -168,8 +168,7 @@ global:
   acls:
 
     # If true, the Helm chart will automatically manage ACL tokens and policies
-    # for all Consul and consul-k8s components. This requires servers to be running inside Kubernetes.
-    # Additionally, requires Consul >= 1.4 and consul-k8s >= 0.14.0.
+    # for all Consul and consul-k8s components. This requires Consul >= 1.4 and consul-k8s >= 0.14.0.
     manageSystemACLs: false
 
     # bootstrapToken references a Kubernetes secret containing the bootstrap token to use
@@ -187,11 +186,14 @@ global:
     # datacenter.
     # In secondary datacenters, the secret needs to be imported from the primary
     # datacenter and referenced via global.acls.replicationToken.
+    # Requires consul-k8s >= 0.13.0
     createReplicationToken: false
 
     # replicationToken references a secret containing the replication ACL token.
     # This token will be used by secondary datacenters to perform ACL replication
     # and create ACL tokens and policies.
+    # # This value is ignored if bootstrapToken is also set.
+    # Requires consul-k8s >= 0.13.0
     replicationToken:
       secretName: null
       secretKey: null
@@ -316,11 +318,13 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
-# Add configuration for Consul servers running outside of Kubernetes.
-# This configuration is recommended if setting global.tls.enableAutoEncrypt to true (requires consul-k8s >= 0.13.0)
-# or global.acls.manageSystemACLs to true (requires consul-k8s >= 0.14.0) and running
-# Consul servers outside of the current Kubernetes cluster.
+# Configuration for Consul servers when the servers are running outside of Kubernetes.
+# When running external servers, configuring these values is recommended
+# if setting global.tls.enableAutoEncrypt to true (requires consul-k8s >= 0.13.0)
+# or global.acls.manageSystemACLs to true (requires consul-k8s >= 0.14.0).
 externalServers:
+  # If true, the Helm chart will be configured to talk to the external servers.
+  # If setting this to true, you must also set server.enabled to false.
   enabled: false
 
   # HTTPS configuration for external servers.
@@ -786,24 +790,16 @@ connectInject:
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
   aclBindingRuleSelector: "serviceaccount.name!=default"
 
-  # If not using global.acls.manageSystemACLs and instead manually setting up an
+  # If you are not using global.acls.manageSystemACLs and instead manually setting up an
   # auth method for Connect inject, set this to the name of your auth method.
   overrideAuthMethodName: ""
 
-  # Custom configuration for the Kubernetes auth method to be used when
-  # global.acls.manageSystemACLs is set to true. Please see
-  # https://www.consul.io/docs/acl/auth-methods/kubernetes.html.
-  #
-  # This is useful when Consul servers are deployed outside of
-  # the Kubernetes cluster. Requires consul-k8s >= 0.14.0.
-  authMethodConfig:
-    # host corresponds to the Consul's Host configuration parameter
-    # ref: https://www.consul.io/docs/acl/auth-methods/kubernetes.html#host.
-    host: ""
-
-    # caCert is the base64-encoded PEM-encoded CA certificate string
-    # for this Kubernetes cluster.
-    caCert: ""
+  # If you are using global.acls.manageSystemACLs but also setting externalServers.enabled
+  # to true, set overrideAuthMethodHost to the address of the Kubernetes API server.
+  # This address must to be reachable from the Consul servers.
+  # Please see https://www.consul.io/docs/acl/auth-methods/kubernetes.html.
+  # Requires consul-k8s >= 0.14.0.
+  overrideAuthMethodHost: ""
 
   # aclInjectToken refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which allows the Connect injector the correct


### PR DESCRIPTION
## Problem
Currently, we support ACL bootstrapping only if the servers are also deployed on Kubernetes. If you're running servers elsewhere, we currently recommend bootstrapping ACLs yourself and setting up the correct policies and tokens for the k8s components. You could then set them as values, e.g. `syncCatalog.aclSyncToken` or `connectInject.overrideAuthMethodName` and `connectInject.aclInjectToken`. 

However, figuring out the right policies is hard, and creating them yourself is still a manual process. Even though servers are running externally, our knowledge about the policies and tokens you need doesn't change since we still consume them from the Helm chart. The workaround right now is to create a Kubernetes secret with the bootstrap token named something that the Helm chart expects. This will trick the job into thinking that the bootstrapping was already done and it will continue to create tokens and policies for the rest of the components.

See #413 for a bit more details.

## Proposal
This PR proposes to use the new `externalServers` configuration to enable the server-acl-init job to talk to external servers. 

It also provides two ways of "initializing" ACLs for external servers:
1. You can run bootstrap ACLs yourself via the `acl/bootstrap` API and then provide the bootstrap token by setting `global.acls.bootstrapToken` secret. The Helm config for this use case could look like this:
    ```yaml
    global:
      enabled: false
      acls:
        manageSystemACLs: true
        bootstrapToken:
          secretName: consul-bootstrap-acl-token
          secretKey: token
    externalServers:
      enabled: true
    client:
      enabled: true
      join: [<retry_join address(es)>]
    connectInject:
      enabled: true
      overrideAuthMethodHost: <external address of the kube api server>
    ...
    ```
1.  You can let the server-acl-init job to call the bootstrapping API. It will behave in the same way as when the servers are running on k8s and will save the bootstrap token as a Kubernetes secret. In this case, the Helm config will look like this:
    ```yaml
    global:
      enabled: false
      acls:
        manageSystemACLs: true
    externalServers:
      enabled: true
    client:
      enabled: true
      join: [<retry_join address(es)>]
    connectInject:
      enabled: true
      overrideAuthMethodHost: <external address of the kube api server>
    ...
    ```

### Testing
This PR can be tested  on AKS with the Helm configs above and the `ishustava/consul-k8s-dev:04-16-2020-ae132bc` image.

Requires #401 to be merged first.