### PR TITLE
Update resource settings for the lifecycle sidecar and init containers for the gateway deployment templates

### DIFF
--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -110,6 +110,13 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          resources:
+            requests:
+              memory: "25Mi"
+              cpu: "50m"
+            limits:
+              memory: "125Mi"
+              cpu: "50m"
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
@@ -399,6 +406,13 @@ spec:
             {{- if $root.Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
+          resources:
+            requests:
+              memory: "25Mi"
+              cpu: "20m"
+            limits:
+              memory: "25Mi"
+              cpu: "20m"
       {{- if (default $defaults.priorityClassName .priorityClassName) }}
       priorityClassName: {{ default $defaults.priorityClassName .priorityClassName | quote }}
       {{- end }}

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -115,7 +115,7 @@ spec:
               memory: "25Mi"
               cpu: "50m"
             limits:
-              memory: "125Mi"
+              memory: "150Mi"
               cpu: "50m"
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -95,7 +95,7 @@ spec:
               memory: "25Mi"
               cpu: "50m"
             limits:
-              memory: "125Mi"
+              memory: "150Mi"
               cpu: "50m"
         {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" . | nindent 8 }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -95,7 +95,7 @@ spec:
               memory: "25Mi"
               cpu: "50m"
             limits:
-              memory: "25Mi"
+              memory: "125Mi"
               cpu: "50m"
         {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" . | nindent 8 }}
@@ -359,10 +359,10 @@ spec:
           resources:
             requests:
               memory: "25Mi"
-              cpu: "10m"
+              cpu: "20m"
             limits:
               memory: "25Mi"
-              cpu: "10m"
+              cpu: "20m"
       {{- if .Values.meshGateway.priorityClassName }}
       priorityClassName: {{ .Values.meshGateway.priorityClassName | quote }}
       {{- end }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -124,6 +124,13 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          resources:
+            requests:
+              memory: "25Mi"
+              cpu: "50m"
+            limits:
+              memory: "125Mi"
+              cpu: "50m"
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
@@ -345,6 +352,13 @@ spec:
             {{- if $root.Values.global.acls.manageSystemACLs }}
             - -token-file=/consul/service/acl-token
             {{- end }}
+          resources:
+            requests:
+              memory: "25Mi"
+              cpu: "20m"
+            limits:
+              memory: "25Mi"
+              cpu: "20m"
       {{- if (default $defaults.priorityClassName .priorityClassName) }}
       priorityClassName: {{ (default $defaults.priorityClassName .priorityClassName) | quote }}
       {{- end }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -129,7 +129,7 @@ spec:
               memory: "25Mi"
               cpu: "50m"
             limits:
-              memory: "125Mi"
+              memory: "150Mi"
               cpu: "50m"
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}


### PR DESCRIPTION
currently the gateways do not have resource settings for their lifecycle sidecars and the resource settings for the init container which issues a `cp` of the consul binary has resource settings which are too low.

This PR : 
1. adds the resource settings for the lifecycle sidecar, increases the lifecycle sidecar cpu settings from `10m` to `20m`
2. adds the resource settings for the init container which copies the consul bin and increases the memory limits  only from the respective pod deployments to `150Mi` only for the init container.