### PR TITLE
remove unnecessary server ClusterRoles

### DIFF
--- a/templates/server-acl-init-cleanup-role.yaml
+++ b/templates/server-acl-init-cleanup-role.yaml
@@ -2,7 +2,7 @@
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
   labels:

--- a/templates/server-acl-init-cleanup-role.yaml
+++ b/templates/server-acl-init-cleanup-role.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-acl-init-cleanup-rolebinding.yaml
+++ b/templates/server-acl-init-cleanup-rolebinding.yaml
@@ -18,6 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/server-acl-init-cleanup-rolebinding.yaml
+++ b/templates/server-acl-init-cleanup-rolebinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-acl-init-cleanup-rolebinding.yaml
+++ b/templates/server-acl-init-cleanup-rolebinding.yaml
@@ -2,7 +2,7 @@
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
   labels:
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
 subjects:
   - kind: ServiceAccount

--- a/templates/server-acl-init-role.yaml
+++ b/templates/server-acl-init-role.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-acl-init-role.yaml
+++ b/templates/server-acl-init-role.yaml
@@ -2,7 +2,7 @@
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   labels:

--- a/templates/server-acl-init-rolebinding.yaml
+++ b/templates/server-acl-init-rolebinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-acl-init-rolebinding.yaml
+++ b/templates/server-acl-init-rolebinding.yaml
@@ -2,7 +2,7 @@
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
   labels:
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "consul.fullname" . }}-server-acl-init
 subjects:
   - kind: ServiceAccount

--- a/templates/server-acl-init-rolebinding.yaml
+++ b/templates/server-acl-init-rolebinding.yaml
@@ -18,6 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init
-    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/server-role.yaml
+++ b/templates/server-role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-role.yaml
+++ b/templates/server-role.yaml
@@ -1,6 +1,6 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server
   labels:
@@ -8,12 +8,15 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-server
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-server
-    namespace: {{ .Release.Namespace }}
+{{- if .Values.global.enablePodSecurityPolicies }}
+rules:
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames:
+  - {{ template "consul.fullname" . }}-server
+  verbs:
+  - use
+{{- else }}
+rules: []
+{{- end }}
 {{- end }}

--- a/templates/server-rolebinding.yaml
+++ b/templates/server-rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/server-rolebinding.yaml
+++ b/templates/server-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server
   labels:
@@ -8,15 +8,12 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.global.enablePodSecurityPolicies }}
-rules:
-- apiGroups: ["policy"]
-  resources: ["podsecuritypolicies"]
-  resourceNames:
-  - {{ template "consul.fullname" . }}-server
-  verbs:
-  - use
-{{- else }}
-rules: []
-{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "consul.fullname" . }}-server
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "consul.fullname" . }}-server
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/templates/server-rolebinding.yaml
+++ b/templates/server-rolebinding.yaml
@@ -16,5 +16,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server
-    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/test/unit/server-acl-init-cleanup-role.bats
+++ b/test/unit/server-acl-init-cleanup-role.bats
@@ -2,29 +2,29 @@
 
 load _helpers
 
