### PR TITLE
Fully remove support for global.bootstrapACLs

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -20,7 +20,7 @@ To learn more about the release if you are using Helm 3, run:
   $ helm get all {{ .Release.Name }}
 
 
-{{- if (and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (gt (len .Values.server.extraConfig) 3)) }}
+{{- if (and .Values.global.acls.manageSystemACLs (gt (len .Values.server.extraConfig) 3)) }}
 Warning: Defining server extraConfig potentially disrupts the automatic ACL
          bootstrapping required settings. This may cause future issues if
          there are conflicts.

--- a/templates/client-clusterrole.yaml
+++ b/templates/client-clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies) }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -18,7 +18,7 @@ rules:
     verbs:
     - use
 {{- end }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -109,7 +109,7 @@ spec:
             secretName: {{ .name }}
             {{- end }}
         {{- end }}
-        {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+        {{- if .Values.global.acls.manageSystemACLs }}
         - name: aclconfig
           emptyDir: {}
         {{- end }}
@@ -201,7 +201,7 @@ spec:
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
                 {{- end }}
-                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- if .Values.global.acls.manageSystemACLs }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
@@ -241,7 +241,7 @@ spec:
               readOnly: true
               mountPath: /consul/userconfig/{{ .name }}
             {{- end }}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- end }}
@@ -305,9 +305,9 @@ spec:
             {{- toYaml .Values.client.resources | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
+      {{- if (or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+      {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/client-snapshot-agent-clusterrole.yaml
+++ b/templates/client-snapshot-agent-clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies) }}
+{{- if (or .Values.global.acls.manageSystemACLs .Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -19,7 +19,7 @@ rules:
     verbs:
     - use
 {{- end }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey)) }}
       volumes:
         {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
         - name: snapshot-config
@@ -47,7 +47,7 @@ spec:
             - key: {{ .Values.client.snapshotAgent.configSecret.secretKey }}
               path: snapshot-config.json
         {{- end }}
-        {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+        {{- if .Values.global.acls.manageSystemACLs }}
         - name: aclconfig
           emptyDir: {}
         {{- end }}
@@ -88,7 +88,7 @@ spec:
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
             {{- end }}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -108,17 +108,17 @@ spec:
                 {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
                 -config-dir=/consul/config \
                 {{- end }}
-                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- if .Values.global.acls.manageSystemACLs }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
-          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) ) }}
+          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) ) }}
           volumeMounts:
             {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
             - name: snapshot-config
               readOnly: true
               mountPath: /consul/config
             {{- end }}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- end }}
@@ -136,9 +136,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if (or (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt)) }}
       initContainers:
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+      {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-snapshot-agent-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/templates/connect-inject-authmethod-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
   verbs:
   - use
 {{- end }}
-{{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces }}
+{{- if and .Values.global.acls.manageSystemACLs .Values.global.enableConsulNamespaces }}
 - apiGroups: [""]
   resources:
     - secrets

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connectInject.aclInjectToken.secretName }}
                   key: {{ .Values.connectInject.aclInjectToken.secretKey }}
-            {{- else if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- else if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -87,7 +87,7 @@ spec:
                 -listen=:8080 \
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
-                {{- else if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- else if .Values.global.acls.manageSystemACLs }}
                 -acl-auth-method="{{ template "consul.fullname" . }}-k8s-auth-method" \
                 {{- end }}
                 {{- if .Values.connectInject.centralConfig.enabled }}
@@ -113,7 +113,7 @@ spec:
                 -k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \
                 {{- end }}
                 {{- end }}
-                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- if .Values.global.acls.manageSystemACLs }}
                 -consul-cross-namespace-acl-policy=cross-namespace-policy \
                 {{- end }}
                 {{- end }}
@@ -206,9 +206,9 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if or (and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or (and .Values.global.acls.manageSystemACLs .Values.global.enableConsulNamespaces) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
-      {{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) .Values.global.enableConsulNamespaces }}
+      {{- if and .Values.global.acls.manageSystemACLs .Values.global.enableConsulNamespaces }}
       - name: injector-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/create-federation-secret-job.yaml
+++ b/templates/create-federation-secret-job.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.global.federation.createFederationSecret }}
 {{- if not .Values.global.federation.enabled }}{{ fail "global.federation.enabled must be true when global.federation.createFederationSecret is true" }}{{ end }}
