### PR TITLE
Support ingress gateways

### DIFF
--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -1,0 +1,376 @@
+{{- if .Values.ingressGateways.enabled }}
+{{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
+{{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
+{{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
+
+{{- $root := . }}
+{{- $defaults := .Values.ingressGateways.defaults }}
+{{- $names := dict }}
+
+{{- range .Values.ingressGateways.gateways }}
+
+{{- $wanAddress := .wanAddress }}
+{{- $service := .service }}
+
+{{- if empty .name }}
+# Check that the gateway name is provided
+{{ fail "Ingress gateway names cannot be empty"}}
+{{ end -}}
+{{- if hasKey $names .name }}
+#  Check that the gateway name is unique
+{{ fail "Ingress gateway names must be unique"}}
+{{ end -}}
+{{- $_ := set $names .name .name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+    ingress-gateway-name: {{ .name }}
+spec:
+  replicas: {{ default $defaults.replicas .replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "consul.name" $root }}
+      chart: {{ template "consul.chart" $root }}
+      release: {{ $root.Release.Name }}
+      component: ingress-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ template "consul.name" $root }}
+        chart: {{ template "consul.chart" $root }}
+        release: {{ $root.Release.Name }}
+        component: ingress-gateway
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+        {{- if $defaults.annotations }}
+        # We allow both default annotations and gateway-specific annotations
+        {{- tpl $defaults.annotations $root | nindent 8 }}
+        {{- end }}
+        {{- if .annotations }}
+        {{- tpl .annotations $root | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if (or $defaults.affinity .affinity) }}
+      affinity:
+        {{ tpl (default $defaults.affinity .affinity) $root | nindent 8 | trim }}
+      {{- end }}
+      {{- if (or $defaults.tolerations .tolerations) }}
+      tolerations:
+        {{ toYaml (default $defaults.tolerations .tolerations) | nindent 8 | trim }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ .name }}
+      volumes:
+        - name: consul-bin
+          emptyDir: {}
+        - name: consul-service
+          emptyDir:
+            medium: "Memory"
+        {{- if $root.Values.global.tls.enabled }}
+        {{- if not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots) }}
+        - name: consul-ca-cert
+          secret:
+            {{- if $root.Values.global.tls.caCert.secretName }}
+            secretName: {{ $root.Values.global.tls.caCert.secretName }}
+            {{- else }}
+            secretName: {{ template "consul.fullname" $root }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" $root.Values.global.tls.caCert.secretKey }}
+              path: tls.crt
+        {{- end }}
+        {{- if $root.Values.global.tls.enableAutoEncrypt }}
+        - name: consul-auto-encrypt-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
+        {{- end }}
+      initContainers:
+        # We use the Envoy image as our base image so we use an init container to
+        # copy the Consul binary to a shared directory that can be used when
+        # starting Envoy.
+        - name: copy-consul-bin
+          image: {{ $root.Values.global.image | quote }}
+          command:
+          - cp
+          - /bin/consul
+          - /consul-bin/consul
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+        {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
+        {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
+        {{- end }}
+        # service-init registers the ingress gateway service.
+        - name: service-init
+          image: {{ $root.Values.global.imageK8S }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+                {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                consul-k8s acl-init \
+                  -secret-name="{{ template "consul.fullname" $root }}-{{ .name }}-ingress-gateway-acl-token" \
+                  -k8s-namespace={{ $root.Release.Namespace }} \
+                  -token-sink-file=/consul/service/acl-token
+                {{ end }}
+
+                {{- $source := (default $defaults.wanAddress.source $wanAddress.source) }}
+                {{- $serviceType := (default $defaults.service.type $service.type) }}
+                {{- $serviceEnabled := (ternary $defaults.service.enabled $service.enabled (kindIs "invalid" $service.enabled)) }}
+                {{- if and (eq $source "Service") (not $serviceEnabled) }}{{ fail "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" }}{{ end }}
+                {{- if or (eq $source "NodeIP") (and (eq $source "Service") (eq $serviceType "NodePort")) }}
+                WAN_ADDR="${HOST_IP}"
+                {{- else if eq $source "NodeName" }}
+                WAN_ADDR="${NODE_NAME}"
+                {{- else if and (eq $source "Service") (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
+                consul-k8s service-address \
+                  -k8s-namespace={{ $root.Release.Namespace }} \
+                  -name={{ .name }} \
+                  -output-file=/tmp/address.txt
+                WAN_ADDR="$(cat /tmp/address.txt)"
+                {{- else if eq $source "Static" }}
+                {{- if eq (default $defaults.wanAddress.static $wanAddress.static) "" }}{{ fail "if ingressGateways .wanAddress.source=Static then ingressGateways .wanAddress.static cannot be empty and must be set in either the defaults or in the gateway definition" }}{{ end }}
+                WAN_ADDR="{{ (default $defaults.wanAddress.static $wanAddress.static) }}"
+                {{- else }}
+                {{- fail "currently set ingressGateway values for wanAddress.source and service.type are not supported" }}
+                {{- end }}
+
+                {{- if eq $source "Service" }}
+                {{- if eq $serviceType "NodePort" }}
+                {{- if not (default $defaults.service.nodePort $service.nodePort) }}{{ fail "if ingressGateways .wanAddress.source=Service and ingressGateways .service.type=NodePort, ingressGateways .service.nodePort must be set in either the defaults or in the gateway definition" }}{{ end }}
+                WAN_PORT="{{ (default $defaults.service.nodePort $service.nodePort) }}"
+                {{- else }}
+                WAN_PORT="{{ (default $defaults.service.port $service.port) }}"
+                {{- end }}
+                {{- else }}
+                WAN_PORT="{{ (default $defaults.wanAddress.port $wanAddress.port) }}"
+                {{- end }}
+
+                cat > /consul/service/service.hcl << EOF
+                service {
+                  kind = "ingress-gateway"
+                  name = "{{ .name }}"
+                  {{- if $root.Values.global.enableConsulNamespaces }}
+                  namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"
+                  {{- end }}
+                  port = ${WAN_PORT}
+                  address = "${WAN_ADDR}"
+                  tagged_addresses {
+                    lan {
+                      address = "${POD_IP}"
+                      port = 8443
+                    }
+                    wan {
+                      address = "${WAN_ADDR}"
+                      port = ${WAN_PORT}
+                    }
+                  }
+                  proxy {
+                    config {
+                      envoy_gateway_no_default_bind = true
+                      envoy_gateway_bind_addresses {
+                        all-interfaces {
+                          address = "0.0.0.0"
+                        }
+                      }
+                    }
+                  }
+                  checks = [
+                    {
+                      name = "Ingress Gateway Listening"
+                      interval = "10s"
+                      tcp = "${POD_IP}:8443"
+                      deregister_critical_service_after = "6h"
+                    }
+                  ]
+                }
+                EOF
+
+                /consul-bin/consul services register \
+                  {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                  -token-file=/consul/service/acl-token \
+                  {{- end }}
+                  /consul/service/service.hcl
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+      containers:
+        - name: ingress-gateway
+          image: {{ $root.Values.global.imageEnvoy | quote }}
+          {{- if (default $defaults.resources .resources) }}
+          resources:
+            {{ toYaml (default $defaults.resources .resources) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+          {{- if $root.Values.global.tls.enabled }}
+          {{- if $root.Values.global.tls.enableAutoEncrypt }}
+          - name: consul-auto-encrypt-ca-cert
+          {{- else }}
+          - name: consul-ca-cert
+          {{- end }}
+            mountPath: /consul/tls/ca
+            readOnly: true
+          {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if eq (default $defaults.wanAddress.source $wanAddress.source) "NodeName" }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- end }}
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "consul.fullname" $root }}-{{ .name }}-ingress-gateway-acl-token"
+                  key: "token"
+            {{- end}}
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_GRPC_ADDR
+              value: https://$(HOST_IP):8502
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            - name: CONSUL_GRPC_ADDR
+              value: $(HOST_IP):8502
+            {{- end }}
+          command:
+            - /consul-bin/consul
+            - connect
+            - envoy
+            - -gateway=ingress
+            - -address=$(POD_IP):8443
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          ports:
+            - name: gateway
+              containerPort: 8443
+              {{- if default $defaults.hostPort .hostPort }}
+              hostPort:  {{ default $defaults.hostPort .hostPort }}
+              {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .name }}\""]
+
+        # lifecycle-sidecar ensures the ingress gateway is always registered with
+        # the local Consul agent, even if it loses the initial registration.
+        - name: lifecycle-sidecar
+          image: {{ $root.Values.global.imageK8S }}
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+              readOnly: true
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - consul-k8s
+            - lifecycle-sidecar
+            - -service-config=/consul/service/service.hcl
+            - -consul-binary=/consul-bin/consul
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - -token-file=/consul/service/acl-token
+            {{- end }}
+      {{- if (default $defaults.priorityClassName .priorityClassName) }}
+      priorityClassName: {{ default $defaults.priorityClassName .priorityClassName | quote }}
+      {{- end }}
+      {{- if (default $defaults.nodeSelector .nodeSelector) }}
+      nodeSelector:
+        {{ tpl (default $defaults.nodeSelector .nodeSelector) $root | indent 8 | trim }}
+      {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -184,7 +184,7 @@ spec:
                   tagged_addresses {
                     lan {
                       address = "${POD_IP}"
-                      port = 8443
+                      port = 21000
                     }
                     wan {
                       address = "${WAN_ADDR}"
@@ -205,7 +205,7 @@ spec:
                     {
                       name = "Ingress Gateway Listening"
                       interval = "10s"
-                      tcp = "${POD_IP}:8443"
+                      tcp = "${POD_IP}:21000"
                       deregister_critical_service_after = "6h"
                     }
                   ]
@@ -290,13 +290,13 @@ spec:
             - connect
             - envoy
             - -gateway=ingress
-            - -address=$(POD_IP):8443
+            - -address=$(POD_IP):21000
             {{- if $root.Values.global.enableConsulNamespaces }}
             - -namespace={{ default $defaults.consulNamespace .consulNamespace }}
             {{- end }}
           livenessProbe:
             tcpSocket:
-              port: 8443
+              port: 21000
             failureThreshold: 3
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -304,18 +304,24 @@ spec:
             timeoutSeconds: 5
           readinessProbe:
             tcpSocket:
-              port: 8443
+              port: 21000
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
           ports:
-            - name: gateway
-              containerPort: 8443
+            - name: gateway-health
+              containerPort: 21000
+            - name: gateway-default
+              containerPort: {{ default $defaults.service.port $service.port }}
               {{- if default $defaults.hostPort .hostPort }}
               hostPort:  {{ default $defaults.hostPort .hostPort }}
               {{- end }}
+            {{- range $index, $port := (default $defaults.service.additionalPorts $service.additionalPorts) }}
+            - name: gateway-{{ $index }}
+              containerPort: {{ $port }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -330,7 +330,15 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .name }}\""]
+                command:
+                  - "/bin/sh"
+                  - "-ec"
+                  - |
+                    /consul-bin/consul services deregister \
+                    {{- if $root.Values.global.enableConsulNamespaces }}
+                    -namespace={{ default $defaults.consulNamespace .consulNamespace }} \
+                    {{- end }}
+                    -id=\"{{ .name }}\"
 
         # lifecycle-sidecar ensures the ingress gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -9,7 +9,6 @@
 
 {{- range .Values.ingressGateways.gateways }}
 
-{{- $wanAddress := .wanAddress }}
 {{- $service := .service }}
 
 {{- if empty .name }}
@@ -142,36 +141,52 @@ spec:
                   -token-sink-file=/consul/service/acl-token
                 {{ end }}
 
-                {{- $source := (default $defaults.wanAddress.source $wanAddress.source) }}
                 {{- $serviceType := (default $defaults.service.type $service.type) }}
-                {{- if or (eq $source "NodeIP") (and (eq $source "Service") (eq $serviceType "NodePort")) }}
+                {{- if (eq $serviceType "NodePort") }}
                 WAN_ADDR="${HOST_IP}"
-                {{- else if eq $source "NodeName" }}
-                WAN_ADDR="${NODE_NAME}"
-                {{- else if and (eq $source "Service") (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
+                {{- else if (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
                 consul-k8s service-address \
                   -k8s-namespace={{ $root.Release.Namespace }} \
                   -name={{ .name }} \
                   -resolve-hostnames \
                   -output-file=/tmp/address.txt
                 WAN_ADDR="$(cat /tmp/address.txt)"
-                {{- else if eq $source "Static" }}
-                {{- if eq (default $defaults.wanAddress.static $wanAddress.static) "" }}{{ fail "if ingressGateways .wanAddress.source=Static then ingressGateways .wanAddress.static cannot be empty and must be set in either the defaults or in the gateway definition" }}{{ end }}
-                WAN_ADDR="{{ (default $defaults.wanAddress.static $wanAddress.static) }}"
                 {{- else }}
-                {{- fail "currently set ingressGateway values for wanAddress.source and service.type are not supported" }}
+                {{- fail "currently set ingressGateway value service.type is not supported" }}
                 {{- end }}
 
-                {{- if eq $source "Service" }}
-                {{- if eq $serviceType "NodePort" }}
-                {{- if not (default $defaults.service.nodePort $service.nodePort) }}{{ fail "if ingressGateways .wanAddress.source=Service and ingressGateways .service.type=NodePort, ingressGateways .service.nodePort must be set in either the defaults or in the gateway definition" }}{{ end }}
-                WAN_PORT="{{ (default $defaults.service.nodePort $service.nodePort) }}"
-                {{- else }}
-                WAN_PORT="{{ (default $defaults.service.port $service.port) }}"
-                {{- end }}
-                {{- else }}
-                WAN_PORT="{{ (default $defaults.wanAddress.port $wanAddress.port) }}"
-                {{- end }}
+          {{- if (eq $serviceType "NodePort") }}
+            {{- if $service.ports }}
+                {{- $firstPort := first $service.ports}}
+              {{- if $firstPort.nodePort }}
+                WAN_PORT={{ $firstPort.nodePort }}
+              {{- else }}{{ fail "if ingressGateways .service.type=NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a nodePort" }}
+              {{- end }}
+            {{- else if $defaults.service.ports }}
+              {{- $firstDefaultPort := first $defaults.service.ports}}
+              {{- if $firstDefaultPort.nodePort }}
+                  WAN_PORT={{ $firstDefaultPort.nodePort }}
+              {{- else }}{{ fail "if ingressGateways .service.type=NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a nodePort" }}
+              {{- end }}
+            {{- else }}{{ fail "if ingressGateways .service.type=NodePort, the first port entry in either the defaults or specific gateway must include a nodePort" }}
+            {{- end }}
+
+          {{- else }}
+            {{- if $service.ports }}
+                {{- $firstPort := first $service.ports}}
+              {{- if $firstPort.port }}
+                WAN_PORT={{ $firstPort.port }}
+              {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a port" }}
+              {{- end }}
+            {{- else if $defaults.service.ports }}
+                {{- $firstDefaultPort := first $defaults.service.ports}}
+              {{- if $firstDefaultPort.port }}
+                WAN_PORT={{ $firstDefaultPort.port }}
+              {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a port" }}
+              {{- end }}
+            {{- else }}{{ fail "if ingressGateways .service.type is not NodePort, the first port entry in either the defaults or specific gateway must include a port" }}
+            {{- end }}
+          {{- end }}
 
                 cat > /consul/service/service.hcl << EOF
                 service {
@@ -260,12 +275,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- if eq (default $defaults.wanAddress.source $wanAddress.source) "NodeName" }}
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            {{- end }}
             {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
@@ -314,14 +323,9 @@ spec:
           ports:
             - name: gateway-health
               containerPort: 21000
-            - name: gateway-default
-              containerPort: {{ default $defaults.service.port $service.port }}
-              {{- if default $defaults.hostPort .hostPort }}
-              hostPort:  {{ default $defaults.hostPort .hostPort }}
-              {{- end }}
-            {{- range $index, $port := (default $defaults.service.additionalPorts $service.additionalPorts) }}
+            {{- range $index, $allPorts := (default $defaults.service.ports $service.ports) }}
             - name: gateway-{{ $index }}
-              containerPort: {{ $port }}
+              containerPort: {{ $allPorts.port }}
             {{- end }}
           lifecycle:
             preStop:

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -20,11 +20,12 @@
 #  Check that the gateway name is unique
 {{ fail "Ingress gateway names must be unique"}}
 {{ end -}}
+{{- /* Add the gateway name to the $names dict to ensure uniqueness */ -}}
 {{- $_ := set $names .name .name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -32,7 +33,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 spec:
   replicas: {{ default $defaults.replicas .replicas }}
   selector:
@@ -64,10 +65,10 @@ spec:
       {{- end }}
       {{- if (or $defaults.tolerations .tolerations) }}
       tolerations:
-        {{ toYaml (default $defaults.tolerations .tolerations) | nindent 8 | trim }}
+        {{ tpl (default $defaults.tolerations .tolerations) $root | nindent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ .name }}
+      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
         - name: consul-bin
           emptyDir: {}
@@ -143,8 +144,6 @@ spec:
 
                 {{- $source := (default $defaults.wanAddress.source $wanAddress.source) }}
                 {{- $serviceType := (default $defaults.service.type $service.type) }}
-                {{- $serviceEnabled := (ternary $defaults.service.enabled $service.enabled (kindIs "invalid" $service.enabled)) }}
-                {{- if and (eq $source "Service") (not $serviceEnabled) }}{{ fail "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" }}{{ end }}
                 {{- if or (eq $source "NodeIP") (and (eq $source "Service") (eq $serviceType "NodePort")) }}
                 WAN_ADDR="${HOST_IP}"
                 {{- else if eq $source "NodeName" }}
@@ -292,6 +291,9 @@ spec:
             - envoy
             - -gateway=ingress
             - -address=$(POD_IP):8443
+            {{- if $root.Values.global.enableConsulNamespaces }}
+            - -namespace={{ default $defaults.consulNamespace .consulNamespace }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 8443

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -152,6 +152,7 @@ spec:
                 consul-k8s service-address \
                   -k8s-namespace={{ $root.Release.Namespace }} \
                   -name={{ .name }} \
+                  -resolve-hostnames \
                   -output-file=/tmp/address.txt
                 WAN_ADDR="$(cat /tmp/address.txt)"
                 {{- else if eq $source "Static" }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -313,6 +313,7 @@ spec:
             - connect
             - envoy
             - -gateway=ingress
+            - -proxy-id=$(POD_NAME)
             - -address=$(POD_IP):21000
             {{- if $root.Values.global.enableConsulNamespaces }}
             - -namespace={{ default $defaults.consulNamespace .consulNamespace }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -125,6 +125,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://$(HOST_IP):8501
@@ -151,7 +155,7 @@ spec:
                 {{- else if (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
                 consul-k8s service-address \
                   -k8s-namespace={{ $root.Release.Namespace }} \
-                  -name={{ .name }} \
+                  -name={{ template "consul.fullname" $root }}-{{ .name }} \
                   -resolve-hostnames \
                   -output-file=/tmp/address.txt
                 WAN_ADDR="$(cat /tmp/address.txt)"
@@ -196,6 +200,7 @@ spec:
                 service {
                   kind = "ingress-gateway"
                   name = "{{ .name }}"
+                  id = "${POD_NAME}"
                   {{- if $root.Values.global.enableConsulNamespaces }}
                   namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"
                   {{- end }}
@@ -279,6 +284,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
@@ -338,11 +347,11 @@ spec:
                   - "/bin/sh"
                   - "-ec"
                   - |
-                    /consul-bin/consul services deregister \
-                    {{- if $root.Values.global.enableConsulNamespaces }}
-                    -namespace={{ default $defaults.consulNamespace .consulNamespace }} \
-                    {{- end }}
-                    -id=\"{{ .name }}\"
+                      /consul-bin/consul services deregister \
+                      {{- if $root.Values.global.enableConsulNamespaces }}
+                      -namespace={{ default $defaults.consulNamespace .consulNamespace }} \
+                      {{- end }}
+                      -id="${POD_NAME}"
 
         # lifecycle-sidecar ensures the ingress gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -39,15 +39,19 @@ spec:
     matchLabels:
       app: {{ template "consul.name" $root }}
       chart: {{ template "consul.chart" $root }}
+      heritage: {{ $root.Release.Service }}
       release: {{ $root.Release.Name }}
       component: ingress-gateway
+      ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   template:
     metadata:
       labels:
         app: {{ template "consul.name" $root }}
         chart: {{ template "consul.chart" $root }}
+        heritage: {{ $root.Release.Service }}
         release: {{ $root.Release.Name }}
         component: ingress-gateway
+        ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if $defaults.annotations }}

--- a/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -1,0 +1,43 @@
+{{- if (and .Values.global.enablePodSecurityPolicies .Values.ingressGateways.enabled) }}
+{{- $root := . }}
+{{- range .Values.ingressGateways.gateways }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -11,6 +11,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/ingress-gateways-role.yaml
+++ b/templates/ingress-gateways-role.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingressGateways.enabled }}
+
+{{- $root := . }}
+{{- $defaults := .Values.ingressGateways.defaults }}
+
+{{- range .Values.ingressGateways.gateways }}
+{{- $wanAddress := .wanAddress }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+{{- $source := (default $defaults.wanAddress.source $wanAddress.source) }}
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies (eq $source "Service")) }}
+rules:
+{{- if $root.Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      - {{ .name }}
+    verbs:
+      - use
+{{- end }}
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .name }}-ingress-gateway-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- if (eq $source "Service") }}
+  - apiGroups: [""]
+    resources:
+      - services
+    resourceNames:
+      - {{ .name }}
+    verbs:
+      - get
+{{- end }}
+{{- else }}
+rules: []
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-role.yaml
+++ b/templates/ingress-gateways-role.yaml
@@ -4,7 +4,6 @@
 {{- $defaults := .Values.ingressGateways.defaults }}
 
 {{- range .Values.ingressGateways.gateways }}
-{{- $wanAddress := .wanAddress }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -16,9 +15,14 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-{{- $source := (default $defaults.wanAddress.source $wanAddress.source) }}
-{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies (eq $source "Service")) }}
 rules:
+  - apiGroups: [""]
+    resources:
+      - services
+    resourceNames:
+      - {{ template "consul.fullname" $root }}-{{ .name }}
+    verbs:
+      - get
 {{- if $root.Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
@@ -35,18 +39,6 @@ rules:
       - {{ template "consul.fullname" $root }}-{{ .name }}-ingress-gateway-acl-token
     verbs:
       - get
-{{- end }}
-{{- if (eq $source "Service") }}
-  - apiGroups: [""]
-    resources:
-      - services
-    resourceNames:
-      - {{ template "consul.fullname" $root }}-{{ .name }}
-    verbs:
-      - get
-{{- end }}
-{{- else }}
-rules: []
 {{- end }}
 ---
 {{- end }}

--- a/templates/ingress-gateways-role.yaml
+++ b/templates/ingress-gateways-role.yaml
@@ -15,6 +15,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/ingress-gateways-role.yaml
+++ b/templates/ingress-gateways-role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -23,7 +23,7 @@ rules:
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames:
-      - {{ .name }}
+      - {{ template "consul.fullname" $root }}-{{ .name }}
     verbs:
       - use
 {{- end }}
@@ -32,7 +32,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ .name }}-ingress-gateway-acl-token
+      - {{ template "consul.fullname" $root }}-{{ .name }}-ingress-gateway-acl-token
     verbs:
       - get
 {{- end }}
@@ -41,7 +41,7 @@ rules:
     resources:
       - services
     resourceNames:
-      - {{ .name }}
+      - {{ template "consul.fullname" $root }}-{{ .name }}
     verbs:
       - get
 {{- end }}

--- a/templates/ingress-gateways-rolebinding.yaml
+++ b/templates/ingress-gateways-rolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingressGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.ingressGateways.gateways }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ $root.Release.Namespace }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-rolebinding.yaml
+++ b/templates/ingress-gateways-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -15,11 +15,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .name }}
-    namespace: {{ $root.Release.Namespace }}
+    name: {{ template "consul.fullname" $root }}-{{ .name }}
 ---
 {{- end }}
 {{- end }}

--- a/templates/ingress-gateways-rolebinding.yaml
+++ b/templates/ingress-gateways-rolebinding.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ingressGateways.enabled }}
+
+{{- $root := . }}
+{{- $defaults := .Values.ingressGateways.defaults }}
+
+{{- range .Values.ingressGateways.gateways }}
+
+{{- $service := .service }}
+{{- $serviceEnabled := (ternary $defaults.service.enabled $service.enabled (kindIs "invalid" $service.enabled)) }}
+
+{{- if $serviceEnabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+  {{- if (or $defaults.service.annotations $service.annotations) }}
+  # We allow both default annotations and gateway-specific annotations
+  annotations:
+    {{- if $defaults.service.annotations }}
+    {{ tpl $defaults.service.annotations $root | nindent 4 | trim }}
+    {{- end }}
+    {{- if $service.annotations }}
+    {{ tpl $service.annotations $root | nindent 4 | trim }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ template "consul.name" $root }}
+    release: "{{ $root.Release.Name }}"
+    component: ingress-gateway
+  ports:
+    - name: gateway
+      port: {{ default $defaults.service.port $service.port }}
+      targetPort: 8443
+      {{- if (default $defaults.service.nodePort $service.nodePort) }}
+      nodePort: {{ default $defaults.service.nodePort $service.nodePort }}
+      {{- end}}
+  type: {{ default $defaults.service.type $service.type }}
+  {{- if (default $defaults.service.additionalSpec $service.additionalSpec) }}
+  {{ tpl (default $defaults.service.additionalSpec $service.additionalSpec) $root | nindent 2 | trim }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -34,14 +34,12 @@ spec:
     component: ingress-gateway
     ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   ports:
-    - name: gateway-default
-      port: {{ default $defaults.service.port $service.port }}
-      {{- if (default $defaults.service.nodePort $service.nodePort) }}
-      nodePort: {{ default $defaults.service.nodePort $service.nodePort }}
-      {{- end}}
-    {{- range $index, $port := (default $defaults.service.additionalPorts $service.additionalPorts ) }}
+    {{- range $index, $ports := (default $defaults.service.ports $service.ports) }}
     - name: gateway-{{ $index }}
-      port: {{ $port }}
+      port: {{ $ports.port }}
+      {{- if $ports.nodePort }}
+      nodePort: {{ $ports.nodePort }}
+      {{- end}}
     {{- end }}
   type: {{ default $defaults.service.type $service.type }}
   {{- if (default $defaults.service.additionalSpec $service.additionalSpec) }}

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -6,13 +6,10 @@
 {{- range .Values.ingressGateways.gateways }}
 
 {{- $service := .service }}
-{{- $serviceEnabled := (ternary $defaults.service.enabled $service.enabled (kindIs "invalid" $service.enabled)) }}
-
-{{- if $serviceEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -35,6 +32,7 @@ spec:
     app: {{ template "consul.name" $root }}
     release: "{{ $root.Release.Name }}"
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   ports:
     - name: gateway
       port: {{ default $defaults.service.port $service.port }}
@@ -47,6 +45,5 @@ spec:
   {{ tpl (default $defaults.service.additionalSpec $service.additionalSpec) $root | nindent 2 | trim }}
   {{- end }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -34,12 +34,15 @@ spec:
     component: ingress-gateway
     ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   ports:
-    - name: gateway
+    - name: gateway-default
       port: {{ default $defaults.service.port $service.port }}
-      targetPort: 8443
       {{- if (default $defaults.service.nodePort $service.nodePort) }}
       nodePort: {{ default $defaults.service.nodePort $service.nodePort }}
       {{- end}}
+    {{- range $index, $port := (default $defaults.service.additionalPorts $service.additionalPorts ) }}
+    - name: gateway-{{ $index }}
+      port: {{ $port }}
+    {{- end }}
   type: {{ default $defaults.service.type $service.type }}
   {{- if (default $defaults.service.additionalSpec $service.additionalSpec) }}
   {{ tpl (default $defaults.service.additionalSpec $service.additionalSpec) $root | nindent 2 | trim }}

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -17,6 +17,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   {{- if (or $defaults.service.annotations $service.annotations) }}
   # We allow both default annotations and gateway-specific annotations
   annotations:

--- a/templates/ingress-gateways-service.yaml
+++ b/templates/ingress-gateways-service.yaml
@@ -37,7 +37,7 @@ spec:
     {{- range $index, $ports := (default $defaults.service.ports $service.ports) }}
     - name: gateway-{{ $index }}
       port: {{ $ports.port }}
-      {{- if $ports.nodePort }}
+      {{- if (and (eq (default $defaults.service.type $service.type) "NodePort") $ports.nodePort) }}
       nodePort: {{ $ports.nodePort }}
       {{- end}}
     {{- end }}

--- a/templates/ingress-gateways-serviceaccount.yaml
+++ b/templates/ingress-gateways-serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingressGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.ingressGateways.gateways }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: ingress-gateway
+{{- with $root.Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress-gateways-serviceaccount.yaml
+++ b/templates/ingress-gateways-serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 {{- with $root.Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/ingress-gateways-serviceaccount.yaml
+++ b/templates/ingress-gateways-serviceaccount.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -97,6 +97,9 @@ spec:
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
               consul-k8s server-acl-init \
+                -resource-prefix=${CONSUL_FULLNAME} \
+                -k8s-namespace={{ .Release.Namespace }} \
+
                 {{- if .Values.externalServers.enabled }}
                 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
                 {{- range .Values.externalServers.hosts }}
@@ -108,8 +111,7 @@ spec:
                 -server-address="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
                 {{- end }}
                 {{- end }}
-                -resource-prefix=${CONSUL_FULLNAME} \
-                -k8s-namespace={{ .Release.Namespace }} \
+
                 {{- if .Values.global.tls.enabled }}
                 -use-https \
                 {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
@@ -119,43 +121,72 @@ spec:
                 -server-port=8501 \
                 {{- end }}
                 {{- end }}
+
                 {{- if .Values.syncCatalog.enabled }}
                 -create-sync-token=true \
                 {{- end }}
+
                 {{- if (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)) }}
                 -allow-dns=true \
                 {{- end }}
+
                 {{- if .Values.connectInject.enabled }}
                 -create-inject-auth-method=true \
                 {{- if and .Values.externalServers.enabled .Values.externalServers.k8sAuthMethodHost }}
                 -inject-auth-method-host={{ .Values.externalServers.k8sAuthMethodHost }} \
                 {{- end }}
                 {{- end }}
+
                 {{- if .Values.meshGateway.enabled }}
                 -create-mesh-gateway-token=true \
                 {{- end }}
+
+                {{- if .Values.ingressGateways.enabled }}
+                {{- if .Values.global.enableConsulNamespaces }}
+                {{- $root := . }}
+                {{- range .Values.ingressGateways.gateways }}
+                {{- if (or $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}
+                -ingress-gateway-name="{{ .name }}.{{ (default $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}" \
+                {{- else }}
+                -ingress-gateway-name="{{ .name }}" \
+                {{- end }}
+                {{- end }}
+                {{- else }}
+                {{- range .Values.ingressGateways.gateways }}
+                -ingress-gateway-name="{{ .name }}" \
+                {{- end }}
+                {{- end }}
+                {{- end }}
+
                 {{- if .Values.connectInject.aclBindingRuleSelector }}
                 -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
                 {{- end }}
+
                 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
                 -create-enterprise-license-token=true \
                 {{- end }}
+
                 {{- if .Values.client.snapshotAgent.enabled }}
                 -create-snapshot-agent-token=true \
                 {{- end }}
+
                 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
                 -create-client-token=false \
                 {{- end }}
+
                 {{- if .Values.global.acls.createReplicationToken }}
                 -create-acl-replication-token=true \
                 {{- end }}
+
                 {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
                 -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
                 {{- else if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
                 -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
                 {{- end }}
+
                 {{- if .Values.global.enableConsulNamespaces }}
                 -enable-namespaces=true \
+
                 {{- /* syncCatalog must be enabled to set sync flags */}}
                 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
                 {{- if .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
@@ -168,6 +199,7 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+
                 {{- /* connectInject must be enabled to set inject flags */}}
                 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
                 -create-inject-namespace-token=true \
@@ -181,6 +213,7 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+
                 {{- end }}
           resources:
             requests:

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -267,9 +267,9 @@ load _helpers
 @test "helper/bootstrapACLs: used alongside manageSystemACLs" {
   cd `chart_dir`
 
-  diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r 'or \.Values\.global\.acls\.manageSystemACLs \.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
+  diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 
-  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r 'or \.Values\.global\.acls\.manageSystemACLs \.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
+  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 }

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -1,0 +1,1978 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateways/Deployment: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Deployment: enabled with ingressGateways, connectInject and client.grpc enabled, has default gateway name" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "ingress-gateway" ]
+}
+
+#--------------------------------------------------------------------
+# prerequisites
+
+@test "ingressGateways/Deployment: fails if connectInject.enabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=false' \
+      --set 'client.grpc=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.enabled must be true" ]]
+}
+
+@test "ingressGateways/Deployment: fails if client.grpc=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'client.grpc=false' \
+      --set 'connectInject.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "client.grpc must be true" ]]
+}
+
+@test "ingressGateways/Deployment: fails if global.enabled is false and clients are not explicitly enabled" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enabled=false' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "clients must be enabled" ]]
+}
+
+@test "ingressGateways/Deployment: fails if global.enabled is true but clients are explicitly disabled" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enabled=true' \
+      --set 'client.enabled=false' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "clients must be enabled" ]]
+}
+
+#--------------------------------------------------------------------
+# envoyImage
+
+@test "ingressGateways/Deployment: envoy image has default global value" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
+}
+
+@test "ingressGateways/Deployment: envoy image can be set using the global value" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.imageEnvoy=new/image' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "new/image" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enabled
+
+@test "ingressGateways/Deployment: sets TLS flags when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8502' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "ingressGateways/Deployment: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local ca_cert_volume=$(helm template \
+      -x templates/client-snapshot-agent-deployment.yaml  \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual=$(echo $ca_cert_volume | yq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # check that the volume uses the provided secret key
+  local actual=$(echo $ca_cert_volume | yq -r '.secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "ingressGateways/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo.com' \
+      --set 'externalServers.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
+#--------------------------------------------------------------------
+# replicas
+
+@test "ingressGateways/Deployment: replicas defaults to 2" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "ingressGateways/Deployment: replicas can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.replicas=3' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "ingressGateways/Deployment: replicas can be set through specific gateway, overrides default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.replicas=3' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].replicas=12' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "12" ]
+}
+
+#--------------------------------------------------------------------
+# hostPort
+
+@test "ingressGateways/Deployment: no hostPort by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Deployment: can set a hostPort through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.hostPort=443' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "ingressGateways/Deployment: can set a hostPort through specific gateway, overrides default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.hostPort=443' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].hostPort=1234' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
+  [ "${actual}" = "1234" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "ingressGateways/Deployment: resources has default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "128Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "250m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "256Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "500m" ]
+}
+
+@test "ingressGateways/Deployment: resources can be set through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.resources.requests.memory=memory' \
+      --set 'ingressGateways.defaults.resources.requests.cpu=cpu' \
+      --set 'ingressGateways.defaults.resources.limits.memory=memory2' \
+      --set 'ingressGateways.defaults.resources.limits.cpu=cpu2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory" ]
+
+  local actual=$(echo $object | yq -r '.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu" ]
+
+  local actual=$(echo $object | yq -r '.limits.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory2" ]
+
+  local actual=$(echo $object | yq -r '.limits.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu2" ]
+}
+
+@test "ingressGateways/Deployment: resources can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.resources.requests.memory=memory' \
+      --set 'ingressGateways.defaults.resources.requests.cpu=cpu' \
+      --set 'ingressGateways.defaults.resources.limits.memory=memory2' \
+      --set 'ingressGateways.defaults.resources.limits.cpu=cpu2' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].resources.requests.memory=gwmemory' \
+      --set 'ingressGateways.gateways[0].resources.requests.cpu=gwcpu' \
+      --set 'ingressGateways.gateways[0].resources.limits.memory=gwmemory2' \
+      --set 'ingressGateways.gateways[0].resources.limits.cpu=gwcpu2' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
+  [ "${actual}" = "gwmemory" ]
+
+  local actual=$(echo $object | yq -r '.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "gwcpu" ]
+
+  local actual=$(echo $object | yq -r '.limits.memory' | tee /dev/stderr)
+  [ "${actual}" = "gwmemory2" ]
+
+  local actual=$(echo $object | yq -r '.limits.cpu' | tee /dev/stderr)
+  [ "${actual}" = "gwcpu2" ]
+}
+
+#--------------------------------------------------------------------
+# affinity
+
+@test "ingressGateways/Deployment: affinity defaults to one per node" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey' | tee /dev/stderr)
+  [ "${actual}" = "kubernetes.io/hostname" ]
+}
+
+@test "ingressGateways/Deployment: affinity can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.affinity=key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "ingressGateways/Deployment: affinity can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.affinity=key: value' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].affinity=key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# tolerations
+
+@test "ingressGateways/Deployment: no tolerations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Deployment: tolerations can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.tolerations[0].key=value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "ingressGateways/Deployment: tolerations can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.tolerations[0].key=value' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].tolerations[0].key=value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "ingressGateways/Deployment: no nodeSelector by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Deployment: can set a nodeSelector through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.nodeSelector=key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "ingressGateways/Deployment: can set a nodeSelector through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.nodeSelector=key: value' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].nodeSelector=key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# priorityClassName
+
+@test "ingressGateways/Deployment: no priorityClassName by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Deployment: can set a priorityClassName through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.priorityClassName=name' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "name" ]
+}
+
+@test "ingressGateways/Deployment: can set a priorityClassName per gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.priorityClassName=name' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].priorityClassName=priority' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "priority" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "ingressGateways/Deployment: no extra annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "ingressGateways/Deployment: extra annotations can be set through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "ingressGateways/Deployment: extra annotations can be set through specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "ingressGateways/Deployment: extra annotations can be set through defaults and specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.annotations=defaultkey: defaultvalue' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "4" ]
+
+  local actual=$(echo $object | yq -r '.defaultkey' | tee /dev/stderr)
+  [ "${actual}" = "defaultvalue" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# service-init init container
+
+@test "ingressGateways/Deployment: service-init init container" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container with acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s acl-init \
+  -secret-name="release-name-consul-ingress-gateway-ingress-gateway-acl-token" \
+  -k8s-namespace=default \
+  -token-sink-file=/consul/service/acl-token
+
+consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  -token-file=/consul/service/acl-token \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container with global.federation.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.federation.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.port can be changed through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=NodeIP' \
+      --set 'ingressGateways.defaults.wanAddress.port=9999' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="9999"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.port can be changed through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=NodeIP' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.port=9999' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="9999"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=NodeIP through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=NodeIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=NodeIP through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=NodeIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=NodeName through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=NodeName' \
+      . | tee /dev/stderr |
+      yq -s '.[0]')
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].env | map(select(.name == "NODE_NAME")) | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${NODE_NAME}"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=NodeName through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=NodeName' \
+      . | tee /dev/stderr |
+      yq -s '.[0]')
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].env | map(select(.name == "NODE_NAME")) | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${NODE_NAME}"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Static fails if wanAddress.static is empty in defaults" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Static' \
+      --set 'ingressGateways.defaults.wanAddress.static=' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if ingressGateways .wanAddress.source=Static then ingressGateways .wanAddress.static cannot be empty and must be set in either the defaults or in the gateway definition" ]]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Static fails if wanAddress.static is empty in specific gateway" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Static' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.static=' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if ingressGateways .wanAddress.source=Static then ingressGateways .wanAddress.static cannot be empty and must be set in either the defaults or in the gateway definition" ]]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Static through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Static' \
+      --set 'ingressGateways.defaults.wanAddress.static=example.com' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="example.com"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Static through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=Static' \
+      --set 'ingressGateways.gateways[0].wanAddress.static=example.com' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="example.com"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service fails if defaults service.enable is false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.service.enabled=false' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" ]]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service fails if specific gateway service.enable is false, overriding defaults" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].service.enabled=false' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" ]]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=LoadBalancer through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.wanAddress.port=ignored' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.type=LoadBalancer' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=LoadBalancer through specific gateway, overrides defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Static' \
+      --set 'ingressGateways.defaults.wanAddress.port=ignored' \
+      --set 'ingressGateways.defaults.service.enabled=false' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=Service' \
+      --set 'ingressGateways.gateways[0].wanAddress.port=ignored' \
+      --set 'ingressGateways.gateways[0].service.enabled=true' \
+      --set 'ingressGateways.gateways[0].service.type=LoadBalancer' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=NodePort through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.nodePort=9999' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="9999"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=NodePort through specific gateway, overrides default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.nodePort=9999' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.defaults.service.nodePort=1234' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='WAN_ADDR="${HOST_IP}"
+WAN_PORT="1234"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=NodePort fails if service.nodePort is null" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.rpc=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if ingressGateways .wanAddress.source=Service and ingressGateways .service.type=NodePort, ingressGateways .service.nodePort must be set in either the defaults or in the gateway definition" ]]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=ClusterIP through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.rpc=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Service' \
+      --set 'ingressGateways.defaults.wanAddress.port=ignored' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.type=ClusterIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=ClusterIP through specific gateway, overrides defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.rpc=true' \
+      --set 'ingressGateways.defaults.wanAddress.source=Static' \
+      --set 'ingressGateways.defaults.wanAddress.port=1234' \
+      --set 'ingressGateways.defaults.service.enabled=false' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=Service' \
+      --set 'ingressGateways.gateways[0].wanAddress.port=ignored' \
+      --set 'ingressGateways.gateways[0].service.enabled=true' \
+      --set 'ingressGateways.gateways[0].service.type=ClusterIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container gateway name can be changed" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=new-name' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=new-name \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "new-name"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container gateway namespace can be specified through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  namespace = "namespace"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "ingressGateways/Deployment: service-init init container gateway namespace can be specified through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=namespace' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].consulNamespace=new-namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s service-address \
+  -k8s-namespace=default \
+  -name=ingress-gateway \
+  -output-file=/tmp/address.txt
+WAN_ADDR="$(cat /tmp/address.txt)"
+WAN_PORT="443"
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "ingress-gateway"
+  name = "ingress-gateway"
+  namespace = "new-namespace"
+  port = ${WAN_PORT}
+  address = "${WAN_ADDR}"
+  tagged_addresses {
+    lan {
+      address = "${POD_IP}"
+      port = 8443
+    }
+    wan {
+      address = "${WAN_ADDR}"
+      port = ${WAN_PORT}
+    }
+  }
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Ingress Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+#--------------------------------------------------------------------
+# multiple gateways
+
+@test "ingressGateways/Deployment: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway2" ]
+
+  local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[1] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/Deployment: enabled with ingressGateways, connectInject and client.grpc enabled, has default gateway name" {
+@test "ingressGateways/Deployment: enabled with ingressGateways, connectInject enabled, has default gateway name" {
   cd `chart_dir`
   local object=$(helm template \
       -x templates/ingress-gateways-deployment.yaml  \

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s '.[0]' | tee /dev/stderr)
 
@@ -25,7 +24,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "ingress-gateway" ]
+  [ "${actual}" = "release-name-consul-ingress-gateway" ]
 }
 
 #--------------------------------------------------------------------
@@ -36,8 +35,7 @@ load _helpers
   run helm template \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=false' \
-      --set 'client.grpc=true' .
+      --set 'connectInject.enabled=false' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "connectInject.enabled must be true" ]]
 }
@@ -58,7 +56,6 @@ load _helpers
   run helm template \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.enabled=false' .
   [ "$status" -eq 1 ]
@@ -70,7 +67,6 @@ load _helpers
   run helm template \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.enabled=true' \
       --set 'client.enabled=false' .
@@ -87,7 +83,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
@@ -99,7 +94,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.imageEnvoy=new/image' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -220,7 +214,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
   [ "${actual}" = "2" ]
@@ -232,7 +225,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.replicas=3' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
@@ -245,7 +237,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.replicas=3' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].replicas=12' \
@@ -263,7 +254,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -275,7 +265,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.hostPort=443' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
@@ -288,7 +277,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.hostPort=443' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].hostPort=1234' \
@@ -306,7 +294,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
 
@@ -322,7 +309,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.resources.requests.memory=memory' \
       --set 'ingressGateways.defaults.resources.requests.cpu=cpu' \
       --set 'ingressGateways.defaults.resources.limits.memory=memory2' \
@@ -349,7 +335,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.resources.requests.memory=memory' \
       --set 'ingressGateways.defaults.resources.requests.cpu=cpu' \
       --set 'ingressGateways.defaults.resources.limits.memory=memory2' \
@@ -384,7 +369,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey' | tee /dev/stderr)
   [ "${actual}" = "kubernetes.io/hostname" ]
@@ -396,7 +380,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.affinity=key: value' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.affinity.key' | tee /dev/stderr)
@@ -409,7 +392,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.affinity=key: value' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].affinity=key2: value2' \
@@ -427,7 +409,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.tolerations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -439,8 +420,7 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.tolerations[0].key=value' \
+      --set 'ingressGateways.defaults.tolerations=- key: value' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
@@ -452,10 +432,9 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.tolerations[0].key=value' \
+      --set 'ingressGateways.defaults.tolerations=- key: value' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
-      --set 'ingressGateways.gateways[0].tolerations[0].key=value2' \
+      --set 'ingressGateways.gateways[0].tolerations=- key: value2' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value2" ]
@@ -470,7 +449,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -482,7 +460,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.nodeSelector=key: value' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.nodeSelector.key' | tee /dev/stderr)
@@ -495,7 +472,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.nodeSelector=key: value' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].nodeSelector=key2: value2' \
@@ -513,7 +489,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -525,7 +500,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.priorityClassName=name' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
@@ -538,7 +512,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.priorityClassName=name' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].priorityClassName=priority' \
@@ -556,7 +529,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.metadata.annotations | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
@@ -568,7 +540,6 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.annotations=key1: value1
 key2: value2' \
       . | tee /dev/stderr |
@@ -590,7 +561,6 @@ key2: value2' \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].annotations=key1: value1
 key2: value2' \
@@ -613,7 +583,6 @@ key2: value2' \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.annotations=defaultkey: defaultvalue' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].annotations=key1: value1
@@ -643,7 +612,6 @@ key2: value2' \
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
 
@@ -758,68 +726,6 @@ EOF
 
 /consul-bin/consul services register \
   -token-file=/consul/service/acl-token \
-  /consul/service/service.hcl'
-
-  [ "${actual}" = "${exp}" ]
-}
-
-@test "ingressGateways/Deployment: service-init init container with global.federation.enabled=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ingress-gateways-deployment.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.federation.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'meshGateway.enabled=true' \
-      . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
-
-  exp='consul-k8s service-address \
-  -k8s-namespace=default \
-  -name=ingress-gateway \
-  -output-file=/tmp/address.txt
-WAN_ADDR="$(cat /tmp/address.txt)"
-WAN_PORT="443"
-
-cat > /consul/service/service.hcl << EOF
-service {
-  kind = "ingress-gateway"
-  name = "ingress-gateway"
-  port = ${WAN_PORT}
-  address = "${WAN_ADDR}"
-  tagged_addresses {
-    lan {
-      address = "${POD_IP}"
-      port = 8443
-    }
-    wan {
-      address = "${WAN_ADDR}"
-      port = ${WAN_PORT}
-    }
-  }
-  proxy {
-    config {
-      envoy_gateway_no_default_bind = true
-      envoy_gateway_bind_addresses {
-        all-interfaces {
-          address = "0.0.0.0"
-        }
-      }
-    }
-  }
-  checks = [
-    {
-      name = "Ingress Gateway Listening"
-      interval = "10s"
-      tcp = "${POD_IP}:8443"
-      deregister_critical_service_after = "6h"
-    }
-  ]
-}
-EOF
-
-/consul-bin/consul services register \
   /consul/service/service.hcl'
 
   [ "${actual}" = "${exp}" ]
@@ -1327,36 +1233,6 @@ EOF
   [ "${actual}" = "${exp}" ]
 }
 
-@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service fails if defaults service.enable is false" {
-  cd `chart_dir`
-  run helm template \
-      -x templates/ingress-gateways-deployment.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'ingressGateways.defaults.wanAddress.source=Service' \
-      --set 'ingressGateways.defaults.service.enabled=false' \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" ]]
-}
-
-@test "ingressGateways/Deployment: service-init init container wanAddress.source=Service fails if specific gateway service.enable is false, overriding defaults" {
-  cd `chart_dir`
-  run helm template \
-      -x templates/ingress-gateways-deployment.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'ingressGateways.defaults.wanAddress.source=Service' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
-      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
-      --set 'ingressGateways.gateways[0].service.enabled=false' \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "if ingressGateways .wanAddress.source=Service then ingressGateways .service.enabled must be set to true in either the defaults or in the gateway definition" ]]
-}
-
 @test "ingressGateways/Deployment: service-init init container wanAddress.source=Service, type=LoadBalancer through defaults" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -1365,7 +1241,6 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Service' \
       --set 'ingressGateways.defaults.wanAddress.port=ignored' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.type=LoadBalancer' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
