### PR TITLE
Support terminating gateways

### DIFF
--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -1,0 +1,326 @@
+{{- if .Values.terminatingGateways.enabled }}
+
+{{- $root := . }}
+{{- $defaults := .Values.terminatingGateways.defaults }}
+{{- $names := dict }}
+
+{{- range .Values.terminatingGateways.gateways }}
+
+{{- if empty .name }}
+# Check that name is not empty
+{{ fail "Terminating gateway names cannot be empty"}}
+{{ end -}}
+{{- if hasKey $names .name }}
+# Check that the name doesn't already exist
+{{ fail "Terminating gateway names must be unique"}}
+{{ end -}}
+{{- $_ := set $names .name .name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+spec:
+  replicas: {{ default $defaults.replicas .replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "consul.name" $root }}
+      chart: {{ template "consul.chart" $root }}
+      release: {{ $root.Release.Name }}
+      component: terminating-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ template "consul.name" $root }}
+        chart: {{ template "consul.chart" $root }}
+        release: {{ $root.Release.Name }}
+        component: terminating-gateway
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+        # We allow both default annotations and gateway-specific annotations
+        {{- if $defaults.annotations }}
+        {{- tpl $defaults.annotations $root | nindent 8 }}
+        {{- end }}
+        {{- if .annotations }}
+        {{- tpl .annotations $root | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if (or $defaults.affinity .affinity) }}
+      affinity:
+        {{ tpl (default $defaults.affinity .affinity) $root | nindent 8 | trim }}
+      {{- end }}
+      {{- if (or $defaults.tolerations .tolerations) }}
+      tolerations:
+        {{ tpl (default $defaults.tolerations .tolerations) $root | nindent 8 | trim }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ .name }}
+      volumes:
+        - name: consul-bin
+          emptyDir: {}
+        - name: consul-service
+          emptyDir:
+            medium: "Memory"
+        {{- range .extraVolumes }}
+        - name: {{ .name }}
+          {{ .type }}:
+            {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+            {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+            {{- end }}
+            {{- with .items }}
+            items:
+            {{- range . }}
+            - key: {{.key}}
+              path: {{.path}}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- if $root.Values.global.tls.enabled }}
+        {{- if not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots) }}
+        - name: consul-ca-cert
+          secret:
+            {{- if $root.Values.global.tls.caCert.secretName }}
+            secretName: {{ $root.Values.global.tls.caCert.secretName }}
+            {{- else }}
+            secretName: {{ template "consul.fullname" $root }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" $root.Values.global.tls.caCert.secretKey }}
+              path: tls.crt
+        {{- end }}
+        {{- if $root.Values.global.tls.enableAutoEncrypt }}
+        - name: consul-auto-encrypt-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
+        {{- end }}
+      initContainers:
+        # We use the Envoy image as our base image so we use an init container to
+        # copy the Consul binary to a shared directory that can be used when
+        # starting Envoy.
+        - name: copy-consul-bin
+          image: {{ $root.Values.global.image | quote }}
+          command:
+          - cp
+          - /bin/consul
+          - /consul-bin/consul
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+        {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
+        {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
+        {{- end }}
+        # service-init registers the terminating gateway service.
+        - name: service-init
+          image: {{ $root.Values.global.imageK8S }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+                {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                consul-k8s acl-init \
+                  -secret-name="{{ .name }}-terminating-gateway-acl-token" \
+                  -k8s-namespace={{ $root.Release.Namespace }} \
+                  -token-sink-file=/consul/service/acl-token
+                {{ end }}
+
+                cat > /consul/service/service.hcl << EOF
+                service {
+                  kind = "terminating-gateway"
+                  name = "{{ .name }}"
+                  address = "${POD_IP}"
+                  port = 8443
+
+                  checks = [
+                    {
+                      name = "Terminating Gateway Listening"
+                      interval = "10s"
+                      tcp = "${POD_IP}:8443"
+                      deregister_critical_service_after = "6h"
+                    }
+                  ]
+                }
+                EOF
+
+                /consul-bin/consul services register \
+                  {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                  -token-file=/consul/service/acl-token \
+                  {{- end }}
+                  /consul/service/service.hcl
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+      containers:
+        - name: terminating-gateway
+          image: {{ default $defaults.imageEnvoy .imageEnvoy | quote }}
+          {{- if (or $defaults.resources .resources) }}
+          resources:
+            {{ toYaml (default $defaults.resources .resources) | nindent 12 | trim }}
+          {{- end }}
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+          {{- if $root.Values.global.tls.enabled }}
+          {{- if $root.Values.global.tls.enableAutoEncrypt }}
+          - name: consul-auto-encrypt-ca-cert
+          {{- else }}
+          - name: consul-ca-cert
+          {{- end }}
+            mountPath: /consul/tls/ca
+            readOnly: true
+          {{- end }}
+          {{- range .extraVolumes }}
+          - name: {{ .name }}
+            readOnly: true
+            mountPath: /consul/userconfig/{{ .name }}
+          {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .name }}-terminating-gateway-acl-token"
+                  key: "token"
+            {{- end}}
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_GRPC_ADDR
+              value: https://$(HOST_IP):8502
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            - name: CONSUL_GRPC_ADDR
+              value: $(HOST_IP):8502
+            {{- end }}
+          command:
+            - /consul-bin/consul
+            - connect
+            - envoy
+            - -terminating-gateway
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          ports:
+            - name: gateway
+              containerPort: 8443
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .name }}\""]
+
+        # lifecycle-sidecar ensures the terminating gateway is always registered with
+        # the local Consul agent, even if it loses the initial registration.
+        - name: lifecycle-sidecar
+          image: {{ $root.Values.global.imageK8S }}
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+              readOnly: true
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - consul-k8s
+            - lifecycle-sidecar
+            - -service-config=/consul/service/service.hcl
+            - -consul-binary=/consul-bin/consul
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - -token-file=/consul/service/acl-token
+            {{- end }}
+      {{- if (or $defaults.priorityClassName .priorityClassName) }}
+      priorityClassName: {{ (default $defaults.priorityClassName .priorityClassName) | quote }}
+      {{- end }}
+      {{- if (or $defaults.nodeSelector .nodeSelector) }}
+      nodeSelector:
+        {{ tpl (default $defaults.nodeSelector .nodeSelector) $root | indent 8 | trim }}
+      {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -1,0 +1,43 @@
+{{- if (and .Values.global.enablePodSecurityPolicies .Values.terminatingGateways.enabled) }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-role.yaml
+++ b/templates/terminating-gateways-role.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.terminatingGateways.enabled }}
+
+{{- $root := . }}
+{{- $defaults := .Values.terminatingGateways.defaults }}
+
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies) }}
+rules:
+{{- if $root.Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      - {{ .name }}
+    verbs:
+      - use
+{{- end }}
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .name }}-terminating-gateway-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- else }}
+rules: []
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-rolebinding.yaml
+++ b/templates/terminating-gateways-rolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.terminatingGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ $root.Release.Namespace }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-serviceaccount.yaml
+++ b/templates/terminating-gateways-serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.terminatingGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+{{- with $root.Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -267,9 +267,9 @@ load _helpers
 @test "helper/bootstrapACLs: used alongside manageSystemACLs" {
   cd `chart_dir`
 
-  diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r 'or \.Values\.global\.acls\.manageSystemACLs \.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
+  diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 
-  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r 'or \.Values\.global\.acls\.manageSystemACLs \.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
+  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1004,6 +1004,55 @@ meshGateway:
   #     "annotation-key": "annotation-value"
   annotations: null
 
+terminatingGateways:
+  enabled: true
+
+  # Defaults sets default values for all gateway fields. With the exception
+  # of annotations, defining any of these values in the `gateways` list
+  # will override the default values provided here.
+  defaults:
+    replicas: 2
+    imageEnvoy: "envoyproxy/envoy:v1.13.0"
+
+    # extraVolumes is a list of extra volumes to mount. These will be exposed
+    # to Consul in the path `/consul/userconfig/<name>/`. The value below is
+    # an array of objects, examples are shown below.
+    #  extraVolumes:
+    #    - type: secret
+    #      name: my-secret
+    #      items:  # optional items array
+    #        - key: key
+    #          path: path  # secret will now mount to /consul/userconfig/my-secret/path
+    extraVolumes: []
+
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "250m"
+      limits:
+        memory: "256Mi"
+        cpu: "500m"
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+              app: {{ template "consul.name" . }}
+              release: "{{ .Release.Name }}"
+              component: terminating-gateway
+              topologyKey: kubernetes.io/hostname
+    tolerations: null
+    nodeSelector: null
+    priorityClassName: ""
+    annotations: null
+
+  # Gateways is a list of gateway objects. The only required field for
+  # each is `name`, though they can also contain any of the fields in
+  # `defaults`. Values defined here override the defaults except in the
+  # case of annotations where both will be applied.
+  gateways:
+    - name: terminating-gateway
+
 # Control whether a test Pod manifest is generated when running helm template.
 # When using helm install, the test Pod is not submitted to the cluster so this
 # is only useful when running helm template.


### PR DESCRIPTION
This creates all of the necessary templates to support terminating
gateways in the helm chart. Using `terminatingGateways.defaults` and
`terminatingGateways.gateways`, it's possible to define multiple
gateways. Names must be provided for each and they must be unique.

Any gateway-specific values will override the default value with the
exception of annotations. Annotations will apply both the defaults
and gateway-specific annotations.

TODO: Add tests.