-{{- if and (not .Values.global.acls.createReplicationToken) (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}{{ fail "global.acls.createReplicationToken must be true when global.acls.manageSystemACLs is true because the federation secret must include the replication token" }}{{ end }}
+{{- if and (not .Values.global.acls.createReplicationToken) .Values.global.acls.manageSystemACLs }}{{ fail "global.acls.createReplicationToken must be true when global.acls.manageSystemACLs is true because the federation secret must include the replication token" }}{{ end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/templates/create-federation-secret-role.yaml
+++ b/templates/create-federation-secret-role.yaml
@@ -28,7 +28,7 @@ rules:
       - {{ template "consul.fullname" . }}-federation
     verbs:
       - update
-  {{- if or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs }}
+  {{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/enterprise-license-clusterrole.yaml
+++ b/templates/enterprise-license-clusterrole.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies }}
+{{- if or .Values.global.acls.manageSystemACLs .Values.global.enablePodSecurityPolicies }}
 rules:
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -65,7 +65,7 @@ spec:
             - name:  CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end}}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -106,7 +106,7 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+      {{- if .Values.global.acls.manageSystemACLs }}
       initContainers:
       - name: ent-license-acl-init
         image: {{ .Values.global.imageK8S }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -142,7 +142,7 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
-                {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                {{- if $root.Values.global.acls.manageSystemACLs }}
                 consul-k8s acl-init \
                   -secret-name="{{ template "consul.fullname" $root }}-{{ .name }}-ingress-gateway-acl-token" \
                   -k8s-namespace={{ $root.Release.Namespace }} \
@@ -238,7 +238,7 @@ spec:
                 EOF
 
                 /consul-bin/consul services register \
-                  {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                  {{- if $root.Values.global.acls.manageSystemACLs }}
                   -token-file=/consul/service/acl-token \
                   {{- end }}
                   /consul/service/service.hcl
@@ -288,7 +288,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            {{- if $root.Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -396,7 +396,7 @@ spec:
             - lifecycle-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
-            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            {{- if $root.Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
       {{- if (default $defaults.priorityClassName .priorityClassName) }}

--- a/templates/ingress-gateways-role.yaml
+++ b/templates/ingress-gateways-role.yaml
@@ -32,7 +32,7 @@ rules:
     verbs:
       - use
 {{- end }}
-{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+{{- if $root.Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/mesh-gateway-clusterrole.yaml
+++ b/templates/mesh-gateway-clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
-{{- if or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs .Values.global.enablePodSecurityPolicies (eq .Values.meshGateway.wanAddress.source "Service") }}
+{{- if or .Values.global.acls.manageSystemACLs .Values.global.enablePodSecurityPolicies (eq .Values.meshGateway.wanAddress.source "Service") }}
 rules:
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -19,7 +19,7 @@ rules:
     verbs:
       - use
 {{- end }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.meshGateway.enabled }}
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
-{{- if and (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
+{{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1
@@ -125,7 +125,7 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
-                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- if .Values.global.acls.manageSystemACLs }}
                 consul-k8s acl-init \
                   -secret-name="{{ template "consul.fullname" . }}-mesh-gateway-acl-token" \
                   -k8s-namespace={{ .Release.Namespace }} \
@@ -196,7 +196,7 @@ spec:
                 EOF
 
                 /consul-bin/consul services register \
-                  {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                  {{- if .Values.global.acls.manageSystemACLs }}
                   -token-file=/consul/service/acl-token \
                   {{- end }}
                   /consul/service/service.hcl
@@ -259,7 +259,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             {{- end }}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -353,7 +353,7 @@ spec:
             - lifecycle-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
           resources:

--- a/templates/server-acl-init-cleanup-clusterrole.yaml
+++ b/templates/server-acl-init-cleanup-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/server-acl-init-cleanup-clusterrolebinding.yaml
+++ b/templates/server-acl-init-cleanup-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 {{- /* See reason for this in server-acl-init-job.yaml */ -}}
 {{- if eq (int .Values.server.updatePartition) 0 }}
 # This job deletes the server-acl-init job once it completes successfully.

--- a/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-acl-init-clusterrole.yaml
+++ b/templates/server-acl-init-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/server-acl-init-clusterrolebinding.yaml
+++ b/templates/server-acl-init-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -2,7 +2,7 @@
 {{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if and .Values.global.acls.createReplicationToken (not .Values.global.acls.manageSystemACLs) }}{{ fail "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" }}{{ end -}}
-{{- if .Values.global.bootstrapACLs }}{{ fail "global.bootstrapACLs is removed, use global.acls.manageSystemACLs instead" }}{{ end -}}
+{{- if .Values.global.bootstrapACLs }}{{ fail "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" }}{{ end -}}
 {{- if .Values.global.acls.manageSystemACLs }}
 {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -1,8 +1,9 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (and $serverEnabled .Values.externalServers.enabled) }}{{ fail "only one of server.enabled or externalServers.enabled can be set" }}{{ end -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if and .Values.global.acls.createReplicationToken (not (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs)) }}{{ fail "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" }}{{ end -}}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if and .Values.global.acls.createReplicationToken (not .Values.global.acls.manageSystemACLs) }}{{ fail "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" }}{{ end -}}
+{{- if .Values.global.bootstrapACLs }}{{ fail "global.bootstrapACLs is removed, use global.acls.manageSystemACLs instead" }}{{ end -}}
+{{- if .Values.global.acls.manageSystemACLs }}
 {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
     the rollout is finished (which won't happen until the partition is 0).

--- a/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/templates/server-acl-init-podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/server-acl-init-serviceaccount.yaml
+++ b/templates/server-acl-init-serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
-  {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+  {{- if .Values.global.acls.manageSystemACLs }}
   acl-config.json: |-
     {
       "acl": {

--- a/templates/sync-catalog-clusterrole.yaml
+++ b/templates/sync-catalog-clusterrole.yaml
@@ -29,7 +29,7 @@ rules:
       - nodes
     verbs:
       - get
-{{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+{{- if .Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -68,7 +68,7 @@ spec:
                   name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
                   key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
             {{- end }}
-            {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+            {{- if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -152,7 +152,7 @@ spec:
                 -k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
                 {{- end }}
                 {{- end }}
-                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+                {{- if .Values.global.acls.manageSystemACLs }}
                 -consul-cross-namespace-acl-policy=cross-namespace-policy \
                 {{- end }}
                 {{- end }}
@@ -180,9 +180,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
+      {{- if .Values.global.acls.manageSystemACLs }}
       - name: sync-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -156,7 +156,7 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
-                {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                {{- if $root.Values.global.acls.manageSystemACLs }}
                 consul-k8s acl-init \
                   -secret-name="{{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token" \
                   -k8s-namespace={{ $root.Release.Namespace }} \
@@ -185,7 +185,7 @@ spec:
                 EOF
 
                 /consul-bin/consul services register \
-                  {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                  {{- if $root.Values.global.acls.manageSystemACLs }}
                   -token-file=/consul/service/acl-token \
                   {{- end }}
                   /consul/service/service.hcl
@@ -239,7 +239,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            {{- if $root.Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -342,7 +342,7 @@ spec:
             - lifecycle-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
-            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            {{- if $root.Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
       {{- if (default $defaults.priorityClassName .priorityClassName) }}

--- a/templates/terminating-gateways-role.yaml
+++ b/templates/terminating-gateways-role.yaml
@@ -16,7 +16,7 @@ metadata:
     release: {{ $root.Release.Name }}
     component: terminating-gateway
     terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
-{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies) }}
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if $root.Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
@@ -26,7 +26,7 @@ rules:
     verbs:
       - use
 {{- end }}
-{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+{{- if $root.Values.global.acls.manageSystemACLs }}
   - apiGroups: [""]
     resources:
       - secrets

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -255,21 +255,3 @@ load _helpers
 
   [ "${actual}" = "" ]
 }
-
-#--------------------------------------------------------------------
-# bootstrapACLs deprecation
-#
-# Test that every place global.bootstrapACLs is used, global.acls.manageSystemACLs
-# is also used.
-# If this test is failing, you've used either only global.bootstrapACLs or
-# only global.acls.manageSystemACLs instead of using the backwards compatible:
-#     or global.acls.manageSystemACLs global.bootstrapACLs
-@test "helper/bootstrapACLs: used alongside manageSystemACLs" {
-  cd `chart_dir`
-
-  diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
-  [ "$diff" = "" ]
-
-  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
-  [ "$diff" = "" ]
-}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -102,7 +102,7 @@ load _helpers
       -x templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "global.bootstrapACLs is removed, use global.acls.manageSystemACLs instead" ]]
+  [[ "$output" =~ "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" ]]
 }
 
 @test "serverACLInit/Job: does not set -create-client-token=false when client is enabled (the default)" {

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -95,6 +95,16 @@ load _helpers
   [[ "$output" =~ "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" ]]
 }
 
+# We removed bootstrapACLs, and now fail in case anyone is still using it.
+@test "serverACLInit/Job: fails if global.bootstrapACLs is true" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/server-acl-init-job.yaml  \
+      --set 'global.bootstrapACLs=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.bootstrapACLs is removed, use global.acls.manageSystemACLs instead" ]]
+}
+
 @test "serverACLInit/Job: does not set -create-client-token=false when client is enabled (the default)" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -389,7 +389,6 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.bootstrapACLs
 # global.acls.manageSystemACLs
 
 @test "syncCatalog/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {

--- a/values.yaml
+++ b/values.yaml
@@ -165,9 +165,6 @@ global:
   # of both the catalog sync and connect injector.
   enableConsulNamespaces: false
 
-  # [DEPRECATED] Use acls.manageSystemACLs instead.
-  bootstrapACLs: false
-
   # Configure ACLs.
   acls:
 


### PR DESCRIPTION
`bootstrapACLs` was deprecated in v0.19.0. We should merge this for release v0.22.0.
Anyone still using `bootstrapACLs` will get an error so they won't accidentally turn off ACLs.

To Do:
- [ ] Add changelog entry once we know next release will be 0.22.0. Adding it now might cause a merge conflict later.