### PR TITLE
Allow setting annotations on syncCatalog pods

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -27,6 +27,9 @@ spec:
         component: sync-catalog
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.syncCatalog.annotations }}
+          {{- tpl .Values.syncCatalog.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
       {{- if .Values.global.tls.enabled }}

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -386,6 +386,29 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec | .tolerations == "foobar"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "syncCatalog/Deployment: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "syncCatalog/Deployment: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/sync-catalog-deployment.yaml \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -740,6 +740,13 @@ syncCatalog:
       memory: "50Mi"
       cpu: "50m"
 
+  # Extra annotations to attach to the syncCatalog pods.
+  # This should be a multi-line YAML string.
+  # Example:
+  #   annotations: |
+  #     "annotation-key": "annotation-value"
+  annotations: null
+
   # Log verbosity level. One of "trace", "debug", "info", "warn", or "error".
   logLevel: info
 


### PR DESCRIPTION
In the same way that we might want to set custom annotations on the
client or server we may need to set annotations on the syncCatalog
deployment.