@@ -1428,12 +1303,10 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Static' \
       --set 'ingressGateways.defaults.wanAddress.port=ignored' \
-      --set 'ingressGateways.defaults.service.enabled=false' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       --set 'ingressGateways.gateways[0].name=ingress-gateway' \
       --set 'ingressGateways.gateways[0].wanAddress.source=Service' \
       --set 'ingressGateways.gateways[0].wanAddress.port=ignored' \
-      --set 'ingressGateways.gateways[0].service.enabled=true' \
       --set 'ingressGateways.gateways[0].service.type=LoadBalancer' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
@@ -1495,7 +1368,6 @@ EOF
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Service' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.nodePort=9999' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       . | tee /dev/stderr |
@@ -1554,7 +1426,6 @@ EOF
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Service' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.nodePort=9999' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       --set 'ingressGateways.gateways[0].name=ingress-gateway' \
@@ -1616,7 +1487,6 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'client.rpc=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Service' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       .
 
@@ -1633,7 +1503,6 @@ EOF
       --set 'client.rpc=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Service' \
       --set 'ingressGateways.defaults.wanAddress.port=ignored' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.type=ClusterIP' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
@@ -1697,12 +1566,10 @@ EOF
       --set 'client.rpc=true' \
       --set 'ingressGateways.defaults.wanAddress.source=Static' \
       --set 'ingressGateways.defaults.wanAddress.port=1234' \
