### PR TITLE
Allow settings extraEnvironmentVars on syncCatalog container

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -84,6 +84,7 @@ spec:
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
             {{- end }}
+            {{- include "consul.extraEnvironmentVars" .Values.syncCatalog | nindent 12 }}
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             {{- if .Values.global.tls.enableAutoEncrypt }}

--- a/values.yaml
+++ b/values.yaml
@@ -693,6 +693,13 @@ syncCatalog:
   # Override the default interval to perform syncing operations creating Consul services.
   consulWriteInterval: null
 
+  # extraEnvVars is a list of extra environment variables to set with the deployment. These could be
+  # used to include proxy settings, custom token locations, or other settings.
+  extraEnvironmentVars: {}
+    # http_proxy: http://localhost:3128,
+    # https_proxy: http://localhost:3128,
+    # no_proxy: internal.domain.com
+
 # ConnectInject will enable the automatic Connect sidecar injector.
 connectInject:
   # True if you want to enable connect injection. Set to "-" to inherit from


### PR DESCRIPTION
There are a whole bunch of useful things you can configure on the
consul-k8s process via environment variables that are not being exposed
via the helm chart.

This is present in the other containers so enable it here as well.