### PR TITLE
Annotate deployments with hashed extraconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENTS:
   StatefulSet and Client Daemonset annotations respectively. This recreates
   the server/client pod when the server/client extraConfig is updated via `helm upgrade` [[GH-550](https://github.com/hashicorp/consul-helm/pull/550)]
 
-BREAKING CHANGESL
+BREAKING CHANGES:
 
 * Updating either server.extraConfig or client.extraConfig and running `helm upgrade` will force a restart of the
   server or agent pods respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+IMPROVEMENTS:
+
+* Add server.extraConfig and client.extraConfig values as hashes on Server
+  StatefulSet and Client Daemonset annotations respectively. This recreates
+  the server/client pod when the server/client extraConfig is updated via `helm upgrade` [[GH-550](https://github.com/hashicorp/consul-helm/pull/550)]
+
+BREAKING CHANGESL
+
+* Updating either server.extraConfig or client.extraConfig and running `helm upgrade` will force a restart of the
+  server or agent pods respectively.
+
 ## 0.23.1 (July 10, 2020)
 
 BUG FIXES:

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        "consul.hashicorp.com/config-checksum": {{ .Values.client.extraConfig | sha256sum }}
         {{- if .Values.client.annotations }}
           {{- tpl .Values.client.annotations . | nindent 8 }}
         {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -40,6 +40,7 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        "consul.hashicorp.com/config-checksum": {{ .Values.server.extraConfig | sha256sum }}
         {{- if .Values.server.annotations }}
           {{- tpl .Values.server.annotations . | nindent 8 }}
         {{- end }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -355,7 +355,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
   [ "${actual}" = "{}" ]
 }
 
@@ -367,6 +367,28 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# extraConfig
+
+@test "client/DaemonSet: adds config-checksum annotation when extraConfig is blank" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  [ "${actual}" = ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356 ]
+}
+
+@test "client/DaemonSet: adds config-checksum annotation when extraConfig is provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.extraConfig="{\"hello\": \"world\"}"' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  [ "${actual}" = 83df36fdaf1b4acb815f1764f9ff2782c520ca012511f282ba9c57a04401a239 ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -353,7 +353,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject")' | tee /dev/stderr)
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
   [ "${actual}" = "{}" ]
 }
 
@@ -365,6 +365,27 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
+}
+#--------------------------------------------------------------------
+# extraConfig
+
+@test "server/StatefulSet: adds config-checksum annotation when extraConfig is blank" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  [ "${actual}" = ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356 ]
+}
+
+@test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.extraConfig="{\"hello\": \"world\"}"' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  [ "${actual}" = 83df36fdaf1b4acb815f1764f9ff2782c520ca012511f282ba9c57a04401a239 ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
When the extra config for a client or server is updated, it updates the underlying configMap but has no way of informing the server statefulSet or client daemonSet of the update.With this PR, the values for server.extraConfig & client.extraConfig are saved as annotations on the server statefulSet spec and client daemonsetSpec respectfully. If a user updates the extraConfig and performs a `helm upgrade`, it will force a reconcile of the server and client pods (depending on what changed) and will keep them updated with the latest config.

Signed-off-by: Ashwin Venkatesh <ashwin@hashicorp.com>

Testing: 
• Install consul using `helm install` with some values file
• Update `sever.extraConfig` and perform a `helm upgrade` with the file
• Observe `kubectl get pods`. The existing server pod will terminate and a new one will spin up with the updated config. You can compare the value of the annotation "consul.hashicorp.com/config-checksum" before and after the upgrade to see it change.
• Update `client.extraConfig` and perform a `helm upgrade` with the file
• Observe `kubectl get pods`. The existing client pod will terminate and a new one will spin up with the updated config. You can compare the value of the annotation "consul.hashicorp.com/config-checksum" before and after the upgrade to see it change.
• Be in awe.