-      --set 'ingressGateways.defaults.service.enabled=false' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       --set 'ingressGateways.gateways[0].name=ingress-gateway' \
       --set 'ingressGateways.gateways[0].wanAddress.source=Service' \
       --set 'ingressGateways.gateways[0].wanAddress.port=ignored' \
-      --set 'ingressGateways.gateways[0].service.enabled=true' \
       --set 'ingressGateways.gateways[0].service.type=ClusterIP' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
@@ -1763,7 +1630,6 @@ EOF
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=new-name' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
@@ -1824,7 +1690,6 @@ EOF
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'ingressGateways.defaults.consulNamespace=namespace' \
       . | tee /dev/stderr |
@@ -1887,7 +1752,6 @@ EOF
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'ingressGateways.defaults.consulNamespace=namespace' \
       --set 'ingressGateways.gateways[0].name=ingress-gateway' \
@@ -1947,6 +1811,48 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# namespaces
+
+@test "ingressGateways/Deployment: namespace command flag is not present by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Deployment: namespace command flag is specified through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace=namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: namespace command flag is specified through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=namespace' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].consulNamespace=new-namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace=new-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # multiple gateways
 
 @test "ingressGateways/Deployment: multiple gateways" {
@@ -1955,17 +1861,16 @@ EOF
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[1].name=gateway2' \
       . | tee /dev/stderr |
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway1" ]
+  [ "${actual}" = "release-name-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway2" ]
+  [ "${actual}" = "release-name-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -878,7 +878,7 @@ key2: value2' \
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=ingress-gateway \
+  -name=release-name-consul-ingress-gateway \
   -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
@@ -888,6 +888,7 @@ cat > /consul/service/service.hcl << EOF
 service {
   kind = "ingress-gateway"
   name = "ingress-gateway"
+  id = "${POD_NAME}"
   port = ${WAN_PORT}
   address = "${WAN_ADDR}"
   tagged_addresses {
@@ -944,7 +945,7 @@ EOF
 
 consul-k8s service-address \
   -k8s-namespace=default \
-  -name=ingress-gateway \
+  -name=release-name-consul-ingress-gateway \
   -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
@@ -954,6 +955,7 @@ cat > /consul/service/service.hcl << EOF
 service {
   kind = "ingress-gateway"
   name = "ingress-gateway"
+  id = "${POD_NAME}"
   port = ${WAN_PORT}
   address = "${WAN_ADDR}"
   tagged_addresses {

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -717,6 +717,7 @@ key2: value2' \
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -782,6 +783,7 @@ EOF
 consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1347,6 +1349,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1413,6 +1416,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1609,6 +1613,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1676,6 +1681,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1736,6 +1742,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=new-name \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1797,6 +1804,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1861,6 +1869,7 @@ EOF
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=ingress-gateway \
+  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -264,13 +264,13 @@ load _helpers
   [ "${actual}" = "gateway-health" ]
 
   local actual=$(echo $object | yq -r '.[1].containerPort' | tee /dev/stderr)
-  [ "${actual}" = "80" ]
+  [ "${actual}" = "8080" ]
 
   local actual=$(echo $object | yq -r '.[1].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-0" ]
 
   local actual=$(echo $object | yq -r '.[2].containerPort' | tee /dev/stderr)
-  [ "${actual}" = "443" ]
+  [ "${actual}" = "8443" ]
 
   local actual=$(echo $object | yq -r '.[2].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-1" ]
@@ -282,8 +282,8 @@ load _helpers
       -x templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'ingressGateways.defaults.service.ports[0].port=8443' \
-      --set 'ingressGateways.defaults.service.ports[1].port=8444' \
+      --set 'ingressGateways.defaults.service.ports[0].port=1234' \
+      --set 'ingressGateways.defaults.service.ports[1].port=4444' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].ports' | tee /dev/stderr)
 
@@ -294,13 +294,13 @@ load _helpers
   [ "${actual}" = "gateway-health" ]
 
   local actual=$(echo $object | yq -r '.[1].containerPort' | tee /dev/stderr)
-  [ "${actual}" = "8443" ]
+  [ "${actual}" = "1234" ]
 
   local actual=$(echo $object | yq -r '.[1].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-0" ]
 
   local actual=$(echo $object | yq -r '.[2].containerPort' | tee /dev/stderr)
-  [ "${actual}" = "8444" ]
+  [ "${actual}" = "4444" ]
 
   local actual=$(echo $object | yq -r '.[2].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-1" ]
@@ -882,7 +882,7 @@ key2: value2' \
   -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
-WAN_PORT=80
+WAN_PORT=8080
 
 cat > /consul/service/service.hcl << EOF
 service {
@@ -949,7 +949,7 @@ consul-k8s service-address \
   -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
-WAN_PORT=80
+WAN_PORT=8080
 
 cat > /consul/service/service.hcl << EOF
 service {

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -396,10 +396,10 @@ load _helpers
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
 
-  [ $(echo "${actual}" | yq -r '.requests.memory') = "128Mi" ]
-  [ $(echo "${actual}" | yq -r '.requests.cpu') = "250m" ]
-  [ $(echo "${actual}" | yq -r '.limits.memory') = "256Mi" ]
-  [ $(echo "${actual}" | yq -r '.limits.cpu') = "500m" ]
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "100Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "100m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "100Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "100m" ]
 }
 
 @test "ingressGateways/Deployment: resources can be set through defaults" {

--- a/test/unit/ingress-gateways-podsecuritypolicy.bats
+++ b/test/unit/ingress-gateways-podsecuritypolicy.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateways/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-podsecuritypolicy.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/PodSecurityPolicy: enabled with ingressGateways, connectInject and client.grpc enabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-podsecuritypolicy.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/PodSecurityPolicy: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-podsecuritypolicy.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[1] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway2" ]
+}

--- a/test/unit/ingress-gateways-podsecuritypolicy.bats
+++ b/test/unit/ingress-gateways-podsecuritypolicy.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/ingress-gateways-podsecuritypolicy.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
@@ -30,7 +29,6 @@ load _helpers
       -x templates/ingress-gateways-podsecuritypolicy.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[1].name=gateway2' \
@@ -47,8 +45,8 @@ load _helpers
   [ "${actual}" = "false" ]
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway1" ]
+  [ "${actual}" = "release-name-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway2" ]
+  [ "${actual}" = "release-name-consul-gateway2" ]
 }

--- a/test/unit/ingress-gateways-podsecuritypolicy.bats
+++ b/test/unit/ingress-gateways-podsecuritypolicy.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/PodSecurityPolicy: enabled with ingressGateways, connectInject and client.grpc enabled and global.enablePodSecurityPolicies=true" {
+@test "ingressGateways/PodSecurityPolicy: enabled with ingressGateways, connectInject enabled and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-podsecuritypolicy.yaml  \

--- a/test/unit/ingress-gateways-role.bats
+++ b/test/unit/ingress-gateways-role.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateways/Role: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Role: enabled with ingressGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Role: rules for PodSecurityPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+@test "ingressGateways/Role: rules for global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+
+  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "ingress-gateway-ingress-gateway-acl-token" ]
+}
+
+@test "ingressGateways/Role: rules for ingressGateways .wanAddress.source=Service" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "services" ]
+}
+
+@test "ingressGateways/Role: rules is empty if no ACLs, PSPs and ingressGateways .source != Service" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].wanAddress.source=NodeIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules' | tee /dev/stderr)
+  [ "${actual}" = "[]" ]
+}
+
+@test "ingressGateways/Role: rules for ACLs, PSPs and ingress gateways" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "ingressGateways/Role: rules for ACLs, PSPs and ingress gateways with multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway2" ]
+
+  local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq '.[1].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/ingress-gateways-role.bats
+++ b/test/unit/ingress-gateways-role.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -29,7 +28,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
@@ -42,7 +40,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].rules[0]' | tee /dev/stderr)
@@ -51,7 +48,7 @@ load _helpers
   [ "${actual}" = "secrets" ]
 
   local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "ingress-gateway-ingress-gateway-acl-token" ]
