### PR TITLE
Do not use ClusterRole/Bindings unnecessarily for tls-init templates

### DIFF
--- a/templates/tls-init-cleanup-role.yaml
+++ b/templates/tls-init-cleanup-role.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.tls.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
   namespace: {{ .Release.Namespace }}
@@ -13,13 +13,26 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-tls-init-cleanup
-subjects:
-- kind: ServiceAccount
-  name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources:
+    - secrets
+  resourceNames:
+    {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
+    - {{ template "consul.fullname" . }}-ca-cert
+    - {{ template "consul.fullname" . }}-ca-key
+    {{- end }}
+    - {{ template "consul.fullname" . }}-server-cert
+  verbs:
+    - delete
+{{- if .Values.global.enablePodSecurityPolicies }}
+- apiGroups: ["policy"]
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - use
+  resourceNames:
+    - {{ template "consul.fullname" . }}-tls-init-cleanup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-rolebinding.yaml
+++ b/templates/tls-init-cleanup-rolebinding.yaml
@@ -20,6 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-cleanup-rolebinding.yaml
+++ b/templates/tls-init-cleanup-rolebinding.yaml
@@ -1,9 +1,9 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.tls.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-tls-init
+  name: {{ template "consul.fullname" . }}-tls-init-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
@@ -11,22 +11,15 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-rules:
-- apiGroups: [""]
-  resources:
-    - secrets
-  verbs:
-    - create
-{{- if .Values.global.enablePodSecurityPolicies }}
-- apiGroups: ["policy"]
-  resources:
-  - podsecuritypolicies
-  verbs:
-    - use
-  resourceNames:
-    - {{ template "consul.fullname" . }}-tls-init
-{{- end }}
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "consul.fullname" . }}-tls-init-cleanup
+subjects:
+- kind: ServiceAccount
+  name: {{ template "consul.fullname" . }}-tls-init-cleanup
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-role.yaml
+++ b/templates/tls-init-role.yaml
@@ -1,9 +1,9 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.tls.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ template "consul.fullname" . }}-tls-init-cleanup
+  name: {{ template "consul.fullname" . }}-tls-init
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
@@ -11,28 +11,22 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups: [""]
   resources:
     - secrets
-  resourceNames:
-    {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
-    - {{ template "consul.fullname" . }}-ca-cert
-    - {{ template "consul.fullname" . }}-ca-key
-    {{- end }}
-    - {{ template "consul.fullname" . }}-server-cert
   verbs:
-    - delete
+    - create
 {{- if .Values.global.enablePodSecurityPolicies }}
 - apiGroups: ["policy"]
   resources:
-    - podsecuritypolicies
+  - podsecuritypolicies
   verbs:
     - use
   resourceNames:
-    - {{ template "consul.fullname" . }}-tls-init-cleanup
+    - {{ template "consul.fullname" . }}-tls-init
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-rolebinding.yaml
+++ b/templates/tls-init-rolebinding.yaml
@@ -20,6 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/tls-init-rolebinding.yaml
+++ b/templates/tls-init-rolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if .Values.global.tls.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
   namespace: {{ .Release.Namespace }}
@@ -15,7 +15,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "consul.fullname" . }}-tls-init
 subjects:
 - kind: ServiceAccount