-@test "serverACLInit/ClusterRole: disabled by default" {
+@test "serverACLInitCleanup/Role: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/Role: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRole: disabled with server=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/Role: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -32,21 +32,21 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with client=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/Role: enabled with client=true and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'client.enabled=false' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRole: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
+@test "serverACLInitCleanup/Role: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
@@ -57,26 +57,12 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# connectInject.enabled
-
-@test "serverACLInit/ClusterRole: allows service accounts when connectInject.enabled is true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "serviceaccounts")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-#--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 
-@test "serverACLInit/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+@test "serverACLInitCleanup/Role: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrole.yaml  \
+      -x templates/server-acl-init-cleanup-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |

--- a/test/unit/server-acl-init-cleanup-rolebinding.bats
+++ b/test/unit/server-acl-init-cleanup-rolebinding.bats
@@ -2,29 +2,29 @@
 
 load _helpers
 
-@test "serverACLInit/ClusterRoleBinding: disabled by default" {
+@test "serverACLInitCleanup/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-cleanup-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/RoleBinding: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-cleanup-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/RoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-cleanup-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -32,10 +32,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInitCleanup/RoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-cleanup-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
@@ -43,10 +43,10 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
+@test "serverACLInitCleanup/RoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-clusterrolebinding.yaml \
+      -x templates/server-acl-init-cleanup-rolebinding.yaml  \
       --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \

--- a/test/unit/server-acl-init-role.bats
+++ b/test/unit/server-acl-init-role.bats
@@ -2,29 +2,29 @@
 
 load _helpers
 
-@test "serverACLInitCleanup/ClusterRole: disabled by default" {
+@test "serverACLInit/Role: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with global.acls.manageSystemACLs=true" {
+@test "serverACLInit/Role: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: disabled with server=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/Role: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -32,21 +32,21 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with client=true and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/Role: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'client.enabled=true' \
+      --set 'client.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRole: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
+@test "serverACLInit/Role: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml \
       --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \
@@ -57,12 +57,26 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.enablePodSecurityPolicies
+# connectInject.enabled
 
-@test "serverACLInitCleanup/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+@test "serverACLInit/Role: allows service accounts when connectInject.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrole.yaml  \
+      -x templates/server-acl-init-role.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules | map(select(.resources[0] == "serviceaccounts")) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+#--------------------------------------------------------------------
+# global.enablePodSecurityPolicies
+
+@test "serverACLInit/Role: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-acl-init-role.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |

--- a/test/unit/server-acl-init-rolebinding.bats
+++ b/test/unit/server-acl-init-rolebinding.bats
@@ -2,29 +2,29 @@
 
 load _helpers
 
-@test "serverACLInitCleanup/ClusterRoleBinding: disabled by default" {
+@test "serverACLInit/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with global.acls.manageSystemACLs=true" {
+@test "serverACLInit/RoleBinding: enabled with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/RoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
@@ -32,10 +32,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
+@test "serverACLInit/RoleBinding: enabled with client=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-rolebinding.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
@@ -43,10 +43,10 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInitCleanup/ClusterRoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
+@test "serverACLInit/RoleBinding: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-cleanup-clusterrolebinding.yaml  \
+      -x templates/server-acl-init-rolebinding.yaml \
       --set 'server.enabled=false' \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'externalServers.enabled=true' \

--- a/test/unit/server-role.bats
+++ b/test/unit/server-role.bats
@@ -2,29 +2,29 @@
 
 load _helpers
 
-@test "server/ClusterRole: enabled by default" {
+@test "server/Role: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "server/ClusterRole: disabled with global.enabled=false" {
+@test "server/Role: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "server/ClusterRole: can be enabled with global.enabled=false" {
+@test "server/Role: can be enabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'global.enabled=false' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
@@ -32,20 +32,20 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "server/ClusterRole: disabled with server.enabled=false" {
+@test "server/Role: disabled with server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "server/ClusterRole: enabled with server.enabled=true" {
+@test "server/Role: enabled with server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -53,10 +53,10 @@ load _helpers
 }
 
 # The rules key must always be set (#178).
-@test "server/ClusterRole: rules empty with server.enabled=true" {
+@test "server/Role: rules empty with server.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
       yq '.rules' | tee /dev/stderr)
@@ -66,10 +66,10 @@ load _helpers
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 
-@test "server/ClusterRole: podsecuritypolicies are added when global.enablePodSecurityPolicies is true" {
+@test "server/Role: podsecuritypolicies are added when global.enablePodSecurityPolicies is true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrole.yaml  \
+      -x templates/server-role.yaml  \
       --set 'server.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |

--- a/test/unit/server-rolebinding.bats
+++ b/test/unit/server-rolebinding.bats
@@ -2,49 +2,49 @@
 
 load _helpers
 
-@test "server/ClusterRoleBinding: enabled by default" {
+@test "server/RoleBinding: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrolebinding.yaml  \
+      -x templates/server-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "server/ClusterRoleBinding: disabled with global.enabled=false" {
+@test "server/RoleBinding: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrolebinding.yaml  \
+      -x templates/server-rolebinding.yaml  \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "server/ClusterRoleBinding: disabled with server disabled" {
+@test "server/RoleBinding: disabled with server disabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrolebinding.yaml  \
+      -x templates/server-rolebinding.yaml  \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "server/ClusterRoleBinding: enabled with server enabled" {
+@test "server/RoleBinding: enabled with server enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrolebinding.yaml  \
+      -x templates/server-rolebinding.yaml  \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "server/ClusterRoleBinding: enabled with server enabled and global.enabled=false" {
+@test "server/RoleBinding: enabled with server enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-clusterrolebinding.yaml  \
+      -x templates/server-rolebinding.yaml  \
       --set 'global.enabled=false' \
       --set 'server.enabled=true' \
       . | tee /dev/stderr |


### PR DESCRIPTION
It is not necessary to use ClusterRoles for all server components as they operate within a singular namespace, we can instead use Role/RoleBinding.

This PR : 
1. Changes ClusterRole/Binding to Role/Binding for server-acl-* and server-role/binding templates
2. Renames the template files accordingly
3. Modifies bats unit tests to point to the new template names and renames them accordingly

This partially addresses #403, and is a follow-on to PR #498
