### PR TITLE
Add ability to add additional labels to server pods

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -38,6 +38,9 @@ spec:
         release: {{ .Release.Name }}
         component: server
         hasDNS: "true"
+        {{- if .Values.server.podLabels }}
+          {{- tpl .Values.server.podLabels . | nindent 8 }}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         "consul.hashicorp.com/config-checksum": {{ .Values.server.extraConfig | sha256sum }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -38,8 +38,8 @@ spec:
         release: {{ .Release.Name }}
         component: server
         hasDNS: "true"
-        {{- if .Values.server.podLabels }}
-          {{- tpl .Values.server.podLabels . | nindent 8 }}
+        {{- if .Values.server.extraLabels }}
+          {{- tpl .Values.server.extraLabels . | nindent 8 }}
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -39,7 +39,7 @@ spec:
         component: server
         hasDNS: "true"
         {{- if .Values.server.extraLabels }}
-          {{- tpl .Values.server.extraLabels . | nindent 8 }}
+          {{- toYaml .Values.server.extraLabels | nindent 8 }}
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -346,6 +346,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# podLabels
+
+@test "server/StatefulSet: no pod labels defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels | del(."app") | del(."chart") | del(."release") | del(."component") | del(."hasDNS")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "server/StatefulSet: pod labels can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.podLabels=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
 # annotations
 
 @test "server/StatefulSet: no annotations defined by default" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -361,7 +361,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.extraLabels=foo: bar' \
+      --set 'server.extraLabels.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
@@ -371,8 +371,8 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.extraLabels=foo: bar \
-baz: qux' \
+      --set 'server.extraLabels.foo=bar' \
+      --set 'server.extraLabels.baz=qux' \
       . | tee /dev/stderr)
   local actualFoo=$(echo "${actual}" | yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
   local actualBaz=$(echo "${actual}" | yq -r '.spec.template.metadata.labels.baz' | tee /dev/stderr)

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -346,9 +346,9 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# podLabels
+# extraLabels
 
-@test "server/StatefulSet: no pod labels defined by default" {
+@test "server/StatefulSet: no extra labels defined by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
@@ -357,14 +357,27 @@ load _helpers
   [ "${actual}" = "{}" ]
 }
 
-@test "server/StatefulSet: pod labels can be set" {
+@test "server/StatefulSet: extra labels can be set" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.podLabels=foo: bar' \
+      --set 'server.extraLabels=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
+}
+
+@test "server/StatefulSet: multiple extra labels can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.extraLabels=foo: bar \
+baz: qux' \
+      . | tee /dev/stderr)
+  local actualFoo=$(echo "${actual}" | yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  local actualBaz=$(echo "${actual}" | yq -r '.spec.template.metadata.labels.baz' | tee /dev/stderr)
+  [ "${actualFoo}" = "bar" ]
+  [ "${actualBaz}" = "qux" ]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -321,6 +321,13 @@ server:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # Extra labels to attach to the server pods.
+  # This should be a multi-line YAML string.
+  # Example:
+  #   podLabels: |
+  #     "label-key": "label-value"
+  podLabels: null
+
   # Extra annotations to attach to the server pods.
   # This should be a multi-line YAML string.
   # Example:

--- a/values.yaml
+++ b/values.yaml
@@ -324,9 +324,10 @@ server:
   # Extra labels to attach to the server pods.
   # This should be a multi-line YAML string.
   # Example:
-  #   podLabels: |
+  #   extraLabels: |
   #     "label-key": "label-value"
-  podLabels: null
+  #     "other-label-key": "another-label-value"
+  extraLabels: null
 
   # Extra annotations to attach to the server pods.
   # This should be a multi-line YAML string.

--- a/values.yaml
+++ b/values.yaml
@@ -322,11 +322,11 @@ server:
   priorityClassName: ""
 
   # Extra labels to attach to the server pods.
-  # This should be a multi-line YAML string.
+  # This should be a regular YAML map.
   # Example:
-  #   extraLabels: |
-  #     "label-key": "label-value"
-  #     "other-label-key": "another-label-value"
+  #   extraLabels:
+  #     labelKey: "label-value"
+  #     otherLabelKey: "another-label-value"
   extraLabels: null
 
   # Extra annotations to attach to the server pods.


### PR DESCRIPTION
I would like to add the ability to add additional labels to consul-server pods, the same way annotations can be added.

At the company I work for, we use specific Kubernetes pod labels to tell Fluentd which Elasticsearch index should be used to send logs to. With this change I can the additional label :)