+  [ "${actual}" = "release-name-consul-ingress-gateway-ingress-gateway-acl-token" ]
 }
 
 @test "ingressGateways/Role: rules for ingressGateways .wanAddress.source=Service" {
@@ -60,7 +57,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "services" ]
@@ -72,7 +68,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=ingress-gateway' \
       --set 'ingressGateways.gateways[0].wanAddress.source=NodeIP' \
       . | tee /dev/stderr |
@@ -86,7 +81,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
@@ -100,7 +94,6 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
@@ -109,10 +102,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway1" ]
+  [ "${actual}" = "release-name-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway2" ]
+  [ "${actual}" = "release-name-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
   [ "${actual}" = "3" ]

--- a/test/unit/ingress-gateways-role.bats
+++ b/test/unit/ingress-gateways-role.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/Role: enabled with ingressGateways, connectInject and client.grpc enabled" {
+@test "ingressGateways/Role: enabled with ingressGateways, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-role.yaml  \
@@ -30,7 +30,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
+      yq -s -r '.[0].rules[1].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "podsecuritypolicies" ]
 }
 
@@ -42,7 +42,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].rules[0]' | tee /dev/stderr)
+      yq -s -r '.[0].rules[1]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
   [ "${actual}" = "secrets" ]
@@ -51,7 +51,7 @@ load _helpers
   [ "${actual}" = "release-name-consul-ingress-gateway-ingress-gateway-acl-token" ]
 }
 
