### PR TITLE
Support terminating gateways

### DIFF
--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -158,6 +158,23 @@ spec:
                 {{- end }}
                 {{- end }}
 
+                {{- if .Values.terminatingGateways.enabled }}
+                {{- if .Values.global.enableConsulNamespaces }}
+                {{- $root := . }}
+                {{- range .Values.terminatingGateways.gateways }}
+                {{- if (or $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}
+                -terminating-gateway-name="{{ .name }}.{{ (default $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}" \
+                {{- else }}
+                -terminating-gateway-name="{{ .name }}" \
+                {{- end }}
+                {{- end }}
+                {{- else }}
+                {{- range .Values.terminatingGateways.gateways }}
+                -terminating-gateway-name="{{ .name }}" \
+                {{- end }}
+                {{- end }}
+                {{- end }}
+
                 {{- if .Values.connectInject.aclBindingRuleSelector }}
                 -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
                 {{- end }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -37,15 +37,19 @@ spec:
     matchLabels:
       app: {{ template "consul.name" $root }}
       chart: {{ template "consul.chart" $root }}
+      heritage: {{ $root.Release.Service }}
       release: {{ $root.Release.Name }}
       component: terminating-gateway
+      terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   template:
     metadata:
       labels:
         app: {{ template "consul.name" $root }}
         chart: {{ template "consul.chart" $root }}
+        heritage: {{ $root.Release.Service }}
         release: {{ $root.Release.Name }}
         component: terminating-gateway
+        terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if $defaults.annotations }}
@@ -135,6 +139,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://$(HOST_IP):8501
@@ -159,6 +167,7 @@ spec:
                 service {
                   kind = "terminating-gateway"
                   name = "{{ .name }}"
+                  id = "${POD_NAME}"
                   {{- if $root.Values.global.enableConsulNamespaces }}
                   namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"
                   {{- end }}
@@ -226,6 +235,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
             - name: CONSUL_HTTP_TOKEN
               valueFrom:
@@ -276,7 +289,15 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .name }}\""]
+                command:
+                  - "/bin/sh"
+                  - "-ec"
+                  - |
+                      /consul-bin/consul services deregister \
+                      {{- if $root.Values.global.enableConsulNamespaces }}
+                      -namespace={{ default $defaults.consulNamespace .consulNamespace }} \
+                      {{- end }}
+                      -id="${POD_NAME}"
 
         # lifecycle-sidecar ensures the terminating gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -1,0 +1,345 @@
