### PR TITLE
Customize the DNS service (fixes #545)

### DIFF
--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
 {{- if .Values.dns.type }}
-type: {{ .Values.dns.type }}
+  type: {{ .Values.dns.type }}
 {{- end }}
 {{- if .Values.dns.clusterIP }}
   clusterIP: {{ .Values.dns.clusterIP }}

--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -16,6 +16,9 @@ metadata:
     {{ tpl .Values.dns.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
+{{- if .Values.dns.type }}
+type: {{ .Values.dns.type }}
+{{- end }}
 {{- if .Values.dns.clusterIP }}
   clusterIP: {{ .Values.dns.clusterIP }}
 {{- end }}
@@ -32,4 +35,7 @@ spec:
     app: {{ template "consul.name" . }}
     release: "{{ .Release.Name }}"
     hasDNS: "true"
+{{- if .Values.dns.additionalSpec }}
+{{ tpl .Values.dns.additionalSpec . | nindent 2 | trim }}
+{{- end }}
 {{- end }}

--- a/templates/dns-service.yaml
+++ b/templates/dns-service.yaml
@@ -35,7 +35,7 @@ spec:
     app: {{ template "consul.name" . }}
     release: "{{ .Release.Name }}"
     hasDNS: "true"
-{{- if .Values.dns.additionalSpec }}
-{{ tpl .Values.dns.additionalSpec . | nindent 2 | trim }}
-{{- end }}
+  {{- if .Values.dns.additionalSpec }}
+  {{ tpl .Values.dns.additionalSpec . | nindent 2 | trim }}
+  {{- end }}
 {{- end }}

--- a/test/unit/dns-service.bats
+++ b/test/unit/dns-service.bats
@@ -83,3 +83,38 @@ load _helpers
       yq '.spec | .clusterIP == "192.168.1.1"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# service type
+
+@test "dns/Service: service type ClusterIP by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/dns-service.yaml \
+      . | tee /dev/stderr |
+      yq '.spec | .type == "ClusterIP"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "dns/Service: add custom service type" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/dns-service.yaml \
+      --set dns.type=LoadBalancer \
+      . | tee /dev/stderr |
+      yq '.spec | .type == "LoadBalancer"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# additionalSpec
+
+@test "dns/Service: add additionalSpec" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/dns-service.yaml \
+      --set dns.additionalSpec="loadBalancerIP: 192.168.0.100" \
+      . | tee /dev/stderr |
+      yq '.spec | .loadBalancerIP == "192.168.0.100"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -558,6 +558,11 @@ client:
 dns:
   enabled: "-"
 
+  # type can be used to control the type of service created. For
+  # example, setting this to "LoadBalancer" will create an external load
+  # balancer (for supported K8S installations)
+  type: ClusterIP
+
   # Set a predefined cluster IP for the DNS service.
   # Useful if you need to reference the DNS service's IP
   # address in CoreDNS config.
@@ -567,6 +572,11 @@ dns:
   # This should be a multi-line string of
   # annotations to apply to the dns Service
   annotations: null
+
+  # Additional ServiceSpec values
+  # This should be a multi-line string mapping directly to a Kubernetes
+  # ServiceSpec object.
+  additionalSpec: null
 
 ui:
   # True if you want to enable the Consul UI. The UI will run only


### PR DESCRIPTION
This PR adds some options to enable the customization the DNS service. See #545 for more information.