### PR TITLE
Allow sync-catalog to run against external consul servers

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -54,6 +54,10 @@ spec:
       {{- if .Values.client.dnsPolicy }}
       dnsPolicy: {{ .Values.client.dnsPolicy }}
       {{- end }}
+      
+      {{- if .Values.client.hostNetwork }}
+      hostNetwork: {{ .Values.client.hostNetwork }}
+      {{- end }}
 
       volumes:
         - name: data

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -54,9 +54,13 @@ spec:
           image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
           env:
             - name: HOST_IP
+            {{- if .Values.global.externalHostIP }}
+              value: {{ .Values.global.externalHostIP }}
+            {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -54,8 +54,8 @@ spec:
           image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
           env:
             - name: HOST_IP
-            {{- if .Values.global.externalHostIP }}
-              value: {{ .Values.global.externalHostIP }}
+            {{- if .Values.externalServers.enabled }}
+              value: "{{ .Values.externalServers.address }}"
             {{- else }}
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Hi,

This teeny PR allows running consul-sync from within K8s against Consul servers that are not in the K8s cluster.

Please let me know if this is a feature you'd be happy to merge in, including if adding this to `externalServers` is the right place (this seems to be the intention for that section, even if it's only used for TLS configuration right now).

Cheers,
--Kieran