### PR TITLE
Restrict permissions for the server-acl-init job

### DIFF
--- a/scripts/generate-helm-config-for-hcs.sh
+++ b/scripts/generate-helm-config-for-hcs.sh
@@ -117,8 +117,6 @@ client:
   join: ${retry_join}
 connectInject:
   enabled: true
-syncCatalog:
-  enabled: true
 EOF
 
 echo

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -13,19 +13,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-      - pods
-    verbs:
-      - list
-  - apiGroups: [""]
-    resources:
       - secrets
     verbs:
       - create
-      - get
-  - apiGroups: ["apps"]
-    resources:
-      - statefulsets
-    verbs:
       - get
 {{- if .Values.connectInject.enabled }}
   - apiGroups: [""]


### PR DESCRIPTION
Now that the server-acl-init command takes server DNS names as input, we don't need permissions to list pods and get statefulsets.

Additionally, only set one of `connectInject.enabled` to true in the generated config for HCS since we don't recommend enabling both `connectInject` and `syncCatalog`.