### PR TITLE
Remove single quotes in TLS Creation

### DIFF
--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -84,8 +84,8 @@ spec:
                 {{- end }}
                 -additional-dnsname='{{ template "consul.fullname" . }}-server' \
                 -additional-dnsname='*.{{ template "consul.fullname" . }}-server' \
-                -additional-dnsname="'*.{{ template "consul.fullname" . }}-server.${NAMESPACE}'" \
-                -additional-dnsname="'*.{{ template "consul.fullname" . }}-server.${NAMESPACE}.svc'" \
+                -additional-dnsname="*.{{ template "consul.fullname" . }}-server.${NAMESPACE}" \
+                -additional-dnsname="*.{{ template "consul.fullname" . }}-server.${NAMESPACE}.svc" \
                 -additional-dnsname='*.server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }}' \
                 {{- range .Values.global.tls.serverAdditionalIPSANs }}
                 -additional-ipaddress={{ . }} \


### PR DESCRIPTION
When enabling TLS got the following error in the  `consul-server-acl-init` Job:

```
2020-07-10T08:48:47.070317259Z 2020-07-10T08:48:47.070Z [ERROR] Failure: calling /agent/self to get datacenter: err="Get "https://consul-server-0.consul-server.consul.svc:8501/v1/agent/self": x509: certificate is valid for consul-server, *.consul-server, '*.consul-server.consul', '*.consul-server.consul.svc', *.server.dc1.consul, server.dc1.consul, localhost, not consul-server-0.consul-server.consul.svc"
2020-07-10T08:48:47.07034817Z 2020-07-10T08:48:47.070Z [INFO]  Retrying in 1s
```

After digging in, I noticed the Cert that is being generated contains single quotes. and that's why it wont match. 

```
DNS Name: consul-server
DNS Name: *.consul-server
DNS Name: '*.consul-server.consul'  <------------
DNS Name: '*.consul-server.consul.svc'  <------------
DNS Name: *.server.dc1.consul
DNS Name: server.dc1.consul
DNS Name: localhost
IP Address: 127.0.0.1
````