### PR TITLE
client.join and externalServers.hosts can accept cloud auto-join with spaces

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -207,12 +207,12 @@ spec:
                 {{- end }}
                 {{- if .Values.client.join }}
                 {{- range $value := .Values.client.join }}
-                -retry-join={{ $value }} \
+                -retry-join={{ quote $value }} \
                 {{- end }}
                 {{- else }}
                 {{- if .Values.server.enabled }}
                 {{- range $index := until (.Values.server.replicas | int) }}
-                -retry-join=${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
+                -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -99,7 +99,7 @@ spec:
                 {{- if .Values.externalServers.enabled }}
                 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
                 {{- range .Values.externalServers.hosts }}
-                -server-address={{ . }} \
+                -server-address={{ quote . }} \
                 {{- end }}
                 -server-port={{ .Values.externalServers.httpsPort }} \
                 {{- else }}

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -194,6 +194,20 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "helper/consul.getAutoEncryptClientCA: can pass cloud auto-join string to server address via externalServers.hosts" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/tests/test-runner.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=provider=my-cloud config=val' \
+      . | tee /dev/stderr |
+      yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | any(contains("-server-addr=\"provider=my-cloud config=val\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "helper/consul.getAutoEncryptClientCA: can set TLS server name if externalServers.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -856,7 +856,20 @@ load _helpers
       --set 'externalServers.enabled=true' \
       --set 'externalServers.hosts[0]=foo.com' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-server-address=foo.com"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-address=\"foo.com\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: can pass cloud auto-join string to server address via externalServers.hosts" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=provider=my-cloud config=val' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-server-address=\"provider=my-cloud config=val\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 


### PR DESCRIPTION
### Testing instructions:
This can be tested by setting `client.join` to `["provider=k8s label_selector=\"app=consul,component=server\""]` and adding pod listing perms to the client cluster role locally:

`config.yaml`:
```yaml
client:
  join: ["provider=k8s label_selector=\"app=consul,component=server\""]
```

Replace [`rules: []`](https://github.com/hashicorp/consul-helm/blob/2edbe56144241f09bf908d63de122a973fe4583e/templates/client-clusterrole.yaml#L31) in the `templates/client-clusterrole.yaml` with the following:
```yaml
rules:
- apiGroups: [""]
  resources:
    - pods
  verbs:
    - list
``` 

Then run `helm install`:
```bash
helm install hashicorp -f config.yaml .
```