--- a/test/unit/tls-init-cleanup-role.bats
+++ b/test/unit/tls-init-cleanup-role.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "tlsInit/ClusterRole: disabled by default" {
+@test "tlsInitCleanup/Role: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRole: disabled with global.enabled=false" {
+@test "tlsInitCleanup/Role: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
@@ -22,10 +22,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRole: disabled when server.enabled=false" {
+@test "tlsInitCleanup/Role: disabled when server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -33,10 +33,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRole: enabled when global.tls.enabled=true and server.enabled=true" {
+@test "tlsInitCleanup/Role: enabled when global.tls.enabled=true and server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
@@ -44,24 +44,24 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInit/ClusterRole: enabled with global.tls.enabled" {
+@test "tlsInitCleanup/Role: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInit/ClusterRole: adds pod security polices with global.tls.enabled and global.enablePodSecurityPolicies" {
+@test "tlsInitCleanup/Role: adds pod security polices with global.tls.enabled and global.enablePodSecurityPolicies" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrole.yaml  \
+      -x templates/tls-init-cleanup-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules[] | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]' | tee /dev/stderr)
 
-  [ "${actual}" = "release-name-consul-tls-init" ]
+  [ "${actual}" = "release-name-consul-tls-init-cleanup" ]
 }

--- a/test/unit/tls-init-cleanup-rolebinding.bats
+++ b/test/unit/tls-init-cleanup-rolebinding.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "tlsInitCleanup/ClusterRoleBinding: disabled by default" {
+@test "tlsInitCleanup/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/tls-init-cleanup-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRoleBinding: disabled with global.enabled=false" {
+@test "tlsInitCleanup/RoleBinding: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/tls-init-cleanup-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
@@ -22,20 +22,20 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRoleBinding: enabled with global.tls.enabled" {
+@test "tlsInitCleanup/RoleBinding: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/tls-init-cleanup-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInitCleanup/ClusterRoleBinding: disabled when server.enabled=false" {
+@test "tlsInitCleanup/RoleBinding: disabled when server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/tls-init-cleanup-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -43,10 +43,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRoleBinding: enabled when global.tls.enabled=true and server.enabled=true" {
+@test "tlsInitCleanup/RoleBinding: enabled when global.tls.enabled=true and server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/tls-init-cleanup-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |

--- a/test/unit/tls-init-role.bats
+++ b/test/unit/tls-init-role.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "tlsInitCleanup/ClusterRole: disabled by default" {
+@test "tlsInit/Role: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRole: disabled with global.enabled=false" {
+@test "tlsInit/Role: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
@@ -22,10 +22,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRole: disabled when server.enabled=false" {
+@test "tlsInit/Role: disabled when server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -33,10 +33,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInitCleanup/ClusterRole: enabled when global.tls.enabled=true and server.enabled=true" {
+@test "tlsInit/Role: enabled when global.tls.enabled=true and server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
@@ -44,24 +44,24 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInitCleanup/ClusterRole: enabled with global.tls.enabled" {
+@test "tlsInit/Role: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInitCleanup/ClusterRole: adds pod security polices with global.tls.enabled and global.enablePodSecurityPolicies" {
+@test "tlsInit/Role: adds pod security polices with global.tls.enabled and global.enablePodSecurityPolicies" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-cleanup-clusterrole.yaml  \
+      -x templates/tls-init-role.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules[] | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]' | tee /dev/stderr)
 
-  [ "${actual}" = "release-name-consul-tls-init-cleanup" ]
+  [ "${actual}" = "release-name-consul-tls-init" ]
 }

--- a/test/unit/tls-init-rolebinding.bats
+++ b/test/unit/tls-init-rolebinding.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "tlsInit/ClusterRoleBinding: disabled by default" {
+@test "tlsInit/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrolebinding.yaml  \
+      -x templates/tls-init-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRoleBinding: disabled with global.enabled=false" {
+@test "tlsInit/RoleBinding: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrolebinding.yaml  \
+      -x templates/tls-init-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
@@ -22,20 +22,20 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRoleBinding: enabled with global.tls.enabled" {
+@test "tlsInit/RoleBinding: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrolebinding.yaml  \
+      -x templates/tls-init-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "tlsInit/ClusterRoleBinding: disabled when server.enabled=false" {
+@test "tlsInit/RoleBinding: disabled when server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrolebinding.yaml  \
+      -x templates/tls-init-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -43,10 +43,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "tlsInit/ClusterRoleBinding: enabled when global.tls.enabled=true and server.enabled=true" {
+@test "tlsInit/RoleBinding: enabled when global.tls.enabled=true and server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tls-init-clusterrolebinding.yaml  \
+      -x templates/tls-init-rolebinding.yaml  \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |


### PR DESCRIPTION
It is not necessary to use ClusterRole and ClusterRoleBinding's for tls-init and tls-init-cleanup, these can be standard Role and RoleBinding's as they do not require access to multiple namespaces.
This resolves #354 and partially addresses #403, follow-up PR's will individually address other components.
The PR : 
1. changes the tls-init-* templates to use standard Role / RoleBindings
2. renames the template files from *-clusterrole.yaml to *-role.yaml
3. modifies the unit tests to reflect changes from 1 + 2
4. renames the unit test bats files to reflect these changes

This PR does not reduce the permissions allotted by the Roles, just the number of namespaces accessible.