+{{- if .Values.terminatingGateways.enabled }}
+{{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
+{{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
+{{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
+
+{{- $root := . }}
+{{- $defaults := .Values.terminatingGateways.defaults }}
+{{- $names := dict }}
+
+{{- range .Values.terminatingGateways.gateways }}
+
+{{- if empty .name }}
+# Check that name is not empty
+{{ fail "Terminating gateway names cannot be empty"}}
+{{ end -}}
+{{- if hasKey $names .name }}
+# Check that the name doesn't already exist
+{{ fail "Terminating gateway names must be unique"}}
+{{ end -}}
+{{- /* Add the gateway name to the $names dict to ensure uniqueness */ -}}
+{{- $_ := set $names .name .name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+spec:
+  replicas: {{ default $defaults.replicas .replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "consul.name" $root }}
+      chart: {{ template "consul.chart" $root }}
+      release: {{ $root.Release.Name }}
+      component: terminating-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ template "consul.name" $root }}
+        chart: {{ template "consul.chart" $root }}
+        release: {{ $root.Release.Name }}
+        component: terminating-gateway
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+        {{- if $defaults.annotations }}
+        # We allow both default annotations and gateway-specific annotations
+        {{- tpl $defaults.annotations $root | nindent 8 }}
+        {{- end }}
+        {{- if .annotations }}
+        {{- tpl .annotations $root | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if (or $defaults.affinity .affinity) }}
+      affinity:
+        {{ tpl (default $defaults.affinity .affinity) $root | nindent 8 | trim }}
+      {{- end }}
+      {{- if (or $defaults.tolerations .tolerations) }}
+      tolerations:
+        {{ tpl (default $defaults.tolerations .tolerations) $root | nindent 8 | trim }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
+      volumes:
+        - name: consul-bin
+          emptyDir: {}
+        - name: consul-service
+          emptyDir:
+            medium: "Memory"
+        {{- range (default $defaults.extraVolumes .extraVolumes) }}
+        - name: userconfig-{{ .name }}
+          {{ .type }}:
+            {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+            {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+            {{- end }}
+            {{- with .items }}
+            items:
+            {{- range . }}
+            - key: {{.key}}
+              path: {{.path}}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- if $root.Values.global.tls.enabled }}
+        {{- if not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots) }}
+        - name: consul-ca-cert
+          secret:
+            {{- if $root.Values.global.tls.caCert.secretName }}
+            secretName: {{ $root.Values.global.tls.caCert.secretName }}
+            {{- else }}
+            secretName: {{ template "consul.fullname" $root }}-ca-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" $root.Values.global.tls.caCert.secretKey }}
+              path: tls.crt
+        {{- end }}
+        {{- if $root.Values.global.tls.enableAutoEncrypt }}
+        - name: consul-auto-encrypt-ca-cert
+          emptyDir:
+            medium: "Memory"
+        {{- end }}
+        {{- end }}
+      initContainers:
+        # We use the Envoy image as our base image so we use an init container to
+        # copy the Consul binary to a shared directory that can be used when
+        # starting Envoy.
+        - name: copy-consul-bin
+          image: {{ $root.Values.global.image | quote }}
+          command:
+          - cp
+          - /bin/consul
+          - /consul-bin/consul
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+        {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
+        {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
+        {{- end }}
+        # service-init registers the terminating gateway service.
+        - name: service-init
+          image: {{ $root.Values.global.imageK8S }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+                {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                consul-k8s acl-init \
+                  -secret-name="{{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token" \
+                  -k8s-namespace={{ $root.Release.Namespace }} \
+                  -token-sink-file=/consul/service/acl-token
+                {{- end }}
+
+                cat > /consul/service/service.hcl << EOF
+                service {
+                  kind = "terminating-gateway"
+                  name = "{{ .name }}"
+                  {{- if $root.Values.global.enableConsulNamespaces }}
+                  namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"
+                  {{- end }}
+                  address = "${POD_IP}"
+                  port = 8443
+                  proxy {
+                    config {
+                      envoy_gateway_no_default_bind = true
+                      envoy_gateway_bind_addresses {
+                        all-interfaces {
+                          address = "0.0.0.0"
+                        }
+                      }
+                    }
+                  }
+                  checks = [
+                    {
+                      name = "Terminating Gateway Listening"
+                      interval = "10s"
+                      tcp = "${POD_IP}:8443"
+                      deregister_critical_service_after = "6h"
+                    }
+                  ]
+                }
+                EOF
+
+                /consul-bin/consul services register \
+                  {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+                  -token-file=/consul/service/acl-token \
+                  {{- end }}
+                  /consul/service/service.hcl
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+      containers:
+        - name: terminating-gateway
+          image: {{ $root.Values.global.imageEnvoy | quote }}
+          {{- if (default $defaults.resources .resources) }}
+          resources: {{ toYaml (default $defaults.resources .resources) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - name: consul-bin
+            mountPath: /consul-bin
+          {{- if $root.Values.global.tls.enabled }}
+          {{- if $root.Values.global.tls.enableAutoEncrypt }}
+          - name: consul-auto-encrypt-ca-cert
+          {{- else }}
+          - name: consul-ca-cert
+          {{- end }}
+            mountPath: /consul/tls/ca
+            readOnly: true
+          {{- end }}
+          {{- range (default $defaults.extraVolumes .extraVolumes) }}
+          - name: userconfig-{{ .name }}
+            readOnly: true
+            mountPath: /consul/userconfig/{{ .name }}
+          {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - name: CONSUL_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token"
+                  key: "token"
+            {{- end}}
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_GRPC_ADDR
+              value: https://$(HOST_IP):8502
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            - name: CONSUL_GRPC_ADDR
+              value: $(HOST_IP):8502
+            {{- end }}
+          command:
+            - /consul-bin/consul
+            - connect
+            - envoy
+            - -gateway=terminating
+            {{- if $root.Values.global.enableConsulNamespaces }}
+            - -namespace={{ default $defaults.consulNamespace .consulNamespace }}
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          ports:
+            - name: gateway
+              containerPort: 8443
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .name }}\""]
+
+        # lifecycle-sidecar ensures the terminating gateway is always registered with
+        # the local Consul agent, even if it loses the initial registration.
+        - name: lifecycle-sidecar
+          image: {{ $root.Values.global.imageK8S }}
+          volumeMounts:
+            - name: consul-service
+              mountPath: /consul/service
+              readOnly: true
+            - name: consul-bin
+              mountPath: /consul-bin
+            {{- if $root.Values.global.tls.enabled }}
+            {{- if $root.Values.global.tls.enableAutoEncrypt }}
+            - name: consul-auto-encrypt-ca-cert
+            {{- else }}
+            - name: consul-ca-cert
+            {{- end }}
+              mountPath: /consul/tls/ca
+              readOnly: true
+            {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if $root.Values.global.tls.enabled }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://$(HOST_IP):8501
+            - name: CONSUL_CACERT
+              value: /consul/tls/ca/tls.crt
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://$(HOST_IP):8500
+            {{- end }}
+          command:
+            - consul-k8s
+            - lifecycle-sidecar
+            - -service-config=/consul/service/service.hcl
+            - -consul-binary=/consul-bin/consul
+            {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+            - -token-file=/consul/service/acl-token
+            {{- end }}
+      {{- if (default $defaults.priorityClassName .priorityClassName) }}
+      priorityClassName: {{ (default $defaults.priorityClassName .priorityClassName) | quote }}
+      {{- end }}
+      {{- if (default $defaults.nodeSelector .nodeSelector) }}
+      nodeSelector:
+        {{ tpl (default $defaults.nodeSelector .nodeSelector) $root | indent 8 | trim }}
+      {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -164,16 +164,6 @@ spec:
                   {{- end }}
                   address = "${POD_IP}"
                   port = 8443
-                  proxy {
-                    config {
-                      envoy_gateway_no_default_bind = true
-                      envoy_gateway_bind_addresses {
-                        all-interfaces {
-                          address = "0.0.0.0"
-                        }
-                      }
-                    }
-                  }
                   checks = [
                     {
                       name = "Terminating Gateway Listening"

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -264,6 +264,7 @@ spec:
             - connect
             - envoy
             - -gateway=terminating
+            - -proxy-id=$(POD_NAME)
             {{- if $root.Values.global.enableConsulNamespaces }}
             - -namespace={{ default $defaults.consulNamespace .consulNamespace }}
             {{- end }}

--- a/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -1,0 +1,43 @@
+{{- if (and .Values.global.enablePodSecurityPolicies .Values.terminatingGateways.enabled) }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -11,6 +11,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/templates/terminating-gateways-role.yaml
+++ b/templates/terminating-gateways-role.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.terminatingGateways.enabled }}
+
+{{- $root := . }}
+{{- $defaults := .Values.terminatingGateways.defaults }}
+
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies) }}
+rules:
+{{- if $root.Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      -  {{ template "consul.fullname" $root }}-{{ .name }}
+    verbs:
+      - use
+{{- end }}
+{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs) }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      -  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token
+    verbs:
+      - get
+{{- end }}
+{{- else }}
+rules: []
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-role.yaml
+++ b/templates/terminating-gateways-role.yaml
@@ -15,6 +15,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.bootstrapACLs $root.Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if $root.Values.global.enablePodSecurityPolicies }}

--- a/templates/terminating-gateways-rolebinding.yaml
+++ b/templates/terminating-gateways-rolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.terminatingGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+subjects:
+  - kind: ServiceAccount
+    name:  {{ template "consul.fullname" $root }}-{{ .name }}
+    namespace: {{ $root.Release.Namespace }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-rolebinding.yaml
+++ b/templates/terminating-gateways-rolebinding.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/terminating-gateways-serviceaccount.yaml
+++ b/templates/terminating-gateways-serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.terminatingGateways.enabled }}
+{{- $root := . }}
+{{- range .Values.terminatingGateways.gateways }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" $root }}
+    chart: {{ template "consul.chart" $root }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+    component: terminating-gateway
+{{- with $root.Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/terminating-gateways-serviceaccount.yaml
+++ b/templates/terminating-gateways-serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
 {{- with $root.Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -270,6 +270,6 @@ load _helpers
   diff=$(diff <(grep -r '\.Values\.global\.bootstrapACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 
-  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
+  diff=$(diff <(grep -r '\.Values\.global\.acls\.manageSystemACLs' templates/*) <(grep -r -e 'or [\$root]*\.Values\.global\.acls\.manageSystemACLs [\$root]*\.Values\.global\.bootstrapACLs' templates/*) | tee /dev/stderr)
   [ "$diff" = "" ]
 }

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -726,16 +726,6 @@ service {
   name = "terminating-gateway"
   address = "${POD_IP}"
   port = 8443
-  proxy {
-    config {
-      envoy_gateway_no_default_bind = true
-      envoy_gateway_bind_addresses {
-        all-interfaces {
-          address = "0.0.0.0"
-        }
-      }
-    }
-  }
   checks = [
     {
       name = "Terminating Gateway Listening"
@@ -774,16 +764,6 @@ service {
   name = "terminating-gateway"
   address = "${POD_IP}"
   port = 8443
-  proxy {
-    config {
-      envoy_gateway_no_default_bind = true
-      envoy_gateway_bind_addresses {
-        all-interfaces {
-          address = "0.0.0.0"
-        }
-      }
-    }
-  }
   checks = [
     {
       name = "Terminating Gateway Listening"
@@ -821,16 +801,6 @@ service {
   namespace = "namespace"
   address = "${POD_IP}"
   port = 8443
-  proxy {
-    config {
-      envoy_gateway_no_default_bind = true
-      envoy_gateway_bind_addresses {
-        all-interfaces {
-          address = "0.0.0.0"
-        }
-      }
-    }
-  }
   checks = [
     {
       name = "Terminating Gateway Listening"
@@ -869,16 +839,6 @@ service {
   namespace = "new-namespace"
   address = "${POD_IP}"
   port = 8443
-  proxy {
-    config {
-      envoy_gateway_no_default_bind = true
-      envoy_gateway_bind_addresses {
-        all-interfaces {
-          address = "0.0.0.0"
-        }
-      }
-    }
-  }
   checks = [
     {
       name = "Terminating Gateway Listening"

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -1,0 +1,969 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "terminatingGateways/Deployment: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/Deployment: enabled with terminatingGateways, connectInject and client.grpc enabled, has default gateway name" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-terminating-gateway" ]
+}
+
+#--------------------------------------------------------------------
+# prerequisites
+
+@test "terminatingGateways/Deployment: fails if connectInject.enabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=false' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.enabled must be true" ]]
+}
+
+@test "terminatingGateways/Deployment: fails if client.grpc=false" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'client.grpc=false' \
+      --set 'connectInject.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "client.grpc must be true" ]]
+}
+
+@test "terminatingGateways/Deployment: fails if global.enabled is false and clients are not explicitly enabled" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enabled=false' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "clients must be enabled" ]]
+}
+
+@test "terminatingGateways/Deployment: fails if global.enabled is true but clients are explicitly disabled" {
+  cd `chart_dir`
+  run helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enabled=true' \
+      --set 'client.enabled=false' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "clients must be enabled" ]]
+}
+
+#--------------------------------------------------------------------
+# envoyImage
+
+@test "terminatingGateways/Deployment: envoy image has default global value" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "envoyproxy/envoy:v1.13.0" ]
+}
+
+@test "terminatingGateways/Deployment: envoy image can be set using the global value" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imageEnvoy=new/image' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "new/image" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enabled
+
+@test "terminatingGateways/Deployment: sets TLS flags when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8502' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: can overwrite CA secret with the provided one" {
+  cd `chart_dir`
+  local ca_cert_volume=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo-ca-cert' \
+      --set 'global.tls.caCert.secretKey=key' \
+      --set 'global.tls.caKey.secretName=foo-ca-key' \
+      --set 'global.tls.caKey.secretKey=key' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  # check that the provided ca cert secret is attached as a volume
+  local actual=$(echo $ca_cert_volume | yq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo-ca-cert" ]
+
+  # check that the volume uses the provided secret key
+  local actual=$(echo $ca_cert_volume | yq -r '.secret.items[0].key' | tee /dev/stderr)
+  [ "${actual}" = "key" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enableAutoEncrypt
+
+@test "terminatingGateways/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: consul-auto-encrypt-ca-cert volumeMount is added when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-auto-encrypt-ca-cert") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: get-auto-encrypt-client-ca init container is created when TLS with auto-encrypt is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: consul-ca-cert volume is not added if externalServers.enabled=true and externalServers.useSystemRoots=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo.com' \
+      --set 'externalServers.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
+#--------------------------------------------------------------------
+# replicas
+
+@test "terminatingGateways/Deployment: replicas defaults to 2" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "terminatingGateways/Deployment: replicas can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.replicas=3' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "terminatingGateways/Deployment: replicas can be set through specific gateway, overrides default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.replicas=3' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].replicas=12' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "12" ]
+}
+
+#--------------------------------------------------------------------
+# extraVolumes
+
+@test "terminatingGateways/Deployment: adds extra volume" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=configMap' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.volumes[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.configMap.name' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object |
+      yq -r '.configMap.secretName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=configMap' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/userconfig/foo" ]
+}
+
+@test "terminatingGateways/Deployment: adds extra secret volume" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=secret' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.volumes[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.secret.name' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo $object |
+      yq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=configMap' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/userconfig/foo" ]
+}
+
+@test "terminatingGateways/Deployment: adds extra secret volume with items" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=secret' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=foo' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].items[0].key=key' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].items[0].path=path' \
+      . | tee /dev/stderr |
+      yq -c -s '.[0].spec.template.spec.volumes[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+  [ "${actual}" = "{\"name\":\"userconfig-foo\",\"secret\":{\"secretName\":\"foo\",\"items\":[{\"key\":\"key\",\"path\":\"path\"}]}}" ]
+}
+
+@test "terminatingGateways/Deployment: adds extra secret volume through specific gateway overriding defaults" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=secret' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=default-foo' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].extraVolumes[0].type=secret' \
+      --set 'terminatingGateways.gateways[0].extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.volumes[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.secret.name' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo $object |
+      yq -r '.secret.secretName' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].type=configMap' \
+      --set 'terminatingGateways.defaults.extraVolumes[0].name=default-foo' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].extraVolumes[0].type=secret' \
+      --set 'terminatingGateways.gateways[0].extraVolumes[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r -s '.[0].spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/userconfig/foo" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "terminatingGateways/Deployment: resources has default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "100Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "100m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "100Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "100m" ]
+}
+
+@test "terminatingGateways/Deployment: resources can be set through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.resources.requests.memory=memory' \
+      --set 'terminatingGateways.defaults.resources.requests.cpu=cpu' \
+      --set 'terminatingGateways.defaults.resources.limits.memory=memory2' \
+      --set 'terminatingGateways.defaults.resources.limits.cpu=cpu2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory" ]
+
+  local actual=$(echo $object | yq -r '.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu" ]
+
+  local actual=$(echo $object | yq -r '.limits.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory2" ]
+
+  local actual=$(echo $object | yq -r '.limits.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu2" ]
+}
+
+@test "terminatingGateways/Deployment: resources can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.resources.requests.memory=memory' \
+      --set 'terminatingGateways.defaults.resources.requests.cpu=cpu' \
+      --set 'terminatingGateways.defaults.resources.limits.memory=memory2' \
+      --set 'terminatingGateways.defaults.resources.limits.cpu=cpu2' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].resources.requests.memory=gwmemory' \
+      --set 'terminatingGateways.gateways[0].resources.requests.cpu=gwcpu' \
+      --set 'terminatingGateways.gateways[0].resources.limits.memory=gwmemory2' \
+      --set 'terminatingGateways.gateways[0].resources.limits.cpu=gwcpu2' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.containers[0].resources' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
+  [ "${actual}" = "gwmemory" ]
+
+  local actual=$(echo $object | yq -r '.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "gwcpu" ]
+
+  local actual=$(echo $object | yq -r '.limits.memory' | tee /dev/stderr)
+  [ "${actual}" = "gwmemory2" ]
+
+  local actual=$(echo $object | yq -r '.limits.cpu' | tee /dev/stderr)
+  [ "${actual}" = "gwcpu2" ]
+}
+
+#--------------------------------------------------------------------
+# affinity
+
+@test "terminatingGateways/Deployment: affinity defaults to one per node" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey' | tee /dev/stderr)
+  [ "${actual}" = "kubernetes.io/hostname" ]
+}
+
+@test "terminatingGateways/Deployment: affinity can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.affinity=key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "terminatingGateways/Deployment: affinity can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.affinity=key: value' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].affinity=key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.affinity.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# tolerations
+
+@test "terminatingGateways/Deployment: no tolerations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "terminatingGateways/Deployment: tolerations can be set through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "terminatingGateways/Deployment: tolerations can be set through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.tolerations=- key: value' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].tolerations=- key: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "terminatingGateways/Deployment: no nodeSelector by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "terminatingGateways/Deployment: can set a nodeSelector through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.nodeSelector=key: value' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "terminatingGateways/Deployment: can set a nodeSelector through specific gateway, overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.nodeSelector=key: value' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].nodeSelector=key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.nodeSelector.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# priorityClassName
+
+@test "terminatingGateways/Deployment: no priorityClassName by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "terminatingGateways/Deployment: can set a priorityClassName through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.priorityClassName=name' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "name" ]
+}
+
+@test "terminatingGateways/Deployment: can set a priorityClassName per gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.priorityClassName=name' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].priorityClassName=priority' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "priority" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "terminatingGateways/Deployment: no extra annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "terminatingGateways/Deployment: extra annotations can be set through defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "terminatingGateways/Deployment: extra annotations can be set through specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+@test "terminatingGateways/Deployment: extra annotations can be set through defaults and specific gateway" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.defaults.annotations=defaultkey: defaultvalue' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[0].annotations=key1: value1
+key2: value2' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '. | length' | tee /dev/stderr)
+  [ "${actual}" = "4" ]
+
+  local actual=$(echo $object | yq -r '.defaultkey' | tee /dev/stderr)
+  [ "${actual}" = "defaultvalue" ]
+
+  local actual=$(echo $object | yq -r '.key1' | tee /dev/stderr)
+  [ "${actual}" = "value1" ]
+
+  local actual=$(echo $object | yq -r '.key2' | tee /dev/stderr)
+  [ "${actual}" = "value2" ]
+}
+
+#--------------------------------------------------------------------
+# service-init init container command
+
+@test "terminatingGateways/Deployment: service-init init container defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "terminating-gateway"
+  name = "terminating-gateway"
+  address = "${POD_IP}"
+  port = 8443
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Terminating Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "terminatingGateways/Deployment: service-init init container with acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='consul-k8s acl-init \
+  -secret-name="release-name-consul-terminating-gateway-terminating-gateway-acl-token" \
+  -k8s-namespace=default \
+  -token-sink-file=/consul/service/acl-token
+
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "terminating-gateway"
+  name = "terminating-gateway"
+  address = "${POD_IP}"
+  port = 8443
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Terminating Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  -token-file=/consul/service/acl-token \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "terminatingGateways/Deployment: service-init init container gateway namespace can be specified through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'terminatingGateways.defaults.consulNamespace=namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "terminating-gateway"
+  name = "terminating-gateway"
+  namespace = "namespace"
+  address = "${POD_IP}"
+  port = 8443
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Terminating Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+@test "terminatingGateways/Deployment: service-init init container gateway namespace can be specified through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'terminatingGateways.defaults.consulNamespace=namespace' \
+      --set 'terminatingGateways.gateways[0].name=terminating-gateway' \
+      --set 'terminatingGateways.gateways[0].consulNamespace=new-namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+
+  exp='
+cat > /consul/service/service.hcl << EOF
+service {
+  kind = "terminating-gateway"
+  name = "terminating-gateway"
+  namespace = "new-namespace"
+  address = "${POD_IP}"
+  port = 8443
+  proxy {
+    config {
+      envoy_gateway_no_default_bind = true
+      envoy_gateway_bind_addresses {
+        all-interfaces {
+          address = "0.0.0.0"
+        }
+      }
+    }
+  }
+  checks = [
+    {
+      name = "Terminating Gateway Listening"
+      interval = "10s"
+      tcp = "${POD_IP}:8443"
+      deregister_critical_service_after = "6h"
+    }
+  ]
+}
+EOF
+
+/consul-bin/consul services register \
+  /consul/service/service.hcl'
+
+  [ "${actual}" = "${exp}" ]
+}
+
+#--------------------------------------------------------------------
+# namespaces
+
+@test "terminatingGateways/Deployment: namespace command flag is not present by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/Deployment: namespace command flag is specified through defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'terminatingGateways.defaults.consulNamespace=namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace=namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: namespace command flag is specified through specific gateway overriding defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'terminatingGateways.defaults.consulNamespace=namespace' \
+      --set 'terminatingGateways.gateways[0].name=terminating-gateway' \
+      --set 'terminatingGateways.gateways[0].consulNamespace=new-namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command | any(contains("-namespace=new-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# multiple gateways
+
+@test "terminatingGateways/Deployment: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+
+  local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[1] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -103,7 +103,7 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
-@test "terminatingGateways/Deployment: sets TLS flags when global.tls.enabled" {
+@test "terminatingGateways/Deployment: sets TLS env variables when global.tls.enabled" {
   cd `chart_dir`
   local env=$(helm template \
       -x templates/terminating-gateways-deployment.yaml \
@@ -118,6 +118,23 @@ load _helpers
 
   local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = 'https://$(HOST_IP):8502' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: sets TLS env variables in lifecycle sidecar when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
 
   local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]
@@ -202,6 +219,33 @@ load _helpers
       . | tee /dev/stderr |
       yq -s '.[0].spec.template.spec.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]
+}
+
+#--------------------------------------------------------------------
+# global.acls.manageSystemACLs
+
+@test "terminatingGateways/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s '[.[0].spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: lifecycle-sidecar uses -token-file flag when global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s '.[0].spec.template.spec.containers[1].command | any(contains("-token-file=/consul/service/acl-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/terminating-gateways-podsecuritypolicy.bats
+++ b/test/unit/terminating-gateways-podsecuritypolicy.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "terminatingGateways/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-podsecuritypolicy.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/PodSecurityPolicy: enabled with terminatingGateways, connectInject and client.grpc enabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-podsecuritypolicy.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/PodSecurityPolicy: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-podsecuritypolicy.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[1] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+}

--- a/test/unit/terminating-gateways-role.bats
+++ b/test/unit/terminating-gateways-role.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "terminatingGateways/Role: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/Role: enabled with terminatingGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Role: rules for PodSecurityPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+}
+
+@test "terminatingGateways/Role: rules for global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "secrets" ]
+
+  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-terminating-gateway-terminating-gateway-acl-token" ]
+}
+
+@test "terminatingGateways/Role: rules is empty if no ACLs, PSPs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules' | tee /dev/stderr)
+  [ "${actual}" = "[]" ]
+}
+
+@test "terminatingGateways/Role: rules for ACLs, PSPs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "terminatingGateways/Role: rules for ACLs, PSPs with multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+
+  local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local actual=$(echo $object | yq '.[1].rules | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/terminating-gateways-rolebinding.bats
+++ b/test/unit/terminating-gateways-rolebinding.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "terminatingGateways/RoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-rolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/RoleBinding: enabled with terminatingGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-rolebinding.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/RoleBinding: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-role.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+
+  local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/terminating-gateways-serviceaccount.bats
+++ b/test/unit/terminating-gateways-serviceaccount.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "terminatingGateways/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/ServiceAccount: enabled with terminatingGateways, connectInject and client.grpc enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/terminating-gateways-serviceaccount.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "terminatingGateways/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-serviceaccount.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[0].imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -s -r '.[0].imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+
+#--------------------------------------------------------------------
+# multiple gateways
+
+@test "terminatingGateways/ServiceAccount: multiple gateways" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/terminating-gateways-serviceaccount.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set 'terminatingGateways.gateways[1].name=gateway2' \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway1" ]
+
+  local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-gateway2" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.[2] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1061,6 +1061,7 @@ meshGateway:
               release: "{{ .Release.Name }}"
               component: mesh-gateway
           topologyKey: kubernetes.io/hostname
+
   # Optional YAML string to specify tolerations.
   tolerations: null
 
@@ -1145,6 +1146,7 @@ ingressGateways:
                 release: "{{ .Release.Name }}"
                 component: ingress-gateway
             topologyKey: kubernetes.io/hostname
+
     # Optional YAML string to specify tolerations.
     tolerations: null
 
@@ -1185,6 +1187,7 @@ ingressGateways:
 # Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
 # global.acls.manageSystemACLs.
 terminatingGateways:
+  # Enable terminating gateway deployment. Requires `connectInject.enabled=true`.
   enabled: false
 
   # Defaults sets default values for all gateway fields. With the exception
@@ -1205,6 +1208,7 @@ terminatingGateways:
     #          path: path  # secret will now mount to /consul/userconfig/my-secret/path
     extraVolumes: []
 
+    # Resource limits for all terminating gateway pods
     resources:
       requests:
         memory: "100Mi"

--- a/values.yaml
+++ b/values.yaml
@@ -1061,7 +1061,6 @@ meshGateway:
               release: "{{ .Release.Name }}"
               component: mesh-gateway
           topologyKey: kubernetes.io/hostname
-
   # Optional YAML string to specify tolerations.
   tolerations: null
 
@@ -1146,7 +1145,6 @@ ingressGateways:
                 release: "{{ .Release.Name }}"
                 component: ingress-gateway
             topologyKey: kubernetes.io/hostname
-
     # Optional YAML string to specify tolerations.
     tolerations: null
 
@@ -1177,6 +1175,87 @@ ingressGateways:
   # case of annotations where both will be applied.
   gateways:
     - name: ingress-gateway
+
+# Configuration options for terminating gateways. Default values for all
+# terminating gateways are defined in `terminatingGateways.defaults`. Any of
+# these values may be overridden in `terminatingGateways.gateways` for a
+# specific gateway with the exception of annotations. Annotations will
+# include both the default annotations and any additional ones defined
+# for a specific gateway.
+# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+# global.acls.manageSystemACLs.
+terminatingGateways:
+  enabled: false
+
+  # Defaults sets default values for all gateway fields. With the exception
+  # of annotations, defining any of these values in the `gateways` list
+  # will override the default values provided here.
+  defaults:
+    # Number of replicas for each terminating gateway defined.
+    replicas: 2
+
+    # extraVolumes is a list of extra volumes to mount. These will be exposed
+    # to Consul in the path `/consul/userconfig/<name>/`. The value below is
+    # an array of objects, examples are shown below.
+    #  extraVolumes:
+    #    - type: secret
+    #      name: my-secret
+    #      items:  # optional items array
+    #        - key: key
+    #          path: path  # secret will now mount to /consul/userconfig/my-secret/path
+    extraVolumes: []
+
+    resources:
+      requests:
+        memory: "100Mi"
+        cpu: "100m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
+
+    # By default, we set an anti affinity so that two of the same gateway pods
+    # won't be on the same node. NOTE: Gateways require that Consul client agents are
+    # also running on the nodes alongside each gateway Pod.
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "consul.name" . }}
+                release: "{{ .Release.Name }}"
+                component: terminating-gateway
+            topologyKey: kubernetes.io/hostname
+
+    # Optional YAML string to specify tolerations.
+    tolerations: null
+
+    # Optional YAML string to specify a nodeSelector config.
+    nodeSelector: null
+
+    # Optional priorityClassName.
+    priorityClassName: ""
+
+    # Annotations to apply to the terminating gateway deployment. Annotations defined
+    # here will be applied to all terminating gateway deployments in addition to any
+    # annotations defined for a specific gateway in `terminatingGateways.gateways`.
+    # Example:
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    annotations: null
+
+    # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
+    # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+    # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+    # Note: The Consul namespace MUST exist before the gateway is deployed or
+    # deployment will fail.
+    consulNamespace: "default"
+
+  # Gateways is a list of gateway objects. The only required field for
+  # each is `name`, though they can also contain any of the fields in
+  # `defaults`. Values defined here override the defaults except in the
+  # case of annotations where both will be applied.
+  gateways:
+    - name: terminating-gateway
 
 # Control whether a test Pod manifest is generated when running helm template.
 # When using helm install, the test Pod is not submitted to the cluster so this

--- a/values.yaml
+++ b/values.yaml
@@ -1049,9 +1049,9 @@ meshGateway:
       memory: "100Mi"
       cpu: "100m"
 
-  # By default, we set an anti affinity so that two gateway pods won't be
+  # By default, we set an anti-affinity so that two gateway pods won't be
   # on the same node. NOTE: Gateways require that Consul client agents are
-  # also running on the nodes alongside each gateway Pod.
+  # also running on the nodes alongside each gateway pod.
   affinity: |
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -1084,14 +1084,17 @@ meshGateway:
 # include both the default annotations and any additional ones defined
 # for a specific gateway.
 # Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
-# global.acls.manageSystemACLs.
+# global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
 ingressGateways:
-  # Enable ingress gateway deployment. Requires `connectInject.enabled=true`.
+  # Enable ingress gateway deployment. Requires `connectInject.enabled=true`
+  # and `client.enabled=true`.
   enabled: false
 
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
-  # will override the default values provided here.
+  # will override the default values provided here. Annotations will
+  # include both the default annotations and any additional ones defined
+  # for a specific gateway.
   defaults:
     # Number of replicas for each ingress gateway defined.
     replicas: 2
@@ -1134,9 +1137,9 @@ ingressGateways:
         memory: "100Mi"
         cpu: "100m"
 
-    # By default, we set an anti affinity so that two of the same gateway pods
+    # By default, we set an anti-affinity so that two of the same gateway pods
     # won't be on the same node. NOTE: Gateways require that Consul client agents are
-    # also running on the nodes alongside each gateway Pod.
+    # also running on the nodes alongside each gateway pod.
     affinity: |
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -1184,14 +1187,17 @@ ingressGateways:
 # include both the default annotations and any additional ones defined
 # for a specific gateway.
 # Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
-# global.acls.manageSystemACLs.
+# global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
 terminatingGateways:
-  # Enable terminating gateway deployment. Requires `connectInject.enabled=true`.
+  # Enable terminating gateway deployment. Requires `connectInject.enabled=true`
+  # and `client.enabled=true`.
   enabled: false
 
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
-  # will override the default values provided here.
+  # will override the default values provided here. Annotations will
+  # include both the default annotations and any additional ones defined
+  # for a specific gateway.
   defaults:
     # Number of replicas for each terminating gateway defined.
     replicas: 2
@@ -1216,9 +1222,9 @@ terminatingGateways:
         memory: "100Mi"
         cpu: "100m"
 
-    # By default, we set an anti affinity so that two of the same gateway pods
+    # By default, we set an anti-affinity so that two of the same gateway pods
     # won't be on the same node. NOTE: Gateways require that Consul client agents are
-    # also running on the nodes alongside each gateway Pod.
+    # also running on the nodes alongside each gateway pod.
     affinity: |
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/values.yaml
+++ b/values.yaml
@@ -1167,8 +1167,7 @@ ingressGateways:
     # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
     # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
     # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
-    # Note: The Consul namespace MUST exist before the gateway is deployed or
-    # deployment will fail.
+    # Note: The Consul namespace MUST exist before the gateway is deployed.
     consulNamespace: "default"
 
   # Gateways is a list of gateway objects. The only required field for
@@ -1250,8 +1249,7 @@ terminatingGateways:
     # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
     # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
     # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
-    # Note: The Consul namespace MUST exist before the gateway is deployed or
-    # deployment will fail.
+    # Note: The Consul namespace MUST exist before the gateway is deployed.
     consulNamespace: "default"
 
   # Gateways is a list of gateway objects. The only required field for


### PR DESCRIPTION
Following up from #491 after a tragic git accident.

This creates all of the necessary templates to support terminating
gateways in the helm chart. Using terminatingGateways.defaults and
terminatingGateways.gateways, it's possible to define multiple
gateways. Names must be provided for each and they must be unique.

Any gateway-specific values will override the default value with the
exception of annotations. Annotations will apply both the defaults
and gateway-specific annotations.

Note: This is ready for a static code review, but has not been tested
yet because of a bug in the gateway implementation. It's also targeting
the ingress gateway branch for now to make it easier for settings and
tests that overlap between gateway implementations.

Replaces and builds on #452