### PR TITLE
Update `config-checksum` annotation on config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ IMPROVEMENTS:
 * Updated the default Consul image to `hashicorp/consul:1.9.0`.
 * Updated the default consul-k8s image to `hashicorp/consul-k8s:0.21.0`.
 * Updated the default envoy image to `envoyproxy/envoy-alpine:v1.16.0`.
+* Add Server ConfigMap and Client ConfigMap values as hashes on Server StatefulSet and Client DaemonSet annotations respectively. This recreates
+  the Server/Client Pod when the Server/Client ConfigMap is updated via `helm upgrade`. This updates the previously hashed values of the extraConfig. [[GH-550](https://github.com/hashicorp/consul-helm/pull/550)]
 
 ## 0.26.0 (Nov 12, 2020)
 

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         hasDNS: "true"
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        "consul.hashicorp.com/config-checksum": {{ .Values.client.extraConfig | sha256sum }}
+        "consul.hashicorp.com/config-checksum": {{ include (print $.Template.BasePath "/client-config-configmap.yaml") . | sha256sum }}
         {{- if .Values.client.annotations }}
           {{- tpl .Values.client.annotations . | nindent 8 }}
         {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        "consul.hashicorp.com/config-checksum": {{ .Values.server.extraConfig | sha256sum }}
+        "consul.hashicorp.com/config-checksum": {{ include (print $.Template.BasePath "/server-config-configmap.yaml") . | sha256sum }}
         {{- if .Values.server.annotations }}
           {{- tpl .Values.server.annotations . | nindent 8 }}
         {{- end }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -370,7 +370,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# extraConfig
+# config-configmap
 
 @test "client/DaemonSet: adds config-checksum annotation when extraConfig is blank" {
   cd `chart_dir`
@@ -378,7 +378,11 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356 ]
+  if [[ $(v2) ]]; then
+    [ "${actual}" = c8c40738a067bbeb4392ec038ad3b1a94d3cd747118b62d72825e44246814951 ]
+  else
+    [ "${actual}" = 1cfdb3a2989f349021d0a4beb7d854a1de35b89d45184caf5290c49460955a33 ]
+  fi
 }
 
 @test "client/DaemonSet: adds config-checksum annotation when extraConfig is provided" {
@@ -388,7 +392,25 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 83df36fdaf1b4acb815f1764f9ff2782c520ca012511f282ba9c57a04401a239 ]
+  if [[ $(v2) ]]; then
+    [ "${actual}" = 7e0bc6cb882996b13c2aad2295ea0a3573185456ba8e1770519b86779075da47 ]
+  else
+    [ "${actual}" = d864eda42c5c072921663de14fd9e0593a9ebce192da82a3239e6ded98ff2e8d ]
+  fi
+}
+
+@test "client/DaemonSet: adds config-checksum annotation when client config is updated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  if [[ $(v2) ]]; then
+    [ "${actual}" = ab9a9f78fc78a0c7509ec21d2f270052c556c28a1eceb26e4b40ef0068a34889 ]
+  else
+    [ "${actual}" = 56e95d32e8bc31f566498a05dc8e1e08b2cb049880ce589d2e9143f45308638c ]
+  fi
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -402,7 +402,7 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 #--------------------------------------------------------------------
-# extraConfig
+# config-configmap
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is blank" {
   cd `chart_dir`
@@ -410,7 +410,11 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356 ]
+  if [[ $(v2) ]]; then
+    [ "${actual}" = 5d152ec45fdfa5a4cb95eee6aae027212a5adad08c6904e4089545afea0ab8f3 ]
+  else
+    [ "${actual}" = 355e9f414430ab2464a6948fcd763b4c79b7ad04b382820e77fb977021bbb635 ]
+  fi
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -420,7 +424,25 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 83df36fdaf1b4acb815f1764f9ff2782c520ca012511f282ba9c57a04401a239 ]
+  if [[ $(v2) ]]; then
+    [ "${actual}" = 67ea7116413d1780d84055440a077abffcf5e520c997ddaf002f446bdcf19f0f ]
+  else
+    [ "${actual}" = d6874107a1da35a40f68469b1c8f58e0a8360af511ab931ed84b312dbbc11f45 ]
+  fi
+}
+
+@test "server/StatefulSet: adds config-checksum annotation when config is updated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
+  if [[ $(v2) ]]; then
+    [ "${actual}" = 6519afe07b3c4d5697b92cba372f2aca9852cd4f1899216cd5cf620f46e9c178 ]
+  else
+    [ "${actual}" = 8bd7707a967de94e300c8df78fd0de469c3e0c40d816105f3230c5715febd1c7 ]
+  fi
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
The `config-checksum` annotation on the server-stateful and client-daemonset would previously only updated on changes to their respective extraConfig. This would fail to restart the server when ACL config was updated. The behaviour has been updated to hash the entire contents of the server/client config configmap so that any changes to the configmap will force a recreate of the server/client pods. This will allows consul upgrades to update an insecure install to a secure one.

Fixes https://github.com/hashicorp/consul-helm/issues/579
Fixes #106 

Testing:
helm install consul with `global.acls.manageSystemACLs: false`
update `global.acls.manageSystemACLs: true` and run helm upgrade
upgrades successfully

The above behavior should hold true for all config that is maintained in the `server-config-configmap` and `client-config-configmap`