### PR TITLE
Support default sidecar proxy resources

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -119,10 +119,24 @@ spec:
                 {{- end }}
                 {{- if .Values.connectInject.certs.secretName }}
                 -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
-                -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }}
+                -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }} \
                 {{- else }}
                 -tls-auto=${CONSUL_FULLNAME}-connect-injector-cfg \
-                -tls-auto-hosts=${CONSUL_FULLNAME}-connect-injector-svc,${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE},${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE}.svc
+                -tls-auto-hosts=${CONSUL_FULLNAME}-connect-injector-svc,${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE},${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE}.svc \
+                {{- end }}
+                {{- $resources := .Values.connectInject.sidecarProxy.resources }}
+                {{- /* kindIs is used here to differentiate between null and 0 */}}
+                {{- if not (kindIs "invalid" $resources.limits.memory) }}
+                -default-sidecar-proxy-memory-limit={{ $resources.limits.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.memory) }}
+                -default-sidecar-proxy-memory-request={{ $resources.requests.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.limits.cpu) }}
+                -default-sidecar-proxy-cpu-limit={{ $resources.limits.cpu }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.cpu) }}
+                -default-sidecar-proxy-cpu-request={{ $resources.requests.cpu }} \
                 {{- end }}
           livenessProbe:
             httpGet:

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -876,3 +876,89 @@ load _helpers
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
 }
+
+#--------------------------------------------------------------------
+# sidecarProxy.resources
+
+@test "connectInject/Deployment: by default there are no resource settings" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-request"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-request"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-limit"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-limit"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: can set resource settings" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.sidecarProxy.resources.requests.memory=10Mi' \
+      --set 'connectInject.sidecarProxy.resources.requests.cpu=100m' \
+      --set 'connectInject.sidecarProxy.resources.limits.memory=20Mi' \
+      --set 'connectInject.sidecarProxy.resources.limits.cpu=200m' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-request=10Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-request=100m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-limit=20Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-limit=200m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: can set resource settings explicitly to 0" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -x templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.sidecarProxy.resources.requests.memory=0' \
+      --set 'connectInject.sidecarProxy.resources.requests.cpu=0' \
+      --set 'connectInject.sidecarProxy.resources.limits.memory=0' \
+      --set 'connectInject.sidecarProxy.resources.limits.cpu=0' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-request=0"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-request=0"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-memory-limit=0"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-sidecar-proxy-cpu-limit=0"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -893,6 +893,26 @@ connectInject:
     proxyDefaults: |
       {}
 
+  sidecarProxy:
+    # Set default resources for sidecar proxy. If null, that resource won't
+    # be set.
+    # These settings can be overridden on a per-pod basis via these annotations:
+    # - consul.hashicorp.com/sidecar-proxy-cpu-limit
+    # - consul.hashicorp.com/sidecar-proxy-cpu-request
+    # - consul.hashicorp.com/sidecar-proxy-memory-limit
+    # - consul.hashicorp.com/sidecar-proxy-memory-request
+    resources:
+      requests:
+        # Recommended default: 100Mi
+        memory: null
+        # Recommended default: 100m
+        cpu: null
+      limits:
+        # Recommended default: 100Mi
+        memory: null
+        # Recommended default: 100m
+        cpu: null
+
 # Mesh Gateways enable Consul Connect to work across Consul datacenters.
 meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs


### PR DESCRIPTION
Companion to https://github.com/hashicorp/consul-k8s/pull/267

Allow setting default sidecar proxy resources. The defaults are set to `null` so that by default the envoy proxy doesn't run up against any limits.

To test, use
```yaml
global:
  imageK8S: lkysow/consul-k8s-dev:may26-resources3
connectInject:
  enabled: true
  sidecarProxy:
    resources:
      limits:
        memory: 200Mi
        cpu: 200m
      requests:
        memory: 100Mi
        cpu: 100m

```