-@test "ingressGateways/Role: rules for ingressGateways .wanAddress.source=Service" {
+@test "ingressGateways/Role: rules for ingressGateways service" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-role.yaml  \
@@ -60,19 +60,6 @@ load _helpers
       . | tee /dev/stderr |
       yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "services" ]
-}
-
-@test "ingressGateways/Role: rules is empty if no ACLs, PSPs and ingressGateways .source != Service" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ingress-gateways-role.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
-      --set 'ingressGateways.gateways[0].wanAddress.source=NodeIP' \
-      . | tee /dev/stderr |
-      yq -s -r '.[0].rules' | tee /dev/stderr)
-  [ "${actual}" = "[]" ]
 }
 
 @test "ingressGateways/Role: rules for ACLs, PSPs and ingress gateways" {

--- a/test/unit/ingress-gateways-rolebinding.bats
+++ b/test/unit/ingress-gateways-rolebinding.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateway/RoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-rolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateway/RoleBinding: enabled with ingressGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-rolebinding.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/RoleBinding: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-role.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "gateway2" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/ingress-gateways-rolebinding.bats
+++ b/test/unit/ingress-gateways-rolebinding.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateway/RoleBinding: enabled with ingressGateways, connectInject and client.grpc enabled" {
+@test "ingressGateway/RoleBinding: enabled with ingressGateways, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-rolebinding.yaml  \

--- a/test/unit/ingress-gateways-rolebinding.bats
+++ b/test/unit/ingress-gateways-rolebinding.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/ingress-gateways-rolebinding.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -29,17 +28,16 @@ load _helpers
       -x templates/ingress-gateways-role.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[1].name=gateway2' \
       . | tee /dev/stderr |
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway1" ]
+  [ "${actual}" = "release-name-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "gateway2" ]
+  [ "${actual}" = "release-name-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/ingress-gateways-service.bats
+++ b/test/unit/ingress-gateways-service.bats
@@ -1,0 +1,326 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateways/Service: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Service: disabled with ingressGateways.enabled=true .service.enabled set to false through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].service.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Service: enabled by default with ingressGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Service: enabled with ingressGateways.enabled=true .service.enabled set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Service: enabled with ingressGateways.enabled=true .service.enabled set through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=false' \
+      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
+      --set 'ingressGateways.gateways[0].service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "ingressGateways/Service: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Deployment: annotations can be set through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "ingressGateways/Service: annotations can be set through specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].service.annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "ingressGateways/Service: annotations can be set through defaults and specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.annotations=defaultkey: defaultvalue' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "4" ]
+
+  local actual=$(echo $object | yq -r '.defaultkey' | tee /dev/stderr)
+  [ "${actual}" = "defaultvalue" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# port
+
+@test "ingressGateways/Service: has default port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "ingressGateways/Service: can set port through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.port=8443' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
+@test "ingressGateways/Service: can set port through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.port=8443' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].service.port=1234' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "1234" ]
+}
+
+#--------------------------------------------------------------------
+# nodePort
+
+@test "ingressGateways/Service: no nodePort by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ingressGateways/Service: can set a nodePort through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.nodePort=8443' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
+@test "ingressGateways/Service: can set a nodePort through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.nodePort=8443' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].service.nodePort=1234' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "1234" ]
+}
+
+#--------------------------------------------------------------------
+# Service type
+
+@test "ingressGateways/Service: defaults to type LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.type' | tee /dev/stderr)
+  [ "${actual}" = "LoadBalancer" ]
+}
+
+@test "ingressGateways/Service: can set type through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.type=ClusterIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.type' | tee /dev/stderr)
+  [ "${actual}" = "ClusterIP" ]
+}
+
+@test "ingressGateways/Service: can set type through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.type=NodePort' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].service.type=ClusterIP' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.type' | tee /dev/stderr)
+  [ "${actual}" = "ClusterIP" ]
+}
+
+#--------------------------------------------------------------------
+# additionalSpec
+
+@test "ingressGateways/Service: can add additionalSpec through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.additionalSpec=key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "ingressGateways/Service: can add additionalSpec through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.defaults.service.enabled=true' \
+      --set 'ingressGateways.defaults.service.additionalSpec=key: value' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].service.additionalSpec=key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}

