### PR TITLE
Add component label to all services

### DIFF
--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: dns
   {{- if .Values.dns.annotations }}
   annotations:
     {{ tpl .Values.dns.annotations . | nindent 4 | trim }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -14,6 +14,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: server
   annotations:
     {{- if .Values.server.service.annotations }}
     {{ tpl .Values.server.service.annotations . | nindent 4 | trim }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: ui
   {{- if .Values.ui.service.annotations }}
   annotations:
     {{ tpl .Values.ui.service.annotations . | nindent 4 | trim }}


### PR DESCRIPTION
This enables querying specific services by labels.
Without this label, most services in the chart have no distinguishing
labels, making it difficult to target specific services with a label
selector.

This enables better integration with tools like prometheus-operator
which use label selectors to determine which endpoints to monitor, as
not all services need to be monitored, and some overlap and reference
the same pods.