### PR TITLE
remove enterprise license cluster roles

### DIFF
--- a/templates/enterprise-license-role.yaml
+++ b/templates/enterprise-license-role.yaml
@@ -1,9 +1,10 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/templates/enterprise-license-rolebinding.yaml
+++ b/templates/enterprise-license-rolebinding.yaml
@@ -17,6 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-enterprise-license
-    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/templates/enterprise-license-rolebinding.yaml
+++ b/templates/enterprise-license-rolebinding.yaml
@@ -1,9 +1,10 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -11,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "consul.fullname" . }}-enterprise-license
 subjects:
   - kind: ServiceAccount

--- a/test/unit/enterprise-license-role.bats
+++ b/test/unit/enterprise-license-role.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "enterpriseLicense/ClusterRole: disabled by default" {
+@test "enterpriseLicense/Role: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRole: disabled with server=false, ent secret defined" {
+@test "enterpriseLicense/Role: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
@@ -23,30 +23,30 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRole: disabled when ent secretName missing" {
+@test "enterpriseLicense/Role: disabled when ent secretName missing" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRole: disabled when ent secretKey missing" {
+@test "enterpriseLicense/Role: disabled when ent secretKey missing" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRole: enabled when ent license defined" {
+@test "enterpriseLicense/Role: enabled when ent license defined" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
@@ -54,10 +54,10 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "enterpriseLicense/ClusterRole: rules are empty if global.acls.manageSystemACLs and global.enablePodSecurityPolicies are false" {
+@test "enterpriseLicense/Role: rules are empty if global.acls.manageSystemACLs and global.enablePodSecurityPolicies are false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
@@ -68,10 +68,10 @@ load _helpers
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 
-@test "enterpriseLicense/ClusterRole: allows acl token when global.acls.manageSystemACLs is true" {
+@test "enterpriseLicense/Role: allows acl token when global.acls.manageSystemACLs is true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
@@ -84,10 +84,10 @@ load _helpers
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 
-@test "enterpriseLicense/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+@test "enterpriseLicense/Role: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrole.yaml  \
+      -x templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       --set 'global.enablePodSecurityPolicies=true' \

--- a/test/unit/enterprise-license-rolebinding.bats
+++ b/test/unit/enterprise-license-rolebinding.bats
@@ -2,19 +2,19 @@
 
 load _helpers
 
-@test "enterpriseLicense/ClusterRoleBinding: disabled by default" {
+@test "enterpriseLicense/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      -x templates/enterprise-license-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: disabled with server=false, ent secret defined" {
+@test "enterpriseLicense/RoleBinding: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      -x templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
@@ -23,30 +23,30 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: disabled when ent secretName missing" {
+@test "enterpriseLicense/RoleBinding: disabled when ent secretName missing" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      -x templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: disabled when ent secretKey missing" {
+@test "enterpriseLicense/RoleBinding: disabled when ent secretKey missing" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      -x templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "enterpriseLicense/ClusterRoleBinding: enabled when ent license defined" {
+@test "enterpriseLicense/RoleBinding: enabled when ent license defined" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/enterprise-license-clusterrolebinding.yaml  \
+      -x templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |


### PR DESCRIPTION
It is not necessary to use ClusterRoles for enterprise license components as they operate within a singular namespace, we can instead use Role/RoleBinding.

This PR :

Changes ClusterRole/Binding to Role/Binding for enterprise-license-role* templates
Renames the template files accordingly
Modifies bats unit tests to point to the new template names and renames them accordingly

This partially addresses #403, and is a follow-on to PR #498