### PR TITLE
Allow passing extraArguments to the client and server start

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -216,6 +216,9 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+                {{- range $cmd := .Values.client.extraArguments }}
+                {{ $cmd }} \
+                {{- end }}
                 -domain={{ .Values.global.domain }}
           volumeMounts:
             - name: data

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -182,6 +182,9 @@ spec:
                 {{- range $index := until (.Values.server.replicas | int) }}
                 -retry-join=${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
                 {{- end }}
+                {{- range $cmd := .Values.server.extraArguments }}
+                {{ $cmd }} \
+                {{- end }}
                 -server
           volumeMounts:
             - name: data-{{ .Release.Namespace }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -796,6 +796,19 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extraArguments
+
+@test "client/DaemonSet: custom command line arguments" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.extraArguments={-config-file=/vault/secrets/custom.json}' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("config-file=/vault/secrets/custom.json"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 
 @test "client/DaemonSet: aclconfig volume is created when global.acls.manageSystemACLs=true" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -475,6 +475,19 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extraArguments
+
+@test "server/StatefulSet: custom command line arguments" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraArguments={-config-file=/vault/secrets/custom.json}' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("config-file=/vault/secrets/custom.json"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # global.tls.enabled
 
 @test "server/StatefulSet: CA volume present when TLS is enabled" {

--- a/values.yaml
+++ b/values.yaml
@@ -339,6 +339,10 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # extraArguments is a list of additional command line switches that should be
+  # passed to the command start.
+  extraArguments: []
+
 # Configuration for Consul servers when the servers are running outside of Kubernetes.
 # When running external servers, configuring these values is recommended
 # if setting global.tls.enableAutoEncrypt to true (requires consul-k8s >= 0.13.0)
@@ -475,6 +479,10 @@ client:
     # http_proxy: http://localhost:3128,
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
+
+  # extraArguments is a list of additional command line switches that
+  # should be passed to the command start.
+  extraArguments: []
 
   # dnsPolicy to use.
   dnsPolicy: null


### PR DESCRIPTION
Community Note

- Please vote on this issue by adding a 👍 reaction to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
- If you are interested in working on this issue or have submitted a pull request, please leave a comment.

---

There are times that the included helm magic is just not sufficient to
start the service in the right way. It's easier to simply let people add
their own custom flags here than to try and support every case.