--- a/test/unit/ingress-gateways-service.bats
+++ b/test/unit/ingress-gateways-service.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/Service: enabled by default with ingressGateways, connectInject and client.grpc enabled" {
+@test "ingressGateways/Service: enabled by default with ingressGateways, connectInject andenabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-service.yaml  \

--- a/test/unit/ingress-gateways-service.bats
+++ b/test/unit/ingress-gateways-service.bats
@@ -11,56 +11,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/Service: disabled with ingressGateways.enabled=true .service.enabled set to false through specific gateway overriding defaults" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ingress-gateways-service.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
-      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
-      --set 'ingressGateways.gateways[0].service.enabled=false' \
-      . | tee /dev/stderr |
-      yq -s '.[0] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
 @test "ingressGateways/Service: enabled by default with ingressGateways, connectInject and client.grpc enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      . | tee /dev/stderr |
-      yq -s '.[0] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "ingressGateways/Service: enabled with ingressGateways.enabled=true .service.enabled set through defaults" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ingress-gateways-service.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
-      . | tee /dev/stderr |
-      yq -s '.[0] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "ingressGateways/Service: enabled with ingressGateways.enabled=true .service.enabled set through specific gateway overriding defaults" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ingress-gateways-service.yaml  \
-      --set 'ingressGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=false' \
-      --set 'ingressGateways.gateways[0].name=ingress-gateway' \
-      --set 'ingressGateways.gateways[0].service.enabled=true' \
       . | tee /dev/stderr |
       yq -s '.[0] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -75,8 +31,6 @@ load _helpers
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.service.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].metadata.annotations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -88,7 +42,6 @@ load _helpers
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.defaults.service.annotations=key1: value1
 key2: value2' \
       . | tee /dev/stderr |
@@ -110,7 +63,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.annotations=key1: value1
 key2: value2' \
@@ -130,19 +82,18 @@ key2: value2' \
 @test "ingressGateways/Service: annotations can be set through defaults and specific gateway" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/ingress-gateways-deployment.yaml  \
+      -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.annotations=defaultkey: defaultvalue' \
+      --set 'ingressGateways.defaults.service.annotations=defaultkey: defaultvalue' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
-      --set 'ingressGateways.gateways[0].annotations=key1: value1
+      --set 'ingressGateways.gateways[0].service.annotations=key1: value1
 key2: value2' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+      yq -s -r '.[0].metadata.annotations' | tee /dev/stderr)
 
   local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
-  [ "${actual}" = "4" ]
+  [ "${actual}" = "3" ]
 
   local actual=$(echo $object | yq -r '.defaultkey' | tee /dev/stderr)
   [ "${actual}" = "defaultvalue" ]
@@ -163,8 +114,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].port' | tee /dev/stderr)
   [ "${actual}" = "443" ]
@@ -176,8 +125,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.port=8443' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].port' | tee /dev/stderr)
@@ -190,8 +137,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.port=8443' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.port=1234' \
@@ -209,8 +154,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -222,8 +165,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.nodePort=8443' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
@@ -236,8 +177,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.nodePort=8443' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.nodePort=1234' \
@@ -249,17 +188,15 @@ key2: value2' \
 #--------------------------------------------------------------------
 # Service type
 
-@test "ingressGateways/Service: defaults to type LoadBalancer" {
+@test "ingressGateways/Service: defaults to type ClusterIP" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.type' | tee /dev/stderr)
-  [ "${actual}" = "LoadBalancer" ]
+  [ "${actual}" = "ClusterIP" ]
 }
 
 @test "ingressGateways/Service: can set type through defaults" {
@@ -268,12 +205,10 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
-      --set 'ingressGateways.defaults.service.type=ClusterIP' \
+      --set 'ingressGateways.defaults.service.type=LoadBalancer' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.type' | tee /dev/stderr)
-  [ "${actual}" = "ClusterIP" ]
+  [ "${actual}" = "LoadBalancer" ]
 }
 
 @test "ingressGateways/Service: can set type through specific gateway overriding defaults" {
@@ -282,8 +217,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.type=ClusterIP' \
@@ -301,8 +234,6 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.additionalSpec=key: value' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.key' | tee /dev/stderr)
@@ -315,12 +246,48 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'ingressGateways.defaults.service.enabled=true' \
       --set 'ingressGateways.defaults.service.additionalSpec=key: value' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.additionalSpec=key2: value2' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.key2' | tee /dev/stderr)
   [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# selectors 
+
+@test "ingressGateways/Service: label selectors uniquely identify gateways" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.selector."ingress-gateway-name"' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-ingress-gateway" ]
+}
+
+#--------------------------------------------------------------------
+# multiple gateways
+
+@test "ingressGateways/Service: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-service.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }

--- a/test/unit/ingress-gateways-service.bats
+++ b/test/unit/ingress-gateways-service.bats
@@ -118,13 +118,13 @@ key2: value2' \
       yq -s -r '.[0].spec.ports' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].port' | tee /dev/stderr)
-  [ "${actual}" = "80" ]
+  [ "${actual}" = "8080" ]
 
   local actual=$(echo $object | yq -r '.[0].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-0" ]
 
   local actual=$(echo $object | yq -r '.[1].port' | tee /dev/stderr)
-  [ "${actual}" = "443" ]
+  [ "${actual}" = "8443" ]
 
   local actual=$(echo $object | yq -r '.[1].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-1" ]
@@ -136,26 +136,26 @@ key2: value2' \
       -x templates/ingress-gateways-service.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'ingressGateways.defaults.service.ports[0].port=8443' \
-      --set 'ingressGateways.defaults.service.ports[1].port=8444' \
-      --set 'ingressGateways.defaults.service.ports[2].port=8445' \
+      --set 'ingressGateways.defaults.service.ports[0].port=4443' \
+      --set 'ingressGateways.defaults.service.ports[1].port=4444' \
+      --set 'ingressGateways.defaults.service.ports[2].port=4445' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].port' | tee /dev/stderr)
-  [ "${actual}" = "8443" ]
+  [ "${actual}" = "4443" ]
 
   local actual=$(echo $object | yq -r '.[0].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-0" ]
 
   local actual=$(echo $object | yq -r '.[1].port' | tee /dev/stderr)
-  [ "${actual}" = "8444" ]
+  [ "${actual}" = "4444" ]
 
   local actual=$(echo $object | yq -r '.[1].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-1" ]
 
   local actual=$(echo $object | yq -r '.[2].port' | tee /dev/stderr)
-  [ "${actual}" = "8445" ]
+  [ "${actual}" = "4445" ]
 
   local actual=$(echo $object | yq -r '.[2].name' | tee /dev/stderr)
   [ "${actual}" = "gateway-2" ]
@@ -219,7 +219,7 @@ key2: value2' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.service.ports[0].port=80' \
-      --set 'ingressGateways.defaults.service.ports[0].nodePort=8443' \
+      --set 'ingressGateways.defaults.service.ports[0].nodePort=4443' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -233,10 +233,10 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
       --set 'ingressGateways.defaults.service.ports[0].port=80' \
-      --set 'ingressGateways.defaults.service.ports[0].nodePort=8443' \
+      --set 'ingressGateways.defaults.service.ports[0].nodePort=4443' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.ports[0].nodePort' | tee /dev/stderr)
-  [ "${actual}" = "8443" ]
+  [ "${actual}" = "4443" ]
 }
 
 @test "ingressGateways/Service: can set a nodePort through specific gateway overriding defaults" {
@@ -246,7 +246,7 @@ key2: value2' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.defaults.service.type=NodePort' \
-      --set 'ingressGateways.defaults.service.ports[0].nodePort=8443' \
+      --set 'ingressGateways.defaults.service.ports[0].nodePort=4443' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[0].service.ports[0].port=80' \
       --set 'ingressGateways.gateways[0].service.ports[0].nodePort=1234' \

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ingressGateways/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/ServiceAccount: enabled with ingressGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ingress-gateways-serviceaccount.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "ingressGateways/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-serviceaccount.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[0].imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[0].imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+
+#--------------------------------------------------------------------
+# multiple gateways
+
+@test "ingressGateways/ServiceAccount: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/ingress-gateways-serviceaccount.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[1] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ingressGateways/ServiceAccount: enabled with ingressGateways, connectInject and client.grpc enabled" {
+@test "ingressGateways/ServiceAccount: enabled with ingressGateways, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ingress-gateways-serviceaccount.yaml  \

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/ingress-gateways-serviceaccount.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -56,17 +55,16 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[1].name=gateway2' \
-      . | tee /dev/stderr)
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
 
   local actual=$(echo "$object" |
-      yq -s -r '.[0] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(echo "$object" |
-      yq -s -r '.[1] | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(echo "$object" |
-      yq -s -r '.[2] | length > 0' | tee /dev/stderr)
+      yq -r '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }

--- a/test/unit/mesh-gateway-clusterrole.bats
+++ b/test/unit/mesh-gateway-clusterrole.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ClusterRole: enabled with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/ClusterRole: enabled with meshGateway, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-clusterrole.yaml  \

--- a/test/unit/mesh-gateway-clusterrole.bats
+++ b/test/unit/mesh-gateway-clusterrole.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrole.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -29,7 +28,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrole.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
@@ -42,7 +40,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrole.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0].resources[0]' | tee /dev/stderr)
@@ -70,7 +67,6 @@ load _helpers
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.wanAddress.source=NodeIP' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.rules' | tee /dev/stderr)
   [ "${actual}" = "[]" ]
@@ -82,7 +78,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrole.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       --set 'meshGateway.service.enabled=true' \

--- a/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrolebinding.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -29,7 +28,6 @@ load _helpers
       -x templates/mesh-gateway-clusterrolebinding.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --name 'release-name' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].name' | tee /dev/stderr)

--- a/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ClusterRoleBinding: enabled with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/ClusterRoleBinding: enabled with meshGateway, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-clusterrolebinding.yaml  \

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -31,8 +30,7 @@ load _helpers
   run helm template \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
-      --set 'connectInject.enabled=false' \
-      --set 'client.grpc=true' .
+      --set 'connectInject.enabled=false' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "connectInject.enabled must be true" ]]
 }
