### PR TITLE
Add ability to mount and to pass custom cacert values for curl commands

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -63,6 +63,19 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/*
+Calculate Kubernetes API CA path
+*/}}
+{{- define "consul.kubernetesCApath" -}}
+{{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) -}}
+{{- if .Values.global.tls.kubernetesCAchain.secretName -}}
+{{- print "/consul/tls/ca/k8s-ca-chain/k8s-ca-chain.crt" -}}
+{{- else -}}
+{{- print "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get Consul client CA to use when auto-encrypt is enabled.
 This template is for an init container.
 */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -66,12 +66,10 @@ Inject extra environment vars in the format key:value, if populated
 Calculate Kubernetes API CA path
 */}}
 {{- define "consul.kubernetesCApath" -}}
-{{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) -}}
 {{- if .Values.global.tls.kubernetesCAchain.secretName -}}
 {{- print "/consul/tls/ca/k8s-ca-chain/k8s-ca-chain.crt" -}}
 {{- else -}}
 {{- print "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -29,6 +29,15 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init-cleanup
+      {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName .Values.global.tls.kubernetesCAchain.secretName) }}
+      volumes:
+      - name: k8s-ca-chain
+        secret:
+          secretName: {{ .Values.global.tls.kubernetesCAchain.secretName }}
+          items:
+          - key: {{ default "k8s-ca-chain.crt" .Values.global.tls.kubernetesCAchain.secretKey }}
+            path: k8s-ca-chain.crt
+      {{- end }}
       containers:
         - name: tls-init-cleanup
           image: "{{ .Values.global.image }}"
@@ -42,15 +51,21 @@ spec:
             - "-ec"
             - |
               {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
-              curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X DELETE --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-ca-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
-              curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X DELETE --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-ca-key \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
               {{- end }}
-              curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X DELETE --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-server-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
+          {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName .Values.global.tls.kubernetesCAchain.secretName) }}
+          volumeMounts:
+            - name: k8s-ca-chain
+              mountPath: /consul/tls/ca/k8s-ca-chain
+              readOnly: true
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init-cleanup
-      {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName .Values.global.tls.kubernetesCAchain.secretName) }}
+      {{- if .Values.global.tls.kubernetesCAchain.secretName }}
       volumes:
       - name: k8s-ca-chain
         secret:
@@ -61,7 +61,7 @@ spec:
               curl -s -X DELETE --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-server-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
