### PR TITLE
Add terminating gateway tests without ACL/TLS

### DIFF
--- a/test/acceptance/tests/terminating-gateway/fixtures/static-client.yaml
+++ b/test/acceptance/tests/terminating-gateway/fixtures/static-client.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: static-client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-client
+  template:
+    metadata:
+      name: static-client
+      labels:
+        app: static-client
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+        "consul.hashicorp.com/connect-service-upstreams": "example-http:1234"
+    spec:
+      containers:
+        # This name will be the service name in Consul.
+        - name: static-client
+          image: tutum/curl:latest
+          # Just spin & wait forever, we'll use  to demo
+          command: [ "/bin/sh", "-c", "--" ]
+          args: [ "while true; do sleep 30; done;" ]
+       # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client

--- a/test/acceptance/tests/terminating-gateway/main_test.go
+++ b/test/acceptance/tests/terminating-gateway/main_test.go
@@ -1,0 +1,15 @@
+package connect
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-helm/test/acceptance/framework"
+)
+
+var suite framework.Suite
+
+func TestMain(m *testing.M) {
+	suite = framework.NewSuite(m)
+	os.Exit(suite.Run())
+}

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -33,15 +33,17 @@ func TestTerminatingGateway(t *testing.T) {
 
 	// Register the external service
 	t.Log("registering the external service")
-	err := consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
-		Address:           "example.com",
-		Meta:              map[string]string{"external-node": "true", "external-probe": "true"},
-		ID:                "example-http",
-		Name:              "example-http",
-		Port:              80,
-		TaggedAddresses:   nil,
-		EnableTagOverride: false,
-	})
+	_, err := consulClient.Catalog().Register(&api.CatalogRegistration{
+		Node: "legacy_node",
+		//ID:       "example-http",
+		Address:  "example.com",
+		NodeMeta: map[string]string{"external-node": "true", "external-probe": "true"},
+		Service: &api.AgentService{
+			ID:      "example-http",
+			Service: "example-http",
+			Port:    80,
+		},
+	}, &api.WriteOptions{})
 	require.NoError(t, err)
 
 	// Create the config entry for the terminating gateway

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -44,6 +44,7 @@ func TestTerminatingGateway(t *testing.T) {
 			Port:              80,
 			TaggedAddresses:   nil,
 			EnableTagOverride: false,
+		})
 		require.NoError(t, err)
 
 		// Create the config entry for the terminating gateway

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -54,7 +54,7 @@ func TestTerminatingGateway(t *testing.T) {
 			Services: []api.LinkedService{{Name: "example-http"}},
 		}, nil)
 		require.NoError(t, err)
-		require.Equal(t, true, created, "config entry failed")
+		require.True(t, created, "config entry failed")
 
 		k8sClient := env.DefaultContext(t).KubernetesClient(t)
 		k8sOptions := env.DefaultContext(t).KubectlOptions()

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -36,7 +36,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 		// Register the external service
 		t.Log("registering the service")
-		if err := consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
+		err := consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
 			Address:           "example.com",
 			Meta:              map[string]string{"external-node": "true", "external-probe": "true"},
 			ID:                "example",
@@ -44,9 +44,7 @@ func TestTerminatingGateway(t *testing.T) {
 			Port:              80,
 			TaggedAddresses:   nil,
 			EnableTagOverride: false,
-		}); err != nil {
-			require.NoError(t, err)
-		}
+		require.NoError(t, err)
 
 		// Create the config entry for the terminating gateway
 		t.Log("creating config entry")

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -1,0 +1,102 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/hashicorp/consul-helm/test/acceptance/framework"
+	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Test that terminating gateways work in a default installation.
+func TestTerminatingGateway(t *testing.T) {
+	testName := "Terminating GW non-acl"
+	t.Run(testName, func(t *testing.T) {
+		env := suite.Environment()
+
+		helmValues := map[string]string{
+			"connectInject.enabled":                    "true",
+			"terminatingGateways.enabled":              "true",
+			"terminatingGateways.gateways[0].name":     "terminating-gateway",
+			"terminatingGateways.gateways[0].replicas": "1",
+		}
+
+		releaseName := helpers.RandomName()
+		consulCluster := framework.NewHelmCluster(t, helmValues, env.DefaultContext(t), suite.Config(), releaseName)
+
+		consulCluster.Create(t)
+
+		/*t.Log("creating server")
+		createServer(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+		*/
+		// Once the cluster is up register the external service, then create the config entry.
+		consulClient := consulCluster.SetupConsulClient(t, false)
+
+		// Register the external service
+		t.Log("registering the service")
+		if err := consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
+			Address:           "example.com",
+			Meta:              map[string]string{"external-node": "true", "external-probe": "true"},
+			ID:                "example-http",
+			Port:              80,
+			TaggedAddresses:   nil,
+			EnableTagOverride: false,
+		}); err != nil {
+			require.NoError(t, err)
+		}
+
+		var ls []api.LinkedService
+		ls = append(ls, api.LinkedService{
+			Name: "example-http",
+		})
+
+		// Create the config entry for the terminating gateway
+		t.Log("creating config entry")
+		created, _, err := consulClient.ConfigEntries().Set(&api.TerminatingGatewayConfigEntry{
+			Kind:     api.TerminatingGateway,
+			Name:     "terminating-gateway",
+			Services: ls,
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, true, created, "config entry failed")
+
+		k8sClient := env.DefaultContext(t).KubernetesClient(t)
+		k8sOptions := env.DefaultContext(t).KubectlOptions()
+
+		// Deploy the static client
+		t.Log("deploying static client")
+		deployStaticClient(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+
+		// Test that we can make a call from the terminating gateway
+		t.Log("trying calls to terminating gateway")
+		checkConnection(t, k8sOptions, k8sClient)
+	})
+}
+
+// checkConnection checks if static-client can connect through the terminating gateway.
+func checkConnection(t *testing.T, options *k8s.KubectlOptions, client kubernetes.Interface) {
+	pods, err := client.CoreV1().Pods(options.Namespace).List(metav1.ListOptions{LabelSelector: "app=static-client"})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 1)
+	retry.Run(t, func(r *retry.R) {
+		output, err := helpers.RunKubectlAndGetOutputE(t, options, "exec", pods.Items[0].Name, "--",
+			"curl", "-vvvs", "-H", "Host: example.com", "http://localhost:1234/")
+		require.NoError(r, err)
+		require.Contains(r, output, "Example Domain")
+	})
+}
+
+func deployStaticClient(t *testing.T, cfg *framework.TestConfig, options *k8s.KubectlOptions) {
+	helpers.KubectlApply(t, options, "fixtures/static-client.yaml")
+
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		helpers.KubectlDelete(t, options, "fixtures/static-client.yaml")
+	})
+
+	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/static-client")
+}


### PR DESCRIPTION
This PR adds base terminating gateways acceptance tests without ACL/TLS support, the test creates a term gw, registers the services and deploys an application which we test for connectivity.

It largely follows the workflow described in the terminating gateway docs : https://www.consul.io/docs/k8s/connect/terminating-gateways