### PR TITLE
Update default Envoy image version and OS

### DIFF
--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -85,7 +85,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.14.2" ]
 }
 
 @test "ingressGateways/Deployment: envoy image can be set using the global value" {

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -238,7 +238,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.14.2" ]
 }
 
 @test "meshGateway/Deployment: envoy image can be set" {

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -85,7 +85,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.14.2" ]
 }
 
 @test "terminatingGateways/Deployment: envoy image can be set using the global value" {

--- a/values.yaml
+++ b/values.yaml
@@ -57,7 +57,7 @@ global:
 
   # imageEnvoy defines the default envoy image to use for ingress and
   # terminating gateways.
-  imageEnvoy: "envoyproxy/envoy:v1.13.0"
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"
 
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
@@ -1032,7 +1032,7 @@ meshGateway:
     additionalSpec: null
 
   # Envoy image to use. For Consul v1.7+, Envoy version 1.13+ is required.
-  imageEnvoy: envoyproxy/envoy:v1.13.0
+  imageEnvoy: envoyproxy/envoy-alpine:v1.14.2
 
   # If set to true, gateway Pods will run on the host network.
   hostNetwork: false


### PR DESCRIPTION
Update Envoy image to alpine version `1.14.2` for all gateways.