### PR TITLE
Use same master version as node version

### DIFF
--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -21,7 +21,7 @@ resource "google_container_cluster" "cluster" {
   initial_node_count = 3
   location           = var.zone
   min_master_version = data.google_container_engine_versions.main.latest_master_version
-  node_version       = data.google_container_engine_versions.main.latest_node_version
+  node_version       = data.google_container_engine_versions.main.latest_master_version
 }
 
 resource "null_resource" "kubectl" {


### PR DESCRIPTION
Otherwise we get the error
```
Error: node_version and min_master_version must be set to equivalent values on create
```