@@ -53,7 +51,6 @@ load _helpers
   run helm template \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.enabled=false' .
   [ "$status" -eq 1 ]
@@ -65,7 +62,6 @@ load _helpers
   run helm template \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.enabled=true' \
       --set 'client.enabled=false' .
@@ -82,7 +78,6 @@ load _helpers
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
@@ -94,7 +89,6 @@ load _helpers
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.annotations=key1: value1
 key2: value2' \
       . | tee /dev/stderr |
@@ -111,7 +105,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.replicas' | tee /dev/stderr)
   [ "${actual}" = "2" ]
@@ -123,7 +116,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.replicas=3' \
       . | tee /dev/stderr |
       yq -r '.spec.replicas' | tee /dev/stderr)
@@ -139,7 +131,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey' | tee /dev/stderr)
   [ "${actual}" = "kubernetes.io/hostname" ]
@@ -151,7 +142,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.affinity=key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.affinity.key' | tee /dev/stderr)
@@ -167,7 +157,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -179,7 +168,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.tolerations=- key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
@@ -196,7 +184,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.hostNetwork' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -208,7 +195,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.hostNetwork=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.hostNetwork' | tee /dev/stderr)
@@ -224,7 +210,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.dnsPolicy' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -236,7 +221,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.dnsPolicy=ClusterFirst' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.dnsPolicy' | tee /dev/stderr)
@@ -252,7 +236,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
@@ -264,7 +247,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.imageEnvoy=new/image' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -280,7 +262,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
 
@@ -296,7 +277,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
@@ -326,7 +306,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr \
       | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
 
@@ -341,7 +320,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.containerPort=9443' \
       . | tee /dev/stderr \
       | yq  '.spec.template.spec.containers[0]' | tee /dev/stderr)
@@ -360,7 +338,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.consulServiceName=override' \
       --set 'global.acls.manageSystemACLs=true' \
       .
@@ -374,7 +351,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.consulServiceName=mesh-gateway' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr \
@@ -389,7 +365,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.consulServiceName=overridden' \
       . | tee /dev/stderr \
       | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
@@ -406,7 +381,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr \
       | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
 
@@ -425,7 +399,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
 
@@ -438,7 +411,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.hostPort=443' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].ports[0].hostPort' | tee /dev/stderr)
@@ -455,7 +427,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
 
@@ -468,7 +439,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.priorityClassName=name' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
@@ -485,7 +455,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
 
@@ -498,7 +467,6 @@ key2: value2' \
       -x templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.nodeSelector=key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.nodeSelector.key' | tee /dev/stderr)

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/Deployment: enabled with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/Deployment: enabled with meshGateway, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-deployment.yaml  \

--- a/test/unit/mesh-gateway-podsecuritypolicy.bats
+++ b/test/unit/mesh-gateway-podsecuritypolicy.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/PodSecurityPolicy: enabled with meshGateway, connectInject and client.grpc enabled and global.enablePodSecurityPolicies=true" {
+@test "meshGateway/PodSecurityPolicy: enabled with meshGateway, connectInject enabled and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-podsecuritypolicy.yaml  \

--- a/test/unit/mesh-gateway-podsecuritypolicy.bats
+++ b/test/unit/mesh-gateway-podsecuritypolicy.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-podsecuritypolicy.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/mesh-gateway-service.bats
+++ b/test/unit/mesh-gateway-service.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -29,7 +28,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -45,7 +43,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations' | tee /dev/stderr)
@@ -58,7 +55,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.annotations=key: value' \
       . | tee /dev/stderr |
@@ -75,7 +71,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].port' | tee /dev/stderr)
@@ -88,7 +83,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.port=8443' \
       . | tee /dev/stderr |
@@ -105,7 +99,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
@@ -118,7 +111,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.containerPort=9443' \
       . | tee /dev/stderr |
@@ -135,7 +127,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
@@ -148,7 +139,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.nodePort=8443' \
       . | tee /dev/stderr |
@@ -165,7 +155,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.type' | tee /dev/stderr)
@@ -178,7 +167,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.type=ClusterIP' \
       . | tee /dev/stderr |
@@ -195,7 +183,6 @@ load _helpers
       -x templates/mesh-gateway-service.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'meshGateway.service.enabled=true' \
       --set 'meshGateway.service.additionalSpec=key: value' \
       . | tee /dev/stderr |

--- a/test/unit/mesh-gateway-service.bats
+++ b/test/unit/mesh-gateway-service.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/Service: enabled by default with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/Service: enabled by default with meshGateway, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-service.yaml  \

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -17,7 +17,6 @@ load _helpers
       -x templates/mesh-gateway-serviceaccount.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -11,7 +11,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "meshGateway/ServiceAccount: enabled with meshGateway, connectInject and client.grpc enabled" {
+@test "meshGateway/ServiceAccount: enabled with meshGateway, connectInject enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/mesh-gateway-serviceaccount.yaml  \

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -258,6 +258,21 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# meshGateway.enabled
+
+@test "serverACLInit/Job: mesh gateway acl option disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-mesh-gateway-token"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "serverACLInit/Job: mesh gateway acl option enabled with .meshGateway.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -269,6 +284,103 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-mesh-gateway-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# ingressGateways.enabled
+
+@test "serverACLInit/Job: ingress gateways acl options disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true (single default gateway)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name=\"ingress-gateway\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: able to define multiple ingress gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'contains("-ingress-gateway-name=\"gateway1\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'contains("-ingress-gateway-name=\"gateway2\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'indices("-ingress-gateway-name") | length' | tee /dev/stderr)
+  [ "${actual}" = 2 ]
+}
+
+@test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true, namespaces enabled, no default namespace set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name=\"ingress-gateway\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: multiple ingress gateways with namespaces enabled provides the correct flag format" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'client.grpc=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=default-namespace' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[1].name=gateway2' \
+      --set 'ingressGateways.gateways[1].consulNamespace=namespace2' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq 'contains("-ingress-gateway-name=\"gateway1.default-namespace\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'contains("-ingress-gateway-name=\"gateway2.namespace2\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+    yq 'indices("-ingress-gateway-name") | length' | tee /dev/stderr)
+  [ "${actual}" = 2 ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -267,7 +267,6 @@ load _helpers
       -x templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-mesh-gateway-token"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -280,7 +279,6 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-mesh-gateway-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -295,7 +293,6 @@ load _helpers
       -x templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -308,7 +305,6 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name=\"ingress-gateway\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -321,7 +317,6 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'ingressGateways.gateways[0].name=gateway1' \
       --set 'ingressGateways.gateways[1].name=gateway2' \
       . | tee /dev/stderr |
@@ -340,6 +335,19 @@ load _helpers
   [ "${actual}" = 2 ]
 }
 
+@test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true, namespaces enabled, default namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name=\"ingress-gateway.default\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true, namespaces enabled, no default namespace set" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -347,8 +355,8 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enableConsulNamespaces=true' \
+      --set 'ingressGateways.defaults.consulNamespace=' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-ingress-gateway-name=\"ingress-gateway\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -361,7 +369,6 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'ingressGateways.defaults.consulNamespace=default-namespace' \
       --set 'ingressGateways.gateways[0].name=gateway1' \

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -118,7 +118,6 @@ load _helpers
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=remote' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.data["proxy-defaults-config.json"]' | yq -r '.config_entries.bootstrap[0].mesh_gateway.mode' | tee /dev/stderr)
   [ "${actual}" = "remote" ]
@@ -132,7 +131,6 @@ load _helpers
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.data["proxy-defaults-config.json"]' | yq '.config_entries.bootstrap[0].mesh_gateway' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -146,7 +144,6 @@ load _helpers
       --set 'connectInject.centralConfig.proxyDefaults="{\"hello\": \"world\"}"' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=null' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.data["proxy-defaults-config.json"]' | yq '.config_entries.bootstrap[0].mesh_gateway' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -160,7 +157,6 @@ load _helpers
       --set 'connectInject.centralConfig.proxyDefaults=""' \
       --set 'meshGateway.enabled=true' \
       --set 'meshGateway.globalMode=remote' \
-      --set 'client.grpc=true' \
       . | tee /dev/stderr |
       yq -r '.data["proxy-defaults-config.json"]' | yq -r '.config_entries.bootstrap[0].mesh_gateway.mode' | tee /dev/stderr)
   [ "${actual}" = "remote" ]

--- a/values.yaml
+++ b/values.yaml
@@ -1133,11 +1133,11 @@ ingressGateways:
 
     resources:
       requests:
-        memory: "128Mi"
-        cpu: "250m"
+        memory: "100Mi"
+        cpu: "100m"
       limits:
-        memory: "256Mi"
-        cpu: "500m"
+        memory: "100Mi"
+        cpu: "100m"
 
     # By default, we set an anti affinity so that two of the same gateway pods
     # won't be on the same node. NOTE: Gateways require that Consul client agents are

--- a/values.yaml
+++ b/values.yaml
@@ -55,6 +55,8 @@ global:
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.15.0"
 
+  # imageEnvoy defines the default envoy image to use for ingress and
+  # terminating gateways.
   imageEnvoy: "envoyproxy/envoy:v1.13.0"
 
   # datacenter is the name of the datacenter that the agents should register
@@ -1059,7 +1061,8 @@ ingressGateways:
     # Number of replicas for each ingress gateway defined.
     replicas: 2
 
-    # What gets registered as WAN address for the gateway.
+    # What gets registered as WAN address for the gateway which is
+    # used as the address for the `.ingress.consul` DNS lookup.
     wanAddress:
       # source configures where to retrieve the WAN address (and possibly port)
       # for the ingress gateway from.
@@ -1098,13 +1101,10 @@ ingressGateways:
     # agent.
     hostPort: null
 
-    # The service option configures the Service that fronts the gateway Deployment.
+    # The service options configure the Service that fronts the gateway Deployment.
     service:
-      # Whether to create a Service or not.
-      enabled: true
-
       # Type of service, ex. LoadBalancer, ClusterIP.
