### PR TITLE
envoy versioning is now set at the global level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENTS:
 * Catalog Sync: Can now be run when Consul clients are disabled. It will make API calls to the Consul servers instead. [[GH-570](https://github.com/hashicorp/consul-helm/pull/570)]
 
 BREAKING CHANGES:
-* `connectInject.imageEnvoy` and `meshGateway.imageEnvoy` have been removed and now inherit `global.imageEnvoy`
+* `connectInject.imageEnvoy` and `meshGateway.imageEnvoy` have been removed and now inherit from `global.imageEnvoy`
   which is now standardized across terminating/ingress/mesh gateways and connectInject.
   `global.imageEnvoy` is now a required parameter. [GH-585](https://github.com/hashicorp/consul-helm/pull/585)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ IMPROVEMENTS:
 * Add `dns.type` and `dns.additionalSpec` settings for changing the DNS service type and adding additional spec. [[GH-555](https://github.com/hashicorp/consul-helm/pull/555)]
 * Catalog Sync: Can now be run when Consul clients are disabled. It will make API calls to the Consul servers instead. [[GH-570](https://github.com/hashicorp/consul-helm/pull/570)]
 
+BREAKING CHANGES:
+* `connectInject.imageEnvoy` and `meshGateway.imageEnvoy` have been removed and now inherit `global.imageEnvoy`
+  which is now standardized across terminating/ingress/mesh gateways and connectInject.
+  `global.imageEnvoy` is now a required parameter. [GH-585](https://github.com/hashicorp/consul-helm/pull/585)
+
 ## 0.24.1 (Aug 10, 2020)
 
 BUG FIXES:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}
-{{ if .Values.connectInject.imageEnvoy -}} {{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" -}} {{ end }}
+{{- if .Values.connectInject.imageEnvoy }}{{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" }}{{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -81,9 +81,7 @@ spec:
               consul-k8s inject-connect \
                 -default-inject={{ .Values.connectInject.default }} \
                 -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
-                {{ if .Values.global.imageEnvoy -}}
                 -envoy-image="{{ .Values.global.imageEnvoy }}" \
-                {{ end -}}
                 -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -listen=:8080 \
                 {{- if .Values.connectInject.overrideAuthMethodName }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}
-{{ if .Values.connectInject.imageEnvoy -}} {{ fail "connectInject.imageEnvoy must be specified in global" -}} {{ end }}
+{{ if .Values.connectInject.imageEnvoy -}} {{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" -}} {{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}
+{{ if .Values.connectInject.imageEnvoy -}} {{ fail "connectInject.imageEnvoy must be specified in global" -}} {{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment
@@ -80,8 +81,8 @@ spec:
               consul-k8s inject-connect \
                 -default-inject={{ .Values.connectInject.default }} \
                 -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
-                {{ if .Values.connectInject.imageEnvoy -}}
-                -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
+                {{ if .Values.global.imageEnvoy -}}
+                -envoy-image="{{ .Values.global.imageEnvoy }}" \
                 {{ end -}}
                 -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -listen=:8080 \

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -2,7 +2,7 @@
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
 {{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
-{{ if .Values.meshGateway.imageEnvoy -}} {{ fail "meshGateway.imageEnvoy must be specified in global" -}} {{ end }}
+{{ if .Values.meshGateway.imageEnvoy -}} {{ fail "meshGateway.imageEnvoy must be specified in global.imageEnvoy" -}} {{ end }}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -2,6 +2,7 @@
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
 {{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
+{{ if .Values.meshGateway.imageEnvoy -}} {{ fail "meshGateway.imageEnvoy must be specified in global" -}} {{ end }}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1
@@ -221,7 +222,7 @@ spec:
               cpu: "50m"
       containers:
         - name: mesh-gateway
-          image: {{ .Values.meshGateway.imageEnvoy | quote }}
+          image: {{ .Values.global.imageEnvoy | quote }}
           {{- if .Values.meshGateway.resources }}
           resources:
             {{- if eq (typeOf .Values.meshGateway.resources) "string" }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -2,7 +2,7 @@
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
 {{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
-{{ if .Values.meshGateway.imageEnvoy -}} {{ fail "meshGateway.imageEnvoy must be specified in global.imageEnvoy" -}} {{ end }}
+{{- if .Values.meshGateway.imageEnvoy }}{{ fail "meshGateway.imageEnvoy must be specified in global.imageEnvoy" }}{{ end -}}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -239,16 +239,15 @@ key2: value2' \
   [ "${actual}" = "envoyproxy/envoy-alpine:v1.14.2" ]
 }
 
-@test "meshGateway/Deployment: envoy image can be set" {
+@test "meshGateway/Deployment: setting meshGateway.imageEnvoy fails" {
   cd `chart_dir`
-  local actual=$(helm template \
+  run helm template \
       -s templates/mesh-gateway-deployment.yaml  \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'meshGateway.imageEnvoy=new/image' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "new/image" ]
+      --set 'meshGateway.imageEnvoy=new/image' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "meshGateway.imageEnvoy must be specified in global" ]]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -55,10 +55,6 @@ global:
   # If using Consul Enterprise namespaces, must be >= 0.12.
   imageK8S: "hashicorp/consul-k8s:0.18.1"
 
-  # imageEnvoy defines the default envoy image to use for ingress and
-  # terminating gateways.
-  imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"
-
   # datacenter is the name of the datacenter that the agents should register
   # as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value
@@ -231,6 +227,13 @@ global:
       limits:
         memory: "50Mi"
         cpu: "20m"
+
+  # The Docker image for envoy to use as the proxy sidecar when performing
+  # Connect injection or using the mesh/terminating/ingress gateways.
+  #. If using Consul 1.7+, the envoy version must be 1.13+.
+  # If not set, the image used depends on the consul-k8s version. For
+  # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"
 
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
@@ -803,12 +806,6 @@ connectInject:
       memory: "50Mi"
       cpu: "50m"
 
-  # The Docker image for envoy to use as the proxy sidecar when performing
-  # Connect injection. If using Consul 1.7+, the envoy version must be 1.13+.
-  # If not set, the image used depends on the consul-k8s version. For
-  # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.
-  imageEnvoy: null
-
   # namespaceSelector is the selector for restricting the webhook to only
   # specific namespaces. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
@@ -1071,9 +1068,6 @@ meshGateway:
 
     # Optional YAML string that will be appended to the Service spec.
     additionalSpec: null
-
-  # Envoy image to use. For Consul v1.7+, Envoy version 1.13+ is required.
-  imageEnvoy: envoyproxy/envoy-alpine:v1.14.2
 
   # If set to true, gateway Pods will run on the host network.
   hostNetwork: false

--- a/values.yaml
+++ b/values.yaml
@@ -230,7 +230,7 @@ global:
 
   # imageEnvoy is the name (and tag) of the Envoy Docker image used for the
   # connect-injected sidecar proxies and the mesh, terminating, and ingress gateways.
-  # If using Consul 1.7+, the envoy version must be 1.13+.
+  # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"
 
 # Server, when enabled, configures a server cluster to run. This should

--- a/values.yaml
+++ b/values.yaml
@@ -230,7 +230,7 @@ global:
 
   # imageEnvoy is the name (and tag) of the Envoy Docker image used for the
   # connect-injected sidecar proxies and the mesh, terminating, and ingress gateways.
-  #. If using Consul 1.7+, the envoy version must be 1.13+.
+  # If using Consul 1.7+, the envoy version must be 1.13+.
   # If not set, the image used depends on the consul-k8s version. For
   # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.
   imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"

--- a/values.yaml
+++ b/values.yaml
@@ -231,8 +231,6 @@ global:
   # imageEnvoy is the name (and tag) of the Envoy Docker image used for the
   # connect-injected sidecar proxies and the mesh, terminating, and ingress gateways.
   # If using Consul 1.7+, the envoy version must be 1.13+.
-  # If not set, the image used depends on the consul-k8s version. For
-  # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.
   imageEnvoy: "envoyproxy/envoy-alpine:v1.14.2"
 
 # Server, when enabled, configures a server cluster to run. This should

--- a/values.yaml
+++ b/values.yaml
@@ -228,8 +228,8 @@ global:
         memory: "50Mi"
         cpu: "20m"
 
-  # The Docker image for envoy to use as the proxy sidecar when performing
-  # Connect injection or using the mesh/terminating/ingress gateways.
+  # imageEnvoy is the name (and tag) of the Envoy Docker image used for the
+  # connect-injected sidecar proxies and the mesh, terminating, and ingress gateways.
   #. If using Consul 1.7+, the envoy version must be 1.13+.
   # If not set, the image used depends on the consul-k8s version. For
   # consul-k8s 0.12.0 the default is envoyproxy/envoy-alpine:v1.13.0.


### PR DESCRIPTION
Remove meshGateway.imageEnvoy and connectInject.imageEnvoy in favour of global.imageEnvoy which is what ingress and terminating gateways use, this will standardize imageEnvoy across all the gateways and connectInject.

Note : we are removing the option to leave `connectInject.imageEnvoy:  "null"` 