-          {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName .Values.global.tls.kubernetesCAchain.secretName) }}
+          {{- if .Values.global.tls.kubernetesCAchain.secretName }}
           volumeMounts:
             - name: k8s-ca-chain
               mountPath: /consul/tls/ca/k8s-ca-chain

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init
-      {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
+      {{- if (or .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName .Values.global.tls.kubernetesCAchain.secretName) }}
       volumes:
+      {{- end }}
+      {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
       - name: consul-ca-cert
         secret:
           secretName: {{ .Values.global.tls.caCert.secretName }}
@@ -43,6 +45,7 @@ spec:
           items:
           - key: {{ default "tls.key" .Values.global.tls.caKey.secretKey }}
             path: tls.key
+      {{- end }}
       {{- if .Values.global.tls.kubernetesCAchain.secretName }}
       - name: k8s-ca-chain
         secret:
@@ -50,7 +53,6 @@ spec:
           items:
           - key: {{ default "k8s-ca-chain.crt" .Values.global.tls.kubernetesCAchain.secretKey }}
             path: k8s-ca-chain.crt
-      {{- end }}
       {{- end }}
       containers:
         - name: tls-init
@@ -117,11 +119,11 @@ spec:
             - name: consul-ca-key
               mountPath: /consul/tls/ca/key
               readOnly: true
+          {{- end }}
           {{- if .Values.global.tls.kubernetesCAchain.secretName }}
             - name: k8s-ca-chain
               mountPath: /consul/tls/ca/k8s-ca-chain
               readOnly: true
-          {{- end }}
           {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -43,6 +43,14 @@ spec:
           items:
           - key: {{ default "tls.key" .Values.global.tls.caKey.secretKey }}
             path: tls.key
+      {{- if .Values.global.tls.kubernetesCAchain.secretName }}
+      - name: k8s-ca-chain
+        secret:
+          secretName: {{ .Values.global.tls.kubernetesCAchain.secretName }}
+          items:
+          - key: {{ default "k8s-ca-chain.crt" .Values.global.tls.kubernetesCAchain.secretKey }}
+            path: k8s-ca-chain.crt
+      {{- end }}
       {{- end }}
       containers:
         - name: tls-init
@@ -63,13 +71,13 @@ spec:
               {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
               consul tls ca create \
                 -domain={{ .Values.global.domain }}
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X POST --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
                 -H "Content-Type: application/json" \
                 -H "Accept: application/json" \
                 -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.domain }}-agent-ca.pem | base64 | tr -d '\n' )\" }}" > /dev/null
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X POST --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
                 -H "Content-Type: application/json" \
@@ -95,7 +103,7 @@ spec:
                  {{- end }}
                 -dc={{ .Values.global.datacenter }} \
                 -domain={{ .Values.global.domain }}
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              curl -s -X POST --cacert {{ template "consul.kubernetesCApath" . }} \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
                 -H "Content-Type: application/json" \
@@ -109,6 +117,11 @@ spec:
             - name: consul-ca-key
               mountPath: /consul/tls/ca/key
               readOnly: true
+          {{- if .Values.global.tls.kubernetesCAchain.secretName }}
+            - name: k8s-ca-chain
+              mountPath: /consul/tls/ca/k8s-ca-chain
+              readOnly: true
+          {{- end }}
           {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -128,6 +128,10 @@ global:
 
     # caCert is a Kubernetes secret containing the certificate
     # of the CA to use for TLS communication within the Consul cluster.
+    # If that consul CA certificate is intermediate and created by another CA,
+    # make sure that you include complete CA chain in that secret
+    # To create bundle:
+    #   cat consul-ca.pem root-ca.pem > bundle.pem
     # If you have generated the CA yourself with the consul CLI,
     # you could use the following command to create the secret in Kubernetes:
     #
@@ -139,6 +143,7 @@ global:
 
     # caKey is a Kubernetes secret containing the private key
     # of the CA to use for TLS communications within the Consul cluster.
+    # At the moment of writing Consul tls commands support only ECDSA keys, not RSA.
     # If you have generated the CA yourself with the consul CLI,
     # you could use the following command to create the secret in Kubernetes:
     #

--- a/values.yaml
+++ b/values.yaml
@@ -153,6 +153,20 @@ global:
       secretName: null
       secretKey: null
 
+    # kubernetesCAchain is a Kubernetes secret containing Kubernetes CA chain.
+    # In some cases Kubernetes CA is an intermediate CA generate by main corporate CA.
+    # /var/run/secrets/kubernetes.io/serviceaccount/ca.crt contains only that, intermediate cluster CA.
+    # While at the same time curl requires complete certifacate-chain to verify kubernetes-API responses.
+    # Example:
+    #    cat root-ca.pem intermediate-cluster-ca.pem > bundle.pem
+    #    kubectl create secret generic k8s-ca-bundle \
+    #            --from-file='bundle.pem=./bundle.pem'
+    # secretName will be k8s-ca-bundle
+    # secretKey will be bundle.pem
+    kubernetesCAchain:
+      secretName: null
+      secretKey: null
+
   # [Enterprise Only] enableConsulNamespaces indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would like to
   # make use of configuration beyond registering everything into the `default` Consul


### PR DESCRIPTION
Adds the ability to mount secret with custom CA and pass it to curl commands in `tls-init` and `tls-init-cleanup` jobs

Fixes https://github.com/hashicorp/consul-helm/issues/443