### PR TITLE
Remove meshGateway.enableHealthChecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+BREAKING CHANGES:
+
+* Mesh Gateway: `meshGateway.enableHealthChecks` is no longer supported. This config
+  option was to work around an issue where mesh gateways would not listen on their
+  bind ports until a Connect service was registered. This issue was fixed in Consul 1.6.2. ([GH-464](https://github.com/hashicorp/consul-helm/pull/464))
+
 ## 0.21.0 (May 14, 2020)
 
 FEATURES

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -266,7 +266,6 @@ spec:
             - connect
             - envoy
             - -mesh-gateway
-          {{- if .Values.meshGateway.enableHealthChecks }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.meshGateway.containerPort }}
@@ -283,7 +282,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
-          {{- end }}
           ports:
             - name: gateway
               containerPort: {{ .Values.meshGateway.containerPort }}

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -402,23 +402,6 @@ key2: value2' \
   [ "${readiness}" = "true" ]
 }
 
-@test "meshGateway/Deployment: can disable healthchecks" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/mesh-gateway-deployment.yaml  \
-      --set 'meshGateway.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'client.grpc=true' \
-      --set 'meshGateway.enableHealthChecks=false' \
-      . | tee /dev/stderr \
-      | yq '.spec.template.spec.containers[0]' | tee /dev/stderr )
-
-  local liveness=$(echo "${actual}" | yq -r '.livenessProbe | length > 0' | tee /dev/stderr)
-  [ "${liveness}" = "false" ]
-  local readiness=$(echo "${actual}" | yq -r '.readinessProbe | length > 0' | tee /dev/stderr)
-  [ "${readiness}" = "false" ]
-}
-
 #--------------------------------------------------------------------
 # hostPort
 

--- a/values.yaml
+++ b/values.yaml
@@ -963,11 +963,6 @@ meshGateway:
   # agent.
   hostPort: null
 
-  # If there are no connect-enabled services running, then the gateway
-  # will fail health checks. You may disable health checks as a temporary
-  # workaround.
-  enableHealthChecks: true
-
   resources: |
     requests:
       memory: "128Mi"


### PR DESCRIPTION
This was a workaround for a bug fixed in Consul 1.6.2.