### PR TITLE
make sync-catalog work with clients disabled

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -76,13 +76,23 @@ spec:
                   key: "token"
             {{- end}}
             {{- if .Values.global.tls.enabled }}
+            {{- if .Values.client.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://$(HOST_IP):8501
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: https://{{ template "consul.fullname" . }}-server:8501
+            {{- end }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
+            {{- if .Values.client.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://{{ template "consul.fullname" . }}-server:8500
+            {{- end }}
             {{- end }}
           {{- if .Values.global.tls.enabled }}
           volumeMounts:

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -762,3 +762,72 @@ load _helpers
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
 }
+
+
+#--------------------------------------------------------------------
+# clients.enabled
+
+@test "syncCatalog/Deployment: HOST_IP is used when client.enabled=true" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "syncCatalog/Deployment: HOST_IP is used when client.enabled=true and global.tls.enabled=true" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+    [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "syncCatalog/Deployment: consul service is used when client.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://release-name-consul-server:8500' ]
+}
+
+@test "syncCatalog/Deployment: consul service is used when client.enabled=false and global.tls.enabled=true" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://release-name-consul-server:8501' ]
+
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+    [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+


### PR DESCRIPTION
Currently sync-catalog won't work when clients are disabled (see #211 ). I'm opening this PR because we have a use case (running multiple consuls) where we disable clients and prefer working with the kubernetes service instead.

The sync-catalog won't work with the clients disabled due to the use of the `HOST_IP` variable. Since the option is given to disable the clients,  I think the logic would go that if the clients are disabled, the sync-catalog talks to the kubernetes service for the consul server instead of interacting through the clients.

It has some duplicate code and I'm not sure if this is the best way, but it has been confirmed to work when deploying our application set.

Feel free to make any suggestions, I mainly want to see #211 resolved.