### PR TITLE
Support disabling creation of helm cleanup hooks

### DIFF
--- a/templates/tls-init-cleanup-clusterrole.yaml
+++ b/templates/tls-init-cleanup-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.tls.enabled }}
+{{- if and .Values.global.tls.enabled (not .Values.global.tls.disableCleanupHooks) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/templates/tls-init-cleanup-clusterrolebinding.yaml
+++ b/templates/tls-init-cleanup-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.tls.enabled }}
+{{- if and .Values.global.tls.enabled (not .Values.global.tls.disableCleanupHooks) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -1,6 +1,6 @@
 # tls-init-cleanup job deletes Kubernetes secrets created by tls-init
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.tls.enabled }}
+{{- if and .Values.global.tls.enabled (not .Values.global.tls.disableCleanupHooks) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/templates/tls-init-cleanup-podsecuritypolicy.yaml
+++ b/templates/tls-init-cleanup-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.global.tls.enabled .Values.global.enablePodSecurityPolicies) }}
+{{- if (and .Values.global.tls.enabled .Values.global.enablePodSecurityPolicies (not .Values.global.tls.disableCleanupHooks)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/templates/tls-init-cleanup-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if .Values.global.tls.enabled }}
+{{- if and .Values.global.tls.enabled (not .Values.global.tls.disableCleanupHooks) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -153,6 +153,14 @@ global:
       secretName: null
       secretKey: null
 
+    # disableCleanupHooks prevents the tls-init-cleanup job from being created.
+    # This is useful if your using helm with other tools that apply the
+    # resources instead of  having helm manage that. In these situations, the
+    # tool typically invokes `helm template` which will produce hooks of all
+    # types, causing the cleanup job to run immediately, which will delete the
+    # certificates, preventing pods from using them.
+    disableCleanupHooks: false
+
   # [Enterprise Only] enableConsulNamespaces indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would like to
   # make use of configuration beyond registering everything into the `default` Consul


### PR DESCRIPTION
When using this chart with argo-cd, kustomize, and many other tools, the
helm annotations aren't used, or are used differently than how helm uses
them, and results in these cleanup hook resources being created at the
same time as everything else.

To better support these tools, add a new global.tls.disableCleanupHooks
option to disable creating the helm hook resources responsible for doing
cleanup actions.