### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,7 @@ use Consul with Kubernetes, please see the
 [Consul and Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html).
 
 ## Prerequisites
-
-To use the charts here, [Helm](https://helm.sh/) must be installed in your
-Kubernetes cluster. Setting up Kubernetes and Helm and is outside the scope
-of this README. Please refer to the Kubernetes and Helm documentation.
-
-The versions required are:
-
-  * **Helm 2.10+** - This is the earliest version of Helm tested. It is possible
+  * **Helm 2.10+ or Helm 3.0+** - This is the earliest version of Helm tested. It is possible
     it works with earlier versions but this chart is untested for those versions.
   * **Kubernetes 1.9+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ use Consul with Kubernetes, please see the
 [Consul and Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html).
 
 ## Prerequisites
-  * **Helm 2.10+ or Helm 3.0+** - This is the earliest version of Helm tested. It is possible
-    it works with earlier versions but this chart is untested for those versions.
+  * **Helm 2.10+ or Helm 3.0+**
   * **Kubernetes 1.9+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.


### PR DESCRIPTION
Remove the part about installing Helm into Kubernetes because with helm 3 they don't need to do this and presumably if they don't already have helm they're going to use helm3 and if they do already have helm 2 then it's already installed on their cluster so they don't need instructions to do so.