### PR TITLE
Update helm test to validate successful installation

### DIFF
--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -67,8 +67,8 @@ spec:
         - "/bin/sh"
         - "-ec"
         - |
-            consul members
-            if [ $(consul members | grep consul-server | wc -l) != $(consul members | grep consul-server | grep alive | wc -l) ]
+            consul members | tee members.txt
+            if [ $(grep -c consul-server members.txt) != $(grep consul-server members.txt | grep -c alive) ]
             then
               echo "Failed because not all consul servers are available"
               exit 1

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -67,10 +67,12 @@ spec:
         - "/bin/sh"
         - "-ec"
         - |
-            export VALUE="{{ .Release.Name }}"
-            consul kv delete _consul_helm_test
-            consul kv put _consul_helm_test $VALUE
-            [ `consul kv get _consul_helm_test` = "$VALUE" ]
-            consul kv delete _consul_helm_test
+            consul members
+            if [ $(consul members | grep consul-server | wc -l) != $(consul members | grep consul-server | grep alive | wc -l) ]
+            then
+              echo "Failed because not all consul servers are available"
+              exit 1
+            fi
+
   restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
In an installation with ACLs enabled, `consul kv` operations returns a 403 error. Replacing this with a members check allows this test to work in multiple installation modes successfully.

Closes #258

Signed-off-by: Ashwin Venkatesh <ashwin@hashicorp.com>