### PR TITLE
add support for client host networking and tests

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -55,6 +55,10 @@ spec:
       dnsPolicy: {{ .Values.client.dnsPolicy }}
       {{- end }}
 
+      {{- if .Values.client.hostNetwork }}
+      hostNetwork: {{ .Values.client.hostNetwork }}
+      {{- end }}
+
       volumes:
         - name: data
         {{- if .Values.client.dataDirectoryHostPath }}

--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -26,7 +26,7 @@ spec:
     {{- if .Values.client.dataDirectoryHostPath }}
     - 'hostPath'
     {{- end }}
-  hostNetwork: false
+  hostNetwork: {{ .Values.client.hostNetwork }}
   hostPorts:
   {{- if (not (and .Values.global.tls.enabled .Values.global.tls.httpsOnly)) }}
   # HTTP Port

--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -26,7 +26,11 @@ spec:
     {{- if .Values.client.dataDirectoryHostPath }}
     - 'hostPath'
     {{- end }}
+  {{- if .Values.client.hostNetwork }}
   hostNetwork: {{ .Values.client.hostNetwork }}
+  {{- else }}
+  hostNetwork: false
+  {{- end }}
   hostPorts:
   {{- if (not (and .Values.global.tls.enabled .Values.global.tls.httpsOnly)) }}
   # HTTP Port

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -963,6 +963,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# hostNetwork
+
+@test "client/DaemonSet: hostNetwork not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.hostNetwork == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: hostNetwork can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-daemonset.yaml \
+      --set 'client.hostNetwork=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.hostNetwork == true' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+#--------------------------------------------------------------------
 # updateStrategy
 
 @test "client/DaemonSet: updateStrategy not set by default" {

--- a/test/unit/client-podsecuritypolicy.bats
+++ b/test/unit/client-podsecuritypolicy.bats
@@ -142,3 +142,14 @@ load _helpers
       yq '.spec.hostNetwork == true' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+# client.hostNetwork = false
+@test "client/PodSecurityPolicy: enabled with global.enablePodSecurityPolicies=true and default hostNetwork=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq '.spec.hostNetwork == false' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/client-podsecuritypolicy.bats
+++ b/test/unit/client-podsecuritypolicy.bats
@@ -129,3 +129,16 @@ load _helpers
       yq -c '.spec.hostPorts' | tee /dev/stderr)
   [ "${actual}" = '[{"min":8501,"max":8501},{"min":8502,"max":8502}]' ]
 }
+
+#--------------------------------------------------------------------
+# client.hostNetwork = true
+@test "client/PodSecurityPolicy: enabled with global.enablePodSecurityPolicies=true and hostNetwork=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'client.hostNetwork=true' \
+      . | tee /dev/stderr |
+      yq '.spec.hostNetwork == true' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -489,6 +489,13 @@ client:
   # dnsPolicy to use.
   dnsPolicy: null
 
+  # hostNetwork defines whether or not we use host networking instead of hostPort in the event
+  # that a CNI plugin doesnt support hostPort. This has security implications and is not recommended
+  # as doing so gives the consul client unnecessary access to all network traffic on the host.
+  # In most cases, pod network and host network are on different subnets so this should be
+  # combined with `dnsPolicy: ClusterFirstWithHostNet`
+  hostNetwork: false
+
   # updateStrategy for the DaemonSet.
   # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
   # This should be a multi-line string mapping directly to the updateStrategy

--- a/values.yaml
+++ b/values.yaml
@@ -492,7 +492,7 @@ client:
   # hostNetwork defines whether or not we use host networking instead of hostPort in the event
   # that a CNI plugin doesnt support hostPort. This has security implications and is not recommended
   # as doing so gives the consul client unnecessary access to all network traffic on the host.
-  # In most cases, pod network and host network are on different subnets so this should be
+  # In most cases, pod network and host network are on different networks so this should be
   # combined with `dnsPolicy: ClusterFirstWithHostNet`
   hostNetwork: false
 


### PR DESCRIPTION
Add support for client host networking along with unit tests and podsecurity support.

It should be duly noted that this feature introduces security considerations which are outlined in values.yaml 

This is an extension of @kieranajp 's #431  and should also resolve #193 and #431
