### PR TITLE
Support custom CA cert for snapshot agent

### DIFF
--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -99,6 +99,11 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
+              {{- if .Values.client.snapshotAgent.caCert }}
+              cat <<EOF > /etc/ssl/certs/custom-ca.pem
+              {{- .Values.client.snapshotAgent.caCert | nindent 14 }}
+              EOF
+              {{- end }}
               exec /bin/consul snapshot agent \
                 {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
                 -config-dir=/consul/config \

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -362,3 +362,25 @@ load _helpers
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
 }
+
+#--------------------------------------------------------------------
+# client.snapshotAgent.caCert
+
+@test "client/SnapshotAgentDeployment: if caCert is set it is used in command" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'client.snapshotAgent.caCert=-----BEGIN CERTIFICATE-----
+MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  exp='cat <<EOF > /etc/ssl/certs/custom-ca.pem
+-----BEGIN CERTIFICATE-----
+MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL
+EOF
+exec /bin/consul snapshot agent \'
+
+  [ "${actual}" = "${exp}" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -529,7 +529,7 @@ client:
         memory: "50Mi"
         cpu: "50m"
 
-    # Optional CA certificate that will be added to the trusted system CAs.
+    # Optional PEM-encoded CA certificate that will be added to the trusted system CAs.
     # Useful if using an S3-compatible storage exposing a self-signed certificate.
     # Example
     #   caCert: |

--- a/values.yaml
+++ b/values.yaml
@@ -529,6 +529,15 @@ client:
         memory: "50Mi"
         cpu: "50m"
 
+    # Optional CA certificate that will be added to the trusted system CAs.
+    # Useful if using an S3-compatible storage exposing a self-signed certificate.
+    # Example
+    #   caCert: |
+    #     -----BEGIN CERTIFICATE-----
+    #     MIIC7jCCApSgAwIBAgIRAIq2zQEVexqxvtxP6J0bXAwwCgYIKoZIzj0EAwIwgbkx
+    #     ...
+    caCert: null
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns


### PR DESCRIPTION
For users running an S3 compatible storage for the snapshot agent with
their own CA cert they need a way to include that in the system certs so
that the snapshot agent can connect with their URL.

Fixes https://github.com/hashicorp/consul-helm/issues/467