### PR TITLE
Enable custom label ability

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -30,10 +30,13 @@ spec:
         release: {{ .Release.Name }}
         component: client
         hasDNS: "true"
+        {{- if .Values.client.labels -}}
+          {{- tpl .Values.client.labels . | trim | nindent 8 -}}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if .Values.client.annotations }}
-          {{- tpl .Values.client.annotations . | nindent 8 }}
+        {{- if .Values.client.annotations -}}
+          {{- tpl .Values.client.annotations . | trim | nindent 8 -}}
         {{- end }}
     spec:
     {{- if .Values.client.affinity }}

--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.dns.labels -}}
+      {{- tpl .Values.dns.labels . | trim | nindent 4 -}}
+    {{- end }}
   {{- if .Values.dns.annotations }}
   annotations:
     {{ tpl .Values.dns.annotations . | nindent 4 | trim }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -30,10 +30,13 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: mesh-gateway
+        {{- if .Values.meshGateway.labels -}}
+        {{- tpl .Values.meshGateway.labels . | trim | nindent 8 -}}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.meshGateway.annotations }}
-        {{- tpl .Values.meshGateway.annotations . | nindent 8 }}
+        {{- tpl .Values.meshGateway.annotations . | trim | nindent 8 -}}
         {{- end }}
     spec:
       {{- if .Values.meshGateway.affinity }}

--- a/templates/mesh-gateway-service.yaml
+++ b/templates/mesh-gateway-service.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
+    {{- if .Values.meshGateway.service.labels -}}
+    {{- tpl .Values.meshGateway.service.labels . | trim | nindent 4 -}}
+    {{- end }}
   {{- if .Values.meshGateway.service.annotations }}
   annotations:
     {{ tpl .Values.meshGateway.service.annotations . | nindent 4 | trim }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -14,6 +14,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.server.service.labels }}
+    {{ tpl .Values.server.service.labels . | nindent 4 | trim }}
+    {{- end }}
   annotations:
     {{- if .Values.server.service.annotations }}
     {{ tpl .Values.server.service.annotations . | nindent 4 | trim }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -36,10 +36,13 @@ spec:
         release: {{ .Release.Name }}
         component: server
         hasDNS: "true"
+        {{- if .Values.server.labels }}
+        {{- tpl .Values.server.labels . | trim | nindent 8 -}}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.server.annotations }}
-          {{- tpl .Values.server.annotations . | nindent 8 }}
+          {{- tpl .Values.server.annotations . | trim | nindent 8 }}
         {{- end }}
     spec:
     {{- if .Values.server.affinity }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.ui.service.labels -}}
+    {{- tpl .Values.ui.service.labels . | trim | nindent 4 -}}
+    {{- end }}
   {{- if .Values.ui.service.annotations }}
   annotations:
     {{ tpl .Values.ui.service.annotations . | nindent 4 | trim }}

--- a/values.yaml
+++ b/values.yaml
@@ -284,6 +284,13 @@ server:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # Extra labels to attach to the server pods.
+  # This should be a multi-line YAML string.
+  # Example:
+  #   labels: |
+  #     "label-key": "label-value"
+  labels: null
+
   # Extra annotations to attach to the server pods.
   # This should be a multi-line YAML string.
   # Example:
@@ -292,6 +299,12 @@ server:
   annotations: null
 
   service:
+    # Labels to apply to the server service.
+    # Example:
+    #   labels: |
+    #     "label-key": "label-value"
+    labels: null
+
     # Annotations to apply to the server service.
     # Example:
     #   annotations: |
@@ -420,6 +433,13 @@ client:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # Extra labels to attach to the client pods.
+  # This should be a multi-line YAML string.
+  # Example:
+  #   labels: |
+  #     "label-key": "label-value"
+  labels: null
+
   # Extra annotations to attach to the client pods
   # Example:
   #   annotations: |
@@ -483,6 +503,14 @@ dns:
   # address in CoreDNS config.
   clusterIP: null
 
+  # Extra labels to attach to the dns service
+  # This should be a multi-line string of
+  # labels to apply to the dns Service
+  # Example:
+  #   labels: |
+  #     "label-key": "label-value"
+  labels: null
+
   # Extra annotations to attach to the dns service
   # This should be a multi-line string of
   # annotations to apply to the dns Service
@@ -503,6 +531,12 @@ ui:
   service:
     enabled: true
     type: null
+
+    # Labels to apply to the UI service.
+    # Example:
+    #   labels: |
+    #     "label-key": "label-value"
+    labels: null
 
     # Annotations to apply to the UI service.
     # Example:
@@ -886,6 +920,12 @@ meshGateway:
     # a port.
     nodePort: null
 
+    # Labels to apply to the mesh gateway service.
+    # Example:
+    #   labels: |
+    #     "label-key": "label-value"
+    labels: null
+
     # Annotations to apply to the mesh gateway service.
     # Example:
     #   annotations: |
@@ -955,6 +995,12 @@ meshGateway:
 
   # Optional priorityClassName.
   priorityClassName: ""
+
+  # Labels to apply to the mesh gateway deployment.
+  # Example:
+  #   labels: |
+  #     "label-key": "label-value"
+  labels: null
 
   # Annotations to apply to the mesh gateway deployment.
   # Example:


### PR DESCRIPTION
Fixes #410.

Every component that allowed custom annotations now allows custom labels. This is also a personal need as many of my `NetworkPolicies` rely on label matching.