### PR TITLE
Acceptance tests: Refactor common connect functions to helpers

### DIFF
--- a/test/acceptance/framework/consul_cluster.go
+++ b/test/acceptance/framework/consul_cluster.go
@@ -121,6 +121,8 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 }
 
 func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {
+	t.Helper()
+
 	mergeMaps(h.helmOptions.SetValues, helmValues)
 	helm.Upgrade(t, h.helmOptions, helmChartPath, h.releaseName)
 	helpers.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))

--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -88,11 +88,13 @@ func Deploy(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailure bool, 
 	RunKubectl(t, options, "wait", "--for=condition=available", fmt.Sprintf("deploy/%s", deployment.Name))
 }
 
-// checkConnection execs into a pod of the deployment given by deploymentName
+// CheckStaticServerConnection execs into a pod of the deployment given by deploymentName
 // and runs a curl command with the provided curlArgs.
+// This function assumes that the connection is made to the static-server and expects the output
+// to be "hello world" in a case of success.
 // If expectSuccess is true, it will expect connection to succeed,
 // otherwise it will expect failure due to intentions.
-func CheckConnection(t *testing.T, options *k8s.KubectlOptions, deploymentName string, expectSuccess bool, curlArgs ...string) {
+func CheckStaticServerConnection(t *testing.T, options *k8s.KubectlOptions, deploymentName string, expectSuccess bool, curlArgs ...string) {
 	t.Helper()
 
 	retrier := &retry.Timer{Timeout: 20 * time.Second, Wait: 500 * time.Millisecond}

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -28,7 +28,7 @@ func TestConnectInjectDefault(t *testing.T) {
 	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	t.Log("checking that connection is successful")
-	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
+	helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
 }
 
 // Test that Connect works in a secure installation,
@@ -53,7 +53,7 @@ func TestConnectInjectSecure(t *testing.T) {
 	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	t.Log("checking that the connection is not successful because there's no intention")
-	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", false, "http://localhost:1234")
+	helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(), "static-client", false, "http://localhost:1234")
 
 	consulClient := consulCluster.SetupConsulClient(t, true)
 
@@ -66,5 +66,5 @@ func TestConnectInjectSecure(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("checking that connection is successful")
-	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
+	helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
 }

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -2,42 +2,40 @@ package connect
 
 import (
 	"testing"
-	"time"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework"
 	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // Test that Connect works in a default installation
 func TestConnectInjectDefault(t *testing.T) {
-	env := suite.Environment()
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
 
 	helmValues := map[string]string{
 		"connectInject.enabled": "true",
 	}
 
 	releaseName := helpers.RandomName()
-	consulCluster := framework.NewHelmCluster(t, helmValues, env.DefaultContext(t), suite.Config(), releaseName)
+	consulCluster := framework.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 
 	consulCluster.Create(t)
 
 	t.Log("creating static-server and static-client deployments")
-	createServerAndClient(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	t.Log("checking that connection is successful")
-	checkConnection(t, env.DefaultContext(t).KubectlOptions(), env.DefaultContext(t).KubernetesClient(t), true)
+	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
 }
 
 // Test that Connect works in a secure installation,
-// with ACLs and TLS enabled
+// with ACLs and TLS enabled.
 func TestConnectInjectSecure(t *testing.T) {
-	env := suite.Environment()
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
 
 	helmValues := map[string]string{
 		"connectInject.enabled":        "true",
@@ -46,15 +44,16 @@ func TestConnectInjectSecure(t *testing.T) {
 	}
 
 	releaseName := helpers.RandomName()
-	consulCluster := framework.NewHelmCluster(t, helmValues, env.DefaultContext(t), suite.Config(), releaseName)
+	consulCluster := framework.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 
 	consulCluster.Create(t)
 
 	t.Log("creating static-server and static-client deployments")
-	createServerAndClient(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	t.Log("checking that the connection is not successful because there's no intention")
-	checkConnection(t, env.DefaultContext(t).KubectlOptions(), env.DefaultContext(t).KubernetesClient(t), false)
+	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", false, "http://localhost:1234")
 
 	consulClient := consulCluster.SetupConsulClient(t, true)
 
@@ -67,49 +66,5 @@ func TestConnectInjectSecure(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("checking that connection is successful")
-	checkConnection(t, env.DefaultContext(t).KubectlOptions(), env.DefaultContext(t).KubernetesClient(t), true)
-}
-
-// createServerAndClient sets up static-server and static-client
-// deployments that will be talking to each other over Connect.
-func createServerAndClient(t *testing.T, cfg *framework.TestConfig, options *k8s.KubectlOptions) {
-	helpers.KubectlApply(t, options, "fixtures/static-server.yaml")
-	helpers.KubectlApply(t, options, "fixtures/static-client.yaml")
-
-	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-		// Note: this delete command won't wait for pods to be fully terminated.
-		// This shouldn't cause any test pollution because the underlying
-		// objects are deployments, and so when other tests create these
-		// they should have different pod names.
-		helpers.KubectlDelete(t, options, "fixtures/static-server.yaml")
-		helpers.KubectlDelete(t, options, "fixtures/static-client.yaml")
-	})
-
-	// Wait for both deployments
-	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/static-server")
-	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/static-client")
-}
-
-// checkConnection checks if static-client can talk to static-server.
-// If expectSuccess is true, it will expect connection to succeed,
-// otherwise it will expect failure due to intentions.
-func checkConnection(t *testing.T, options *k8s.KubectlOptions, client kubernetes.Interface, expectSuccess bool) {
-	pods, err := client.CoreV1().Pods(options.Namespace).List(metav1.ListOptions{LabelSelector: "app=static-client"})
-	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
-
-	retrier := &retry.Timer{
-		Timeout: 20 * time.Second,
-		Wait:    500 * time.Millisecond,
-	}
-	retry.RunWith(retrier, t, func(r *retry.R) {
-		output, err := helpers.RunKubectlAndGetOutputE(t, options, "exec", pods.Items[0].Name, "-c", "static-client", "--", "curl", "-vvvsSf", "http://127.0.0.1:1234/")
-		if expectSuccess {
-			require.NoError(r, err)
-			require.Contains(r, output, "hello world")
-		} else {
-			require.Error(r, err)
-			require.Contains(r, output, "503 Service Unavailable")
-		}
-	})
+	helpers.CheckConnection(t, ctx.KubectlOptions(), "static-client", true, "http://localhost:1234")
 }

--- a/test/acceptance/tests/connect/fixtures/static-client.yaml
+++ b/test/acceptance/tests/connect/fixtures/static-client.yaml
@@ -20,7 +20,6 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "true"
         "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
-        "consul.hashicorp.com/connect-service-protocol": "http"
     spec:
       containers:
         - name: static-client

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -1,17 +1,13 @@
-package connect
+package ingressgateway
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework"
 	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // Test that ingress gateways work in a default installation and a secure installation.
@@ -19,7 +15,8 @@ func TestIngressGateway(t *testing.T) {
 	for _, secure := range []bool{false, true} {
 		testName := fmt.Sprintf("secure: %t", secure)
 		t.Run(testName, func(t *testing.T) {
-			env := suite.Environment()
+			ctx := suite.Environment().DefaultContext(t)
+			cfg := suite.Config()
 
 			helmValues := map[string]string{
 				"connectInject.enabled":                "true",
@@ -33,17 +30,17 @@ func TestIngressGateway(t *testing.T) {
 			}
 
 			releaseName := helpers.RandomName()
-			consulCluster := framework.NewHelmCluster(t, helmValues, env.DefaultContext(t), suite.Config(), releaseName)
+			consulCluster := framework.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 
 			consulCluster.Create(t)
 
 			t.Log("creating server")
-			createServer(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
 
 			// We use a "bounce" pod so that we can make calls to the ingress gateway
 			// via kubectl exec without needing a route into the cluster from the test machine.
 			t.Log("creating bounce pod")
-			createBouncePod(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/bounce.yaml")
 
 			// With the cluster up, we can create our ingress-gateway config entry.
 			t.Log("creating config entry")
@@ -68,8 +65,7 @@ func TestIngressGateway(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, true, created, "config entry failed")
 
-			k8sClient := env.DefaultContext(t).KubernetesClient(t)
-			k8sOptions := env.DefaultContext(t).KubectlOptions()
+			k8sOptions := ctx.KubectlOptions()
 
 			// If ACLs are enabled, test that intentions prevent connections.
 			if secure {
@@ -77,7 +73,12 @@ func TestIngressGateway(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				t.Log("testing intentions prevent ingress")
-				checkConnection(t, releaseName, k8sOptions, k8sClient, false)
+				helpers.CheckConnection(t,
+					k8sOptions,
+					"bounce",
+					false,
+					"-H", "Host: static-server.ingress.consul",
+					fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
 
 				// Now we create the allow intention.
 				t.Log("creating ingress-gateway => static-server intention")
@@ -92,46 +93,12 @@ func TestIngressGateway(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the bounce pod. It should route to the static-server pod.
 			t.Log("trying calls to ingress gateway")
-			checkConnection(t, releaseName, k8sOptions, k8sClient, true)
+			helpers.CheckConnection(t,
+				k8sOptions,
+				"bounce",
+				true,
+				"-H", "Host: static-server.ingress.consul",
+				fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
 		})
 	}
-}
-
-// checkConnection checks if bounce pod can talk to static-server.
-// If expectSuccess is true, it will expect connection to succeed,
-// otherwise it will expect failure due to intentions.
-func checkConnection(t *testing.T, releaseName string, options *k8s.KubectlOptions, client kubernetes.Interface, expectSuccess bool) {
-	pods, err := client.CoreV1().Pods(options.Namespace).List(metav1.ListOptions{LabelSelector: "app=bounce"})
-	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
-	retry.Run(t, func(r *retry.R) {
-		output, err := helpers.RunKubectlAndGetOutputE(t, options, "exec", pods.Items[0].Name, "--", "curl", "-vvvsSs", "-H", "Host: static-server.ingress.consul", fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
-		if expectSuccess {
-			require.NoError(r, err)
-			require.Contains(r, output, "hello world")
-		} else {
-			require.Error(r, err)
-			require.Contains(r, output, "curl: (52) Empty reply from server")
-		}
-	})
-}
-
-func createServer(t *testing.T, cfg *framework.TestConfig, options *k8s.KubectlOptions) {
-	helpers.KubectlApply(t, options, "fixtures/static-server.yaml")
-
-	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-		helpers.KubectlDelete(t, options, "fixtures/static-server.yaml")
-	})
-
-	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/static-server")
-}
-
-func createBouncePod(t *testing.T, cfg *framework.TestConfig, options *k8s.KubectlOptions) {
-	helpers.KubectlApply(t, options, "fixtures/bounce.yaml")
-
-	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-		helpers.KubectlDelete(t, options, "fixtures/bounce.yaml")
-	})
-
-	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/bounce")
 }

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -73,7 +73,7 @@ func TestIngressGateway(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				t.Log("testing intentions prevent ingress")
-				helpers.CheckConnection(t,
+				helpers.CheckStaticServerConnection(t,
 					k8sOptions,
 					"bounce",
 					false,
@@ -93,7 +93,7 @@ func TestIngressGateway(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the bounce pod. It should route to the static-server pod.
 			t.Log("trying calls to ingress gateway")
-			helpers.CheckConnection(t,
+			helpers.CheckStaticServerConnection(t,
 				k8sOptions,
 				"bounce",
 				true,

--- a/test/acceptance/tests/ingress-gateway/main_test.go
+++ b/test/acceptance/tests/ingress-gateway/main_test.go
@@ -1,4 +1,4 @@
-package connect
+package ingressgateway
 
 import (
 	"os"

--- a/test/acceptance/tests/mesh-gateway/fixtures/static-client.yaml
+++ b/test/acceptance/tests/mesh-gateway/fixtures/static-client.yaml
@@ -20,7 +20,6 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "true"
         "consul.hashicorp.com/connect-service-upstreams": "static-server:1234:dc2"
-        "consul.hashicorp.com/connect-service-protocol": "http"
     spec:
       containers:
         - name: static-client

--- a/test/acceptance/tests/mesh-gateway/fixtures/static-server.yaml
+++ b/test/acceptance/tests/mesh-gateway/fixtures/static-server.yaml
@@ -19,7 +19,6 @@ spec:
         app: static-server
       annotations:
         "consul.hashicorp.com/connect-inject": "true"
-        "consul.hashicorp.com/connect-service-protocol": "http"
     spec:
       containers:
         - name: static-server

--- a/test/acceptance/tests/mesh-gateway/main_test.go
+++ b/test/acceptance/tests/mesh-gateway/main_test.go
@@ -1,6 +1,7 @@
 package meshgateway
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -11,5 +12,10 @@ var suite framework.Suite
 
 func TestMain(m *testing.M) {
 	suite = framework.NewSuite(m)
-	os.Exit(suite.Run())
+	if suite.Config().EnableMultiCluster {
+		os.Exit(suite.Run())
+	} else {
+		fmt.Println("Skipping mesh gateway tests because -enable-multi-cluster is not set")
+		os.Exit(0)
+	}
 }

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -93,7 +93,7 @@ func TestMeshGatewayDefault(t *testing.T) {
 	helpers.Deploy(t, primaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	t.Log("checking that connection is successful")
-	helpers.CheckConnection(t,
+	helpers.CheckStaticServerConnection(t,
 		primaryContext.KubectlOptions(),
 		"static-client",
 		true,
@@ -215,7 +215,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Log("checking that connection is successful")
-			helpers.CheckConnection(t,
+			helpers.CheckStaticServerConnection(t,
 				primaryContext.KubectlOptions(),
 				"static-client",
 				true,

--- a/test/acceptance/tests/sync/fixtures/static-server.yaml
+++ b/test/acceptance/tests/sync/fixtures/static-server.yaml
@@ -17,8 +17,6 @@ spec:
       name: static-server
       labels:
         app: static-server
-      annotations:
-        "consul.hashicorp.com/connect-inject": "true"
     spec:
       containers:
         - name: static-server
@@ -30,3 +28,15 @@ spec:
             - containerPort: 8080
               name: http
       serviceAccountName: static-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-server
+spec:
+  selector:
+    app: static-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/test/acceptance/tests/terminating-gateway/fixtures/static-client.yaml
+++ b/test/acceptance/tests/terminating-gateway/fixtures/static-client.yaml
@@ -19,14 +19,11 @@ spec:
         app: static-client
       annotations:
         "consul.hashicorp.com/connect-inject": "true"
-        "consul.hashicorp.com/connect-service-upstreams": "example-http:1234"
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
     spec:
       containers:
-        # This name will be the service name in Consul.
         - name: static-client
           image: tutum/curl:latest
-          # Just spin & wait forever, we'll use  to demo
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
-       # If ACLs are enabled, the serviceAccountName must match the Consul service name.
       serviceAccountName: static-client

--- a/test/acceptance/tests/terminating-gateway/fixtures/static-server.yaml
+++ b/test/acceptance/tests/terminating-gateway/fixtures/static-server.yaml
@@ -17,8 +17,6 @@ spec:
       name: static-server
       labels:
         app: static-server
-      annotations:
-        "consul.hashicorp.com/connect-inject": "true"
     spec:
       containers:
         - name: static-server
@@ -30,3 +28,15 @@ spec:
             - containerPort: 8080
               name: http
       serviceAccountName: static-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-server
+spec:
+  selector:
+    app: static-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/test/acceptance/tests/terminating-gateway/main_test.go
+++ b/test/acceptance/tests/terminating-gateway/main_test.go
@@ -1,4 +1,4 @@
-package connect
+package terminatinggateway
 
 import (
 	"os"

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -1,21 +1,19 @@
-package connect
+package terminatinggateway
 
 import (
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework"
 	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // Test that terminating gateways work in a default installation.
 func TestTerminatingGateway(t *testing.T) {
-	env := suite.Environment()
+	ctx := suite.Environment().DefaultContext(t)
+	cfg := suite.Config()
+
 	helmValues := map[string]string{
 		"connectInject.enabled":                    "true",
 		"terminatingGateways.enabled":              "true",
@@ -25,22 +23,25 @@ func TestTerminatingGateway(t *testing.T) {
 
 	t.Log("creating consul cluster")
 	releaseName := helpers.RandomName()
-	consulCluster := framework.NewHelmCluster(t, helmValues, env.DefaultContext(t), suite.Config(), releaseName)
+	consulCluster := framework.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 	consulCluster.Create(t)
 
-	// Once the cluster is up register the external service, then create the config entry.
+	// Deploy a static-server that will play the role of an external service
+	t.Log("creating static-server deployment")
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+
+	// Once the cluster is up, register the external service, then create the config entry.
 	consulClient := consulCluster.SetupConsulClient(t, false)
 
 	// Register the external service
 	t.Log("registering the external service")
 	_, err := consulClient.Catalog().Register(&api.CatalogRegistration{
-		Node: "legacy_node",
-		//ID:       "example-http",
-		Address:  "example.com",
+		Node:     "legacy_node",
+		Address:  "static-server",
 		NodeMeta: map[string]string{"external-node": "true", "external-probe": "true"},
 		Service: &api.AgentService{
-			ID:      "example-http",
-			Service: "example-http",
+			ID:      "static-server",
+			Service: "static-server",
 			Port:    80,
 		},
 	}, &api.WriteOptions{})
@@ -51,41 +52,20 @@ func TestTerminatingGateway(t *testing.T) {
 	created, _, err := consulClient.ConfigEntries().Set(&api.TerminatingGatewayConfigEntry{
 		Kind:     api.TerminatingGateway,
 		Name:     "terminating-gateway",
-		Services: []api.LinkedService{{Name: "example-http"}},
+		Services: []api.LinkedService{{Name: "static-server"}},
 	}, nil)
 	require.NoError(t, err)
 	require.True(t, created, "config entry failed")
 
-	k8sClient := env.DefaultContext(t).KubernetesClient(t)
-	k8sOptions := env.DefaultContext(t).KubectlOptions()
-
 	// Deploy the static client
 	t.Log("deploying static client")
-	deployStaticClient(t, suite.Config(), env.DefaultContext(t).KubectlOptions())
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
 
 	// Test that we can make a call to the terminating gateway
 	t.Log("trying calls to terminating gateway")
-	checkConnection(t, k8sOptions, k8sClient)
-}
-
-// checkConnection checks if static-client can connect to the external service through the terminating gateway.
-func checkConnection(t *testing.T, options *k8s.KubectlOptions, client kubernetes.Interface) {
-	pods, err := client.CoreV1().Pods(options.Namespace).List(metav1.ListOptions{LabelSelector: "app=static-client"})
-	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
-	retry.Run(t, func(r *retry.R) {
-		output, err := helpers.RunKubectlAndGetOutputE(t, options, "exec", pods.Items[0].Name, "--",
-			"curl", "-vvvs", "-H", "Host: example.com", "http://localhost:1234/")
-		require.NoError(r, err)
-		require.Contains(r, output, "Example Domain")
-	})
-}
-
-func deployStaticClient(t *testing.T, cfg *framework.TestConfig, options *k8s.KubectlOptions) {
-	helpers.KubectlApply(t, options, "fixtures/static-client.yaml")
-
-	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-		helpers.KubectlDelete(t, options, "fixtures/static-client.yaml")
-	})
-	helpers.RunKubectl(t, options, "wait", "--for=condition=available", "deploy/static-client")
+	helpers.CheckConnection(t,
+		ctx.KubectlOptions(),
+		"static-client",
+		true,
+		"http://localhost:1234")
 }

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -63,7 +63,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 	// Test that we can make a call to the terminating gateway
 	t.Log("trying calls to terminating gateway")
-	helpers.CheckConnection(t,
+	helpers.CheckStaticServerConnection(t,
 		ctx.KubectlOptions(),
 		"static-client",
 		true,


### PR DESCRIPTION
This PR makes the following changes:
* Only run mesh gateway tests when `-enable-multi-cluster` is set
* Use helpers.Deploy for deploying deployments from fixtures
* Use helpers.CheckConnection for checking connections for connect
* Mark helper methods with t.Helper()
* Use static-server in the terminating gateway test instead of the example.com website