### PR TITLE
allow to disable fsgroup, when installing to openshift

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -54,8 +54,10 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "consul.fullname" . }}-server
+      {{- if not .Values.server.disableFsGroupSecurityContext }}
       securityContext:
         fsGroup: 1000
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -390,6 +390,29 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# server.disableFsGroupSecurityContext
+
+@test "server/StatefulSet: can disable fsGroup security context settings" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.disableFsGroupSecurityContext=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/StatefulSet: default fsGroup security context settings fsGroup: 1000" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.disableFsGroupSecurityContext=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+  [ "${actual}" = "1000" ]
+}
+
+#--------------------------------------------------------------------
 # gossip encryption
 
 @test "server/StatefulSet: gossip encryption disabled in server StatefulSet by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -344,6 +344,10 @@ server:
     # https_proxy: http://localhost:3128,
     # no_proxy: internal.domain.com
 
+  # disableFsGroupSecurityContext disables setting the fsGroup securityContext for the server statefulset,
+  # this is required when using the OpenShift platform as fsGroup is automatically set to an arbitrary gid.
+  disableFsGroupSecurityContext : false
+
 # Configuration for Consul servers when the servers are running outside of Kubernetes.
 # When running external servers, configuring these values is recommended
 # if setting global.tls.enableAutoEncrypt to true (requires consul-k8s >= 0.13.0)


### PR DESCRIPTION
When trying to install this chart to OpenShift, the StatefulSet fails, since the fsGroup is set by default to 1000, which is not valid in OpenShift by default.

Adding this option allows the fsGroup not to be set, when running in OpenShift.