### PR TITLE
refactor resource requests and limits for init containers and lifecycle sidecar

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -138,6 +138,34 @@ spec:
                 {{- if not (kindIs "invalid" $resources.requests.cpu) }}
                 -default-sidecar-proxy-cpu-request={{ $resources.requests.cpu }} \
                 {{- end }}
+                {{- $resources := .Values.global.initCopyContainerResources.resources }}
+                {{- /* kindIs is used here to differentiate between null and 0 */}}
+                {{- if not (kindIs "invalid" $resources.limits.memory) }}
+                -init-copy-container-memory-limit={{ $resources.limits.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.memory) }}
+                -init-copy-container-memory-request={{ $resources.requests.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.limits.cpu) }}
+                -init-copy-container-cpu-limit={{ $resources.limits.cpu }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.cpu) }}
+                -init-copy-container-cpu-request={{ $resources.requests.cpu }} \
+                {{- end }}
+                {{- $resources := .Values.global.lifecycleSidecarContainerResources.resources }}
+                {{- /* kindIs is used here to differentiate between null and 0 */}}
+                {{- if not (kindIs "invalid" $resources.limits.memory) }}
+                -lifecycle-sidecar-memory-limit={{ $resources.limits.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.memory) }}
+                -lifecycle-sidecar-memory-request={{ $resources.requests.memory }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.limits.cpu) }}
+                -lifecycle-sidecar-cpu-limit={{ $resources.limits.cpu }} \
+                {{- end }}
+                {{- if not (kindIs "invalid" $resources.requests.cpu) }}
+                -lifecycle-sidecar-cpu-request={{ $resources.requests.cpu }} \
+                {{- end }}
           livenessProbe:
             httpGet:
               path: /health/ready

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -138,22 +138,20 @@ spec:
                 {{- if not (kindIs "invalid" $resources.requests.cpu) }}
                 -default-sidecar-proxy-cpu-request={{ $resources.requests.cpu }} \
                 {{- end }}
-                {{- $resources := .Values.global.initCopyContainerResources.resources }}
-                {{- /* kindIs is used here to differentiate between null and 0 */}}
+                {{- $resources := .Values.global.initContainer.resources }}
                 {{- if not (kindIs "invalid" $resources.limits.memory) }}
-                -init-copy-container-memory-limit={{ $resources.limits.memory }} \
+                -init-container-memory-limit={{ $resources.limits.memory }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $resources.requests.memory) }}
-                -init-copy-container-memory-request={{ $resources.requests.memory }} \
+                -init-container-memory-request={{ $resources.requests.memory }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $resources.limits.cpu) }}
-                -init-copy-container-cpu-limit={{ $resources.limits.cpu }} \
+                -init-container-cpu-limit={{ $resources.limits.cpu }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $resources.requests.cpu) }}
-                -init-copy-container-cpu-request={{ $resources.requests.cpu }} \
+                -init-container-cpu-request={{ $resources.requests.cpu }} \
                 {{- end }}