-      type: LoadBalancer
+      type: ClusterIP
 
       # Port that the service will be exposed on.
       # The targetPort will be set to 8443.
@@ -1167,7 +1167,9 @@ ingressGateways:
     # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
     # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
     # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
-    consulNamespace: null
+    # Note: The Consul namespace MUST exist before the gateway is deployed or
+    # deployment will fail.
+    consulNamespace: "default"
 
   # Gateways is a list of gateway objects. The only required field for
   # each is `name`, though they can also contain any of the fields in

--- a/values.yaml
+++ b/values.yaml
@@ -1106,14 +1106,19 @@ ingressGateways:
       # Type of service, ex. LoadBalancer, ClusterIP.
       type: ClusterIP
 
-      # Port that the service will be exposed on.
-      # The targetPort will be set to 8443.
+      # Port that the service will be exposed on. This port will be used in the
+      # Consul dns lookup for the ingress gateway.
       port: 443
 
       # Optionally hardcode the nodePort of the service if using type: NodePort.
       # If not set and using type: NodePort, Kubernetes will automatically assign
       # a port.
       nodePort: null
+
+      # Additional ports to expose on both the service and the ingress gateway
+      # container for any listeners that will be defined in the gateway's
+      # configuration entry.
+      additionalPorts: [80]
 
       # Annotations to apply to the ingress gateway service. Annotations defined
       # here will be applied to all ingress gateway services in addition to any

--- a/values.yaml
+++ b/values.yaml
@@ -1075,9 +1075,9 @@ ingressGateways:
       # SRV record. If using a NodePort service type, you must specify the
       # desired nodePort for each exposed port.
       ports:
-        - port: 80
+        - port: 8080
           nodePort: null
-        - port: 443
+        - port: 8443
           nodePort: null
 
       # Annotations to apply to the ingress gateway service. Annotations defined

--- a/values.yaml
+++ b/values.yaml
@@ -55,6 +55,8 @@ global:
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.15.0"
 
+  imageEnvoy: "envoyproxy/envoy:v1.13.0"
+
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value
@@ -1038,6 +1040,141 @@ meshGateway:
   #   annotations: |
   #     "annotation-key": "annotation-value"
   annotations: null
+
+# Configuration options for ingress gateways. Default values for all
+# ingress gateways are defined in `ingressGateways.defaults`. Any of
+# these values may be overridden in `ingressGateways.gateways` for a
+# specific gateway with the exception of annotations. Annotations will
+# include both the default annotations and any additional ones defined
+# for a specific gateway.
+# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+# global.acls.manageSystemACLs.
+ingressGateways:
+  enabled: false
+
+  # Defaults sets default values for all gateway fields. With the exception
+  # of annotations, defining any of these values in the `gateways` list
+  # will override the default values provided here.
+  defaults:
+    # Number of replicas for each ingress gateway defined.
+    replicas: 2
+
+    # What gets registered as WAN address for the gateway.
+    wanAddress:
+      # source configures where to retrieve the WAN address (and possibly port)
+      # for the ingress gateway from.
+      # Can be set to either: Service, NodeIP, NodeName or Static.
+      #
+      # Service - Determine the address based on the service type.
+      #   If service.type=LoadBalancer use the external IP or hostname of
+      #   the service. Use the port set by service.port.
+      #   If service.type=NodePort use the Node IP. The port will be set to
+      #   service.nodePort so service.nodePort cannot be null.
+      #   If service.type=ClusterIP use the ClusterIP. The port will be set to
+      #   service.port.
+      #   service.type=ExternalName is not supported.
+      # NodeIP - The node IP as provided by the Kubernetes downward API.
+      # NodeName - The name of the node as provided by the Kubernetes downward
+      #   API. This is useful if the node names are DNS entries that
+      #   are routable from other datacenters.
+      # Static - Use the address hardcoded in wanAddress.static.
+      source: "Service"
+
+      # Port that gets registered for WAN traffic.
+      # If source is set to "Service" then this setting will have no effect.
+      # See the documentation for source as to which port will be used in that
+      # case.
+      port: 443
+
+      # If source is set to "Static" then this value will be used as the WAN
+      # address of the ingress gateways. This is useful if you've configured a
+      # DNS entry to point to your ingress gateways.
+      static: ""
+
+    # Optional hostPort for the gateway to be exposed on.
+    # This can be used with wanAddress.port and wanAddress.useNodeIP
+    # to expose the gateways directly from the node.
+    # NOTE: Cannot set to 8500 or 8502 because those are reserved for the Consul
+    # agent.
+    hostPort: null
+
+    # The service option configures the Service that fronts the gateway Deployment.
+    service:
+      # Whether to create a Service or not.
+      enabled: true
+
+      # Type of service, ex. LoadBalancer, ClusterIP.
+      type: LoadBalancer
+
+      # Port that the service will be exposed on.
+      # The targetPort will be set to 8443.
+      port: 443
+
+      # Optionally hardcode the nodePort of the service if using type: NodePort.
+      # If not set and using type: NodePort, Kubernetes will automatically assign
+      # a port.
+      nodePort: null
+
+      # Annotations to apply to the ingress gateway service. Annotations defined
+      # here will be applied to all ingress gateway services in addition to any
+      # service annotations defined for a specific gateway in `ingressGateways.gateways`.
+      # Example:
+      #   annotations: |
+      #     "annotation-key": "annotation-value"
+      annotations: null
+
+      # Optional YAML string that will be appended to the Service spec.
+      additionalSpec: null
+
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "250m"
+      limits:
+        memory: "256Mi"
+        cpu: "500m"
+
+    # By default, we set an anti affinity so that two of the same gateway pods
+    # won't be on the same node. NOTE: Gateways require that Consul client agents are
+    # also running on the nodes alongside each gateway Pod.
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "consul.name" . }}
+                release: "{{ .Release.Name }}"
+                component: ingress-gateway
+            topologyKey: kubernetes.io/hostname
+
+    # Optional YAML string to specify tolerations.
+    tolerations: null
+
+    # Optional YAML string to specify a nodeSelector config.
+    nodeSelector: null
+
+    # Optional priorityClassName.
+    priorityClassName: ""
+
+    # Annotations to apply to the ingress gateway deployment. Annotations defined
+    # here will be applied to all ingress gateway deployments in addition to any
+    # annotations defined for a specific gateway in `ingressGateways.gateways`.
+    # Example:
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    annotations: null
+
+    # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
+    # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+    # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+    consulNamespace: null
+
+  # Gateways is a list of gateway objects. The only required field for
+  # each is `name`, though they can also contain any of the fields in
+  # `defaults`. Values defined here override the defaults except in the
+  # case of annotations where both will be applied.
+  gateways:
+    - name: ingress-gateway
 
 # Control whether a test Pod manifest is generated when running helm template.
 # When using helm install, the test Pod is not submitted to the cluster so this

--- a/values.yaml
+++ b/values.yaml
@@ -1061,64 +1061,23 @@ ingressGateways:
     # Number of replicas for each ingress gateway defined.
     replicas: 2
 
-    # What gets registered as WAN address for the gateway which is
-    # used as the address for the `.ingress.consul` DNS lookup.
-    wanAddress:
-      # source configures where to retrieve the WAN address (and possibly port)
-      # for the ingress gateway from.
-      # Can be set to either: Service, NodeIP, NodeName or Static.
-      #
-      # Service - Determine the address based on the service type.
-      #   If service.type=LoadBalancer use the external IP or hostname of
-      #   the service. Use the port set by service.port.
-      #   If service.type=NodePort use the Node IP. The port will be set to
-      #   service.nodePort so service.nodePort cannot be null.
-      #   If service.type=ClusterIP use the ClusterIP. The port will be set to
-      #   service.port.
-      #   service.type=ExternalName is not supported.
-      # NodeIP - The node IP as provided by the Kubernetes downward API.
-      # NodeName - The name of the node as provided by the Kubernetes downward
-      #   API. This is useful if the node names are DNS entries that
-      #   are routable from other datacenters.
-      # Static - Use the address hardcoded in wanAddress.static.
-      source: "Service"
-
-      # Port that gets registered for WAN traffic.
-      # If source is set to "Service" then this setting will have no effect.
-      # See the documentation for source as to which port will be used in that
-      # case.
-      port: 443
-
-      # If source is set to "Static" then this value will be used as the WAN
-      # address of the ingress gateways. This is useful if you've configured a
-      # DNS entry to point to your ingress gateways.
-      static: ""
-
-    # Optional hostPort for the gateway to be exposed on.
-    # This can be used with wanAddress.port and wanAddress.useNodeIP
-    # to expose the gateways directly from the node.
-    # NOTE: Cannot set to 8500 or 8502 because those are reserved for the Consul
-    # agent.
-    hostPort: null
-
     # The service options configure the Service that fronts the gateway Deployment.
     service:
-      # Type of service, ex. LoadBalancer, ClusterIP.
+      # Type of service: LoadBalancer, ClusterIP or NodePort. If using NodePort service
+      # type, you must set the desired nodePorts in the `port` setting below.
       type: ClusterIP
 
-      # Port that the service will be exposed on. This port will be used in the
-      # Consul dns lookup for the ingress gateway.
-      port: 443
-
-      # Optionally hardcode the nodePort of the service if using type: NodePort.
-      # If not set and using type: NodePort, Kubernetes will automatically assign
-      # a port.
-      nodePort: null
-
-      # Additional ports to expose on both the service and the ingress gateway
-      # container for any listeners that will be defined in the gateway's
-      # configuration entry.
-      additionalPorts: [80]
+      # Ports that will be exposed on the service and gateway container. Any
+      # ports defined as ingress listeners on the gateway's Consul configuration
+      # entry should be included here. The first port will be used as part of
+      # the Consul service registration for the gateway and be listed in its
+      # SRV record. If using a NodePort service type, you must specify the
+      # desired nodePort for each exposed port.
+      ports:
+        - port: 80
+          nodePort: null
+        - port: 443
+          nodePort: null
 
       # Annotations to apply to the ingress gateway service. Annotations defined
       # here will be applied to all ingress gateway services in addition to any

--- a/values.yaml
+++ b/values.yaml
@@ -1052,6 +1052,7 @@ meshGateway:
 # Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
 # global.acls.manageSystemACLs.
 ingressGateways:
+  # Enable ingress gateway deployment. Requires `connectInject.enabled=true`.
   enabled: false
 
   # Defaults sets default values for all gateway fields. With the exception
@@ -1064,7 +1065,7 @@ ingressGateways:
     # The service options configure the Service that fronts the gateway Deployment.
     service:
       # Type of service: LoadBalancer, ClusterIP or NodePort. If using NodePort service
-      # type, you must set the desired nodePorts in the `port` setting below.
+      # type, you must set the desired nodePorts in the `ports` setting below.
       type: ClusterIP
 
       # Ports that will be exposed on the service and gateway container. Any
@@ -1090,6 +1091,7 @@ ingressGateways:
       # Optional YAML string that will be appended to the Service spec.
       additionalSpec: null
 
+    # Resource limits for all ingress gateway pods
     resources:
       requests:
         memory: "100Mi"


### PR DESCRIPTION
This creates all of the necessary templates to enable ingress gateways
in the Helm chart. By making use of `ingressGateways.defaults` and
`ingressGateways.gateways` setting, it's possible to enable multiple
ingress gateways. Names must be provided for each and they must be
unique.

All fields defined in the `ingressGateways.defaults` may be overridden
by defining that field on the relevant `ingressGateways.gateways`
entry, with the exception of annotations. Annotations will apply
both the default annotations and any gateway specific annotations.

In an effort to reduce the intrusiveness of the installation, this
feature uses a role and a rolebinding rather than clusterrole/binding.

Added support for creating ingress gateway tokens to the server acl
init job. Added additional (unrendered) spaces in this job's
command to make it easier to reason about.

Note: the current default affinity for ingress gateways won't allow
more than one ingress gateway to be scheduled on the same node, even if
they are logically different gateways. Due to limitations in templating,
there's no good way to change this automatically. To work around it,
an `ingress-gateway-name` label has been added to the deployment.
With it, users will be able to define an affinity per gateway if
they would like to allow multiple, but different, gateways per node.