### PR TITLE
Support consul external to k8s cluster clients

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
+      {{- if .Values.global.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      {{- end }}
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "consul.fullname" . }}-server
       securityContext:
@@ -135,7 +139,11 @@ spec:
 
               exec /bin/consul agent \
                 -advertise="${POD_IP}" \
+                {{- if .Values.global.hostNetwork }}
+                -bind=${NODE_IP} \
+                {{- else }}
                 -bind=0.0.0.0 \
+                {{- end }}
                 -bootstrap-expect={{ .Values.server.bootstrapExpect }} \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
@@ -179,8 +187,12 @@ spec:
                 {{- if .Values.ui.enabled }}
                 -ui \
                 {{- end }}
+                {{- if .Values.global.hostNetwork }}
+                -retry-join=${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
+                {{- else }}
                 {{- range $index := until (.Values.server.replicas | int) }}
                 -retry-join=${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
+                {{- end }}
                 {{- end }}
                 -server
           volumeMounts:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
-      {{- if .Values.global.hostNetwork }}
+      {{- if .Values.server.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       {{- end }}
@@ -123,7 +123,7 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
-            {{- if .Values.global.hostNetwork }}
+            {{- if .Values.server.hostNetwork }}
             - name: NODE_IP
               valueFrom:
                 fieldRef:
@@ -144,7 +144,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
               exec /bin/consul agent \
-                {{- if .Values.global.hostNetwork }}
+                {{- if .Values.server.hostNetwork }}
                 -bind=${NODE_IP} \
                 -advertise="${NODE_IP}" \
                 {{- else }}
@@ -194,7 +194,7 @@ spec:
                 {{- if .Values.ui.enabled }}
                 -ui \
                 {{- end }}
-                {{- if .Values.global.hostNetwork }}
+                {{- if .Values.server.hostNetwork }}
                 -retry-join=${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
                 {{- else }}
                 {{- range $index := until (.Values.server.replicas | int) }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -123,6 +123,13 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
+            {{- if .Values.global.hostNetwork }}
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            {{- end }}
             {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
             - name: ACL_REPLICATION_TOKEN
               valueFrom:
@@ -136,13 +143,13 @@ spec:
             - "-ec"
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
-
               exec /bin/consul agent \
-                -advertise="${POD_IP}" \
                 {{- if .Values.global.hostNetwork }}
                 -bind=${NODE_IP} \
+                -advertise="${NODE_IP}" \
                 {{- else }}
                 -bind=0.0.0.0 \
+                -advertise="${POD_IP}" \
                 {{- end }}
                 -bootstrap-expect={{ .Values.server.bootstrapExpect }} \
                 {{- if .Values.global.tls.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,11 +66,6 @@ global:
   # chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
   enablePodSecurityPolicies: false
 
-  # hostNework Controls whether the pod may use the node network namespace. Doing so gives the pod access to the loopback device, services listening on localhost
-  # Enable hostNework to run the server on the node network. the server is reacheble by the node ip.
-  # This is usefull to support external-to-k8s Consul clients
-  hostNetwork: False
-  
   # gossipEncryption configures which Kubernetes secret to retrieve Consul's
   # gossip encryption key from (see https://www.consul.io/docs/agent/options.html#_encrypt).
   # If secretName or secretKey are not set, gossip encryption will not be enabled.
@@ -268,6 +263,11 @@ server:
   # of Consul. Please refer to the documentation for more information.
   updatePartition: 0
 
+  # hostNework Controls whether the pod may use the node network namespace. Doing so gives the pod access to the loopback device, services listening on localhost
+  # Enable hostNework to run the server on the node network. the server is reacheble by the node ip.
+  # This is usefull to support external-to-k8s Consul clients
+  hostNetwork: False
+  
   # disruptionBudget enables the creation of a PodDisruptionBudget to
   # prevent voluntary degrading of the Consul server cluster.
   disruptionBudget:

--- a/values.yaml
+++ b/values.yaml
@@ -66,6 +66,11 @@ global:
   # chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
   enablePodSecurityPolicies: false
 
+  # hostNework Controls whether the pod may use the node network namespace. Doing so gives the pod access to the loopback device, services listening on localhost
+  # Enable hostNework to run the server on the node network. the server is reacheble by the node ip.
+  # This is usefull to support external-to-k8s Consul clients
+  hostNetwork: False
+  
   # gossipEncryption configures which Kubernetes secret to retrieve Consul's
   # gossip encryption key from (see https://www.consul.io/docs/agent/options.html#_encrypt).
   # If secretName or secretKey are not set, gossip encryption will not be enabled.


### PR DESCRIPTION
If pod netwok is not routeable form external nodes/ agents (which is the most common case) we need to run the servers in the node network

Fixes:
https://github.com/hashicorp/consul-helm/issues/358

hostPort definitions are not needed as we run in hostNetwork.

```
      dnsPolicy: ClusterFirstWithHostNet
      hostNetwork: true
```

* inside the k8s cluster consul is reachable via k8s dns:
  euler-server.consul.svc (from inside a pod)
  euler-server.consul.svc.cluster.local (from a k8s node)

* on the external nodes, the consul servers are reachable via dns at consul.service.consul for 
  nodes using the consul dns server or, and recommended for big cluster, any other caching dns that stub-zone or forward-zone (i.e. unbound with consul stub-zone).

Signed-off-by: Nico <zakkg3@gmail.com>
in collaboration with @asteven