-                {{- $resources := .Values.global.lifecycleSidecarContainerResources.resources }}
-                {{- /* kindIs is used here to differentiate between null and 0 */}}
+                {{- $resources := .Values.global.lifecycleSidecarContainer.resources }}
                 {{- if not (kindIs "invalid" $resources.limits.memory) }}
                 -lifecycle-sidecar-memory-limit={{ $resources.limits.memory }} \
                 {{- end }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -110,6 +110,9 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          {{- if ( default $root.Values.global.initCopyContainerResources .resources) }}
+          resources: {{ toYaml (default $root.Values.global.initCopyContainerResources.resources .resources) | nindent 12 }}
+          {{- end }}
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
@@ -260,8 +263,7 @@ spec:
         - name: ingress-gateway
           image: {{ $root.Values.global.imageEnvoy | quote }}
           {{- if (default $defaults.resources .resources) }}
-          resources:
-            {{ toYaml (default $defaults.resources .resources) | nindent 12 }}
+          resources: {{ toYaml (default $defaults.resources .resources) | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: consul-bin

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -110,9 +110,7 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
-          {{- if ( default $root.Values.global.initCopyContainerResources .resources) }}
-          resources: {{ toYaml (default $root.Values.global.initCopyContainerResources.resources .resources) | nindent 12 }}
-          {{- end }}
+          resources: {{ toYaml $root.Values.global.initContainer.resources | nindent 12 }}
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
@@ -375,6 +373,7 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
+          resources: {{ toYaml $root.Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -90,13 +90,10 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          {{- if ( default .Values.global.initCopyContainerResources .resources) }}
           resources:
-            requests:
-              memory: "25Mi"
-              cpu: "50m"
-            limits:
-              memory: "25Mi"
-              cpu: "50m"
+            {{ toYaml (default .Values.global.initCopyContainerResources .resources) | nindent 12 }}
+          {{- end }}
         {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" . | nindent 8 }}
         {{- end }}
@@ -356,13 +353,10 @@ spec:
             {{- if .Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
+          {{- if ( default .Values.global.lifecycleSidecarContainerResources .resources) }}
           resources:
-            requests:
-              memory: "25Mi"
-              cpu: "10m"
-            limits:
-              memory: "25Mi"
-              cpu: "10m"
+            {{ toYaml (default .Values.global.lifecycleSidecarContainerResources .resources) | nindent 12 }}
+          {{- end }}
       {{- if .Values.meshGateway.priorityClassName }}
       priorityClassName: {{ .Values.meshGateway.priorityClassName | quote }}
       {{- end }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -90,10 +90,7 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
-          {{- if ( default .Values.global.initCopyContainerResources .resources) }}
-          resources:
-            {{ toYaml (default .Values.global.initCopyContainerResources .resources) | nindent 12 }}
-          {{- end }}
+          resources: {{ toYaml .Values.global.initContainer.resources | nindent 12 }}
         {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" . | nindent 8 }}
         {{- end }}
@@ -327,6 +324,7 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
+          resources: {{ toYaml .Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -124,6 +124,10 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          {{- if ( default $root.Values.global.initCopyContainerResources .resources) }}
+          resources:
+            {{ toYaml (default $root.Values.global.initCopyContainerResources .resources) | nindent 12 }}
+          {{- end }}
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -124,10 +124,7 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
-          {{- if ( default $root.Values.global.initCopyContainerResources .resources) }}
-          resources:
-            {{ toYaml (default $root.Values.global.initCopyContainerResources .resources) | nindent 12 }}
-          {{- end }}
+          resources: {{ toYaml $root.Values.global.initContainer.resources | nindent 12 }}
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
@@ -323,6 +320,7 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
+          resources: {{ toYaml $root.Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -920,6 +920,104 @@ load _helpers
   [ "${actual}" = '{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
 }
 
+@test "connectInject/Deployment: default init and sidecar container resources" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-memory-request=25Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-cpu-request=50m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-memory-limit=125Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-cpu-limit=50m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-memory-request=25Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-cpu-request=20m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-memory-limit=25Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-cpu-limit=20m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+@test "connectInject/Deployment: can set init container resources" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.initContainer.resources.requests.memory=100Mi' \
+      --set 'global.initContainer.resources.requests.cpu=100m' \
+      --set 'global.initContainer.resources.limits.memory=200Mi' \
+      --set 'global.initContainer.resources.limits.cpu=200m' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-memory-request=100Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-cpu-request=100m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-memory-limit=200Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-init-container-cpu-limit=200m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: lifecycle sidecar container resources" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.lifecycleSidecarContainer.resources.requests.memory=100Mi' \
+      --set 'global.lifecycleSidecarContainer.resources.requests.cpu=100m' \
+      --set 'global.lifecycleSidecarContainer.resources.limits.memory=200Mi' \
+      --set 'global.lifecycleSidecarContainer.resources.limits.cpu=200m' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-memory-request=100Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-cpu-request=100m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-memory-limit=200Mi"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-lifecycle-sidecar-cpu-limit=200m"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # sidecarProxy.resources
 

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -446,6 +446,36 @@ load _helpers
   [ "${actual}" = "gwcpu2" ]
 }
 
+@test "ingressGateways/Deployment: init container has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "125Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "50m" ]
+}
+
+@test "ingressGateways/Deployment: lifecycle sidecar has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "20m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "20m" ]
+}
+
 #--------------------------------------------------------------------
 # affinity
 

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -295,6 +295,36 @@ key2: value2' \
   [ "${actual}" = "bar" ]
 }
 
+@test "meshGateway/Deployment: init container has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "125Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "50m" ]
+}
+
+@test "meshGateway/Deployment: lifecycle sidecar has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "20m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "20m" ]
+}
+
 #--------------------------------------------------------------------
 # containerPort
 

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -506,6 +506,36 @@ load _helpers
   [ "${actual}" = "gwcpu2" ]
 }
 
+@test "terminatingGateways/Deployment: init container has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "125Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "50m" ]
+}
+
+@test "terminatingGateways/Deployment: lifecycle sidecar has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "20m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "20m" ]
+}
+
 #--------------------------------------------------------------------
 # affinity
 

--- a/values.yaml
+++ b/values.yaml
@@ -219,8 +219,11 @@ global:
     # Requires consul-k8s 0.15.0+.
     createFederationSecret: false
 
-  # Resource settings for lifecycle-sidecar containers
-  lifecycleSidecarContainerResources:
+  # Resource settings for lifecycle-sidecar containers.
+  # The lifecycle sidecar ensures the Consul services are always registered with
+  # their local consul clients and is used by the ingress/terminating/mesh gateways
+  # as well as with every connect-injected service.
+  lifecycleSidecarContainer:
     resources:
       requests:
         memory: "25Mi"
@@ -229,10 +232,11 @@ global:
         memory: "25Mi"
         cpu: "20m"
 
-  # Resource settings for copy-consul-bin init containers.
-  # these settings are bounded by the size of the consul binary
-  # as we issue a cp of it during the init container.
-  initCopyContainerResources:
+  # Resource settings for copy-consul-bin init containers which are used by the
+  # ingress/terminating/mesh gateways.
+  # These settings are bounded by the size of the consul binary
+  # as we use `cp` to copy it into a shared volume in the init container.
+  initContainer:
     resources:
       requests:
         memory: "25Mi"

--- a/values.yaml
+++ b/values.yaml
@@ -219,6 +219,28 @@ global:
     # Requires consul-k8s 0.15.0+.
     createFederationSecret: false
 
+  # Resource settings for lifecycle-sidecar containers
+  lifecycleSidecarContainerResources:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "20m"
+      limits:
+        memory: "25Mi"
+        cpu: "20m"
+
+  # Resource settings for copy-consul-bin init containers.
+  # these settings are bounded by the size of the consul binary
+  # as we issue a cp of it during the init container.
+  initCopyContainerResources:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "50m"
+      limits:
+        memory: "125Mi"
+        cpu: "50m"
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.


### PR DESCRIPTION
We now define resources for the connect inject init copy container in values.yaml and standardize usage of CPU Limit/Request and Memory Limit/Request for it across the ingress/terminating/mesh gateways and connect-inject deployments via new entries in the values.yaml file.

These are passed in as command line arguments to consul-k8s and are thereby are now configurable.
This PR resolves #515 and resolves #529 by increasing the default cpu request+limit and memory limit, respectively, making them configurable to the user.
