### PR TITLE
Pass extraVolumes last for -config-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+IMPROVEMENTS:
+
+* The volumes set by `client.extraVolumes` are now passed as the last `-config-dir` argument.
+  This means any settings there will override previous settings. This allows users to override
+  settings that Helm is setting automatically, for example the acl down policy. [[GH-531](https://github.com/hashicorp/consul-helm/pull/531)]
+
 ## 0.22.0 (June 18, 2020)
 
 FEATURES:

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -196,13 +196,16 @@ spec:
                 -hcl='ports { grpc = 8502 }' \
                 {{- end }}
                 -config-dir=/consul/config \
+                {{- if .Values.global.acls.manageSystemACLs }}
+                -config-dir=/consul/aclconfig \
+                {{- end }}
+                {{- /* Always include the extraVolumes at the end so that users can
+                      override other Consul settings. The last -config-dir takes
+                      precedence. */}}
                 {{- range .Values.client.extraVolumes }}
                 {{- if .load }}
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
-                {{- end }}
-                {{- if .Values.global.acls.manageSystemACLs }}
-                -config-dir=/consul/aclconfig \
                 {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
                 -data-dir=/consul/data \

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -156,6 +156,9 @@ spec:
                 {{- end }}
                 -client=0.0.0.0 \
                 -config-dir=/consul/config \
+                {{- /* Always include the extraVolumes at the end so that users can
+                    override other Consul settings. The last -config-dir takes
+                    precedence. */}}
                 {{- range .Values.server.extraVolumes }}
                 {{- if .load }}
                 -config-dir=/consul/userconfig/{{ .name }} \


### PR DESCRIPTION
This will allow user-defined config to override any config set in the
helm-created config map because Consul will override previous
configuration with the last -config-dir.

For example, this user (https://github.com/hashicorp/consul-k8s/pull/220) wants to specify the `"acl": {"down_policy": "your-policy"}` config which is set in `/consul/aclconfig` by the helm chart (technically it's written by `consul-k8s acl-init`). By swapping the ordering here, they can now create their own configmap which sets
```
"acl": {"down_policy": "their-policy"}
```

and pass it in via

```yaml
client:
  extraVolumes:
  - type: configMap
     name: my-config-map
     load: true
```

And that single key will be overridden.

Fixes https://github.com/hashicorp/consul-k8s/pull/220