### PR TITLE
Write debug info when tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,11 @@ jobs:
             eval "$(echo export primary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[0]))"
             eval "$(echo export secondary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[1]))"
 
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 20m -enable-multi-cluster \
-              -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 20m -failfast \
+              -enable-multi-cluster \
+              -kubeconfig="$primary_kubeconfig" \
+              -secondary-kubeconfig="$secondary_kubeconfig" \
+              -debug-directory="$TEST_RESULTS/debug"
 
       - store_test_results:
           path: /tmp/test-results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ Below is the list of available flags:
     The Consul image to use for all tests.
 -consul-k8s-image string
     The consul-k8s image to use for all tests.
+-debug-directory
+    The directory where to dump debug information about test runs, such as logs, pod definitions etc. If not provided, a temporary directory will be created by the tests.
 -enable-multi-cluster
     If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -kubeconfig string

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Below is the list of available flags:
 -consul-k8s-image string
     The consul-k8s image to use for all tests.
 -debug-directory
-    The directory where to write debug information about test runs, uch as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
+    The directory where to write debug information about failed test runs, such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
 -enable-multi-cluster
     If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -kubeconfig string
@@ -101,7 +101,7 @@ Below is the list of available flags:
 -namespace string
     The Kubernetes namespace to use for tests. (default "default")
 -no-cleanup-on-failure
-    If true, the tests will not cleanup resources they create when they finish running.Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.
+    If true, the tests will not cleanup Kubernetes resources they create when they finish running.Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.
 -secondary-kubeconfig string
     The path to a kubeconfig file of the secondary k8s cluster. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
 -secondary-kubecontext string

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Below is the list of available flags:
 -consul-k8s-image string
     The consul-k8s image to use for all tests.
 -debug-directory
-    The directory where to dump debug information about test runs, such as logs, pod definitions etc. If not provided, a temporary directory will be created by the tests.
+    The directory where to write debug information about test runs, uch as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
 -enable-multi-cluster
     If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -kubeconfig string

--- a/test/acceptance/framework/config.go
+++ b/test/acceptance/framework/config.go
@@ -15,6 +15,7 @@ type TestConfig struct {
 	ConsulK8SImage string
 
 	NoCleanupOnFailure bool
+	DebugDirectory     string
 }
 
 // HelmValuesFromConfig returns a map of Helm values

--- a/test/acceptance/framework/consul_cluster_test.go
+++ b/test/acceptance/framework/consul_cluster_test.go
@@ -26,6 +26,10 @@ func TestNewHelmCluster(t *testing.T) {
 
 type ctx struct{}
 
+func (c *ctx) Name() string {
+	return ""
+}
+
 func (c *ctx) KubectlOptions() *k8s.KubectlOptions {
 	return &k8s.KubectlOptions{}
 }

--- a/test/acceptance/framework/environment.go
+++ b/test/acceptance/framework/environment.go
@@ -88,19 +88,9 @@ func (k kubernetesContext) KubernetesClient(t *testing.T) kubernetes.Interface {
 		return k.client
 	}
 
-	configPath, err := k.KubectlOptions().GetConfigPath(t)
-	require.NoError(t, err)
-
-	t.Logf("Creating client from config path at %s for context %s", configPath, k.kubeContextName)
-	config, err := k8s.LoadApiClientConfigE(configPath, k.kubeContextName)
-	require.NoError(t, err)
-
-	client, err := kubernetes.NewForConfig(config)
-	require.NoError(t, err)
-
 	k.client = helpers.KubernetesClientFromOptions(t, k.KubectlOptions())
 
-	return client
+	return k.client
 }
 
 func NewContext(namespace, pathToKubeConfig, kubeContextName string) *kubernetesContext {

--- a/test/acceptance/framework/flags.go
+++ b/test/acceptance/framework/flags.go
@@ -53,10 +53,10 @@ func (t *TestFlags) init() {
 	flag.StringVar(&t.flagSecondaryNamespace, "secondary-namespace", "default", "The Kubernetes namespace to use in the secondary k8s cluster.")
 
 	flag.BoolVar(&t.flagNoCleanupOnFailure, "no-cleanup-on-failure", false,
-		"If true, the tests will not cleanup resources they create when they finish running."+
+		"If true, the tests will not cleanup Kubernetes resources they create when they finish running."+
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
 
-	flag.StringVar(&t.flagDebugDirectory, "debug-directory", "", "The directory where to write debug information about test runs, "+
+	flag.StringVar(&t.flagDebugDirectory, "debug-directory", "", "The directory where to write debug information about failed test runs, "+
 		"such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.")
 }
 

--- a/test/acceptance/framework/flags.go
+++ b/test/acceptance/framework/flags.go
@@ -56,8 +56,8 @@ func (t *TestFlags) init() {
 		"If true, the tests will not cleanup resources they create when they finish running."+
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
 
-	flag.StringVar(&t.flagDebugDirectory, "debug-directory", "", "The directory where to dump debug information about test runs, "+
-		"such as logs, pod definitions etc. If not provided, a temporary directory will be created by the tests.")
+	flag.StringVar(&t.flagDebugDirectory, "debug-directory", "", "The directory where to write debug information about test runs, "+
+		"such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.")
 }
 
 func (t *TestFlags) validate() error {

--- a/test/acceptance/framework/flags.go
+++ b/test/acceptance/framework/flags.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"errors"
 	"flag"
-	"io/ioutil"
 	"sync"
 )
 
@@ -70,16 +69,8 @@ func (t *TestFlags) validate() error {
 	return nil
 }
 
-func (t *TestFlags) testConfigFromFlags() (*TestConfig, error) {
+func (t *TestFlags) testConfigFromFlags() *TestConfig {
 	tempDir := t.flagDebugDirectory
-
-	if tempDir == "" {
-		var err error
-		tempDir, err = ioutil.TempDir("", "test")
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	return &TestConfig{
 		Kubeconfig:    t.flagKubeconfig,
@@ -96,5 +87,5 @@ func (t *TestFlags) testConfigFromFlags() (*TestConfig, error) {
 
 		NoCleanupOnFailure: t.flagNoCleanupOnFailure,
 		DebugDirectory:     tempDir,
-	}, nil
+	}
 }

--- a/test/acceptance/framework/suite.go
+++ b/test/acceptance/framework/suite.go
@@ -24,12 +24,8 @@ func NewSuite(m *testing.M) Suite {
 
 	flag.Parse()
 
-	testConfig := flags.testConfigFromFlags()
-
 	return &suite{
 		m:     m,
-		env:   newKubernetesEnvironmentFromConfig(testConfig),
-		cfg:   testConfig,
 		flags: flags,
 	}
 }
@@ -40,6 +36,15 @@ func (s *suite) Run() int {
 		fmt.Printf("Flag validation failed: %s\n", err)
 		return 1
 	}
+
+	testConfig, err := s.flags.testConfigFromFlags()
+	if err != nil {
+		fmt.Printf("Failed to create test config: %s\n", err)
+		return 1
+	}
+
+	s.env = newKubernetesEnvironmentFromConfig(testConfig)
+	s.cfg = testConfig
 
 	return s.m.Run()
 }

--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -164,13 +164,6 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 		contextName := kubernetesContextFromOptions(t, kubectlOptions)
 
-		// Create a temporary directory if one isn't provided.
-		if debugDirectory == "" {
-			var err error
-			debugDirectory, err = ioutil.TempDir("", "consul-test")
-			require.NoError(t, err)
-		}
-
 		// Create a directory for the test
 		testDebugDirectory := filepath.Join(debugDirectory, t.Name(), contextName)
 		require.NoError(t, os.MkdirAll(testDebugDirectory, 0755))

--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -2,14 +2,17 @@ package helpers
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -65,7 +68,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 
 // Deploy creates a Kubernetes deployment by applying configuration stored at filepath,
 // sets up a cleanup function and waits for the deployment to become available.
-func Deploy(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailure bool, filepath string) {
+func Deploy(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailure bool, debugDirectory string, filepath string) {
 	t.Helper()
 
 	KubectlApply(t, options, filepath)
@@ -82,6 +85,7 @@ func Deploy(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailure bool, 
 		// This shouldn't cause any test pollution because the underlying
 		// objects are deployments, and so when other tests create these
 		// they should have different pod names.
+		WritePodsDebugInfoIfFailed(t, options, debugDirectory, labelMapToString(deployment.GetLabels()))
 		KubectlDelete(t, options, filepath)
 	})
 
@@ -147,4 +151,96 @@ func Cleanup(t *testing.T, noCleanupOnFailure bool, cleanup func()) {
 	}
 
 	t.Cleanup(wrappedCleanupFunc)
+}
+
+// WritePodsDebugInfoIfFailed calls kubectl describe and kubectl logs --all-containers
+// on pods filtered by the labelSelector and writes it to the debugDirectory.
+func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions, debugDirectory, labelSelector string) {
+	t.Helper()
+
+	if t.Failed() {
+		// Create k8s client from kubectl options
+		client := KubernetesClientFromOptions(t, kubectlOptions)
+
+		contextName := kubernetesContextFromOptions(t, kubectlOptions)
+
+		// Create a temporary directory if one isn't provided.
+		if debugDirectory == "" {
+			var err error
+			debugDirectory, err = ioutil.TempDir("", "consul-test")
+			require.NoError(t, err)
+		}
+
+		// Create a directory for the test
+		testDebugDirectory := filepath.Join(debugDirectory, t.Name(), contextName)
+		require.NoError(t, os.MkdirAll(testDebugDirectory, 0755))
+
+		t.Logf("dumping logs and pod info for %s to %s", labelSelector, testDebugDirectory)
+		pods, err := client.CoreV1().Pods(kubectlOptions.Namespace).List(metav1.ListOptions{LabelSelector: labelSelector})
+		require.NoError(t, err)
+
+		for _, pod := range pods.Items {
+			// Get logs for each pod, passing the discard logger to make sure secrets aren't printed to test logs.
+			logs, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "logs", "--all-containers=true", pod.Name)
+			require.NoError(t, err)
+
+			// Write logs to file name <pod.Name>.log
+			logFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.log", pod.Name))
+			require.NoError(t, ioutil.WriteFile(logFilename, []byte(logs), 0600))
+
+			// Describe pod
+			desc, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "describe", "pod", pod.Name)
+			require.NoError(t, err)
+
+			// Write pod info to file name <pod.Name>.txt
+			descFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.txt", pod.Name))
+			require.NoError(t, ioutil.WriteFile(descFilename, []byte(desc), 0600))
+		}
+	}
+}
+
+// KubernetesClientFromOptions takes KubectlOptions and returns Kubernetes API client.
+func KubernetesClientFromOptions(t *testing.T, options *k8s.KubectlOptions) kubernetes.Interface {
+	configPath, err := options.GetConfigPath(t)
+	require.NoError(t, err)
+
+	config, err := k8s.LoadApiClientConfigE(configPath, options.ContextName)
+	require.NoError(t, err)
+
+	client, err := kubernetes.NewForConfig(config)
+	require.NoError(t, err)
+
+	return client
+}
+
+// kubernetesContextFromOptions returns the Kubernetes context from options.
+// If context is explicitly set in options, it returns that context.
+// Otherwise, it returns the current context.
+func kubernetesContextFromOptions(t *testing.T, options *k8s.KubectlOptions) string {
+	t.Helper()
+
+	// First, check if context set in options and return that
+	if options.ContextName != "" {
+		return options.ContextName
+	}
+
+	// Otherwise, get current context from config
+	configPath, err := options.GetConfigPath(t)
+	require.NoError(t, err)
+
+	rawConfig, err := k8s.LoadConfigFromPath(configPath).RawConfig()
+	require.NoError(t, err)
+
+	return rawConfig.CurrentContext
+}
+
+// labelMapToString takes a label map[string]string
+// and returns the string-ified version of, e.g app=foo,env=dev.
+func labelMapToString(labelMap map[string]string) string {
+	var labels []string
+	for k, v := range labelMap {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(labels, ",")
 }

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -26,8 +26,8 @@ func TestConnectInjectDefault(t *testing.T) {
 	consulCluster.Create(t)
 
 	t.Log("creating static-server and static-client deployments")
-	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
-	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
+	helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-client.yaml")
 
 	t.Log("checking that connection is successful")
 	helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(), true, staticClientName, "http://localhost:1234")
@@ -67,8 +67,8 @@ func TestConnectInjectSecure(t *testing.T) {
 			consulCluster.Create(t)
 
 			t.Log("creating static-server and static-client deployments")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-client.yaml")
 
 			t.Log("checking that the connection is not successful because there's no intention")
 			helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(), false, staticClientName, "http://localhost:1234")

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -54,12 +54,12 @@ func TestIngressGateway(t *testing.T) {
 			consulCluster.Create(t)
 
 			t.Log("creating server")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
 
 			// We use a "bounce" pod so that we can make calls to the ingress gateway
 			// via kubectl exec without needing a route into the cluster from the test machine.
 			t.Log("creating bounce pod")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/bounce.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/bounce.yaml")
 
 			// With the cluster up, we can create our ingress-gateway config entry.
 			t.Log("creating config entry")

--- a/test/acceptance/tests/mesh-gateway/main_test.go
+++ b/test/acceptance/tests/mesh-gateway/main_test.go
@@ -12,6 +12,7 @@ var suite framework.Suite
 
 func TestMain(m *testing.M) {
 	suite = framework.NewSuite(m)
+
 	if suite.Config().EnableMultiCluster {
 		os.Exit(suite.Run())
 	} else {

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -89,10 +89,10 @@ func TestMeshGatewayDefault(t *testing.T) {
 
 	// Check that we can connect services over the mesh gateways
 	t.Log("creating static-server in dc2")
-	helpers.Deploy(t, secondaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+	helpers.Deploy(t, secondaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
 
 	t.Log("creating static-client in dc1")
-	helpers.Deploy(t, primaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
+	helpers.Deploy(t, primaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-client.yaml")
 
 	t.Log("checking that connection is successful")
 	helpers.CheckStaticServerConnection(t, primaryContext.KubectlOptions(), true, staticClientName, "http://localhost:1234")
@@ -199,10 +199,10 @@ func TestMeshGatewaySecure(t *testing.T) {
 
 			// Check that we can connect services over the mesh gateways
 			t.Log("creating static-server in dc2")
-			helpers.Deploy(t, secondaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+			helpers.Deploy(t, secondaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
 
 			t.Log("creating static-client in dc1")
-			helpers.Deploy(t, primaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
+			helpers.Deploy(t, primaryContext.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-client.yaml")
 
 			t.Log("creating intention")
 			_, _, err = consulClient.Connect().IntentionCreate(&api.Intention{

--- a/test/acceptance/tests/sync/sync_catalog_test.go
+++ b/test/acceptance/tests/sync/sync_catalog_test.go
@@ -59,7 +59,7 @@ func TestSyncCatalog(t *testing.T) {
 			consulCluster.Create(t)
 
 			t.Log("creating a static-server with a service")
-			helpers.Deploy(t, ctx.KubectlOptions(), suite.Config().NoCleanupOnFailure, "fixtures/static-server.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), suite.Config().NoCleanupOnFailure, suite.Config().DebugDirectory, "fixtures/static-server.yaml")
 
 			consulClient := consulCluster.SetupConsulClient(t, c.secure)
 

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -60,7 +60,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 			// Deploy a static-server that will play the role of an external service
 			t.Log("creating static-server deployment")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-server.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-server.yaml")
 
 			// Once the cluster is up, register the external service, then create the config entry.
 			consulClient := consulCluster.SetupConsulClient(t, c.secure)
@@ -121,7 +121,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 			// Deploy the static client
 			t.Log("deploying static client")
-			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, "fixtures/static-client.yaml")
+			helpers.Deploy(t, ctx.KubectlOptions(), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "fixtures/static-client.yaml")
 
 			// If ACLs are enabled, test that intentions prevent connections.
 			if c.secure {


### PR DESCRIPTION
This PR proposes the following changes: 

* Adds a new flag `-debug-directory`.
* When the flag is not set, the tests will create a temporary directory.
* On cleanup, the consul cluster and
helpers.Deploy functions will write pod info and logs
to the debug directory. 

For the time being, we will only support these functions, but if more support is needed, it might make sense to provide this more natively within the framework for each test.

See [this build](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/1203/workflows/fb420d14-436d-457a-a192-6803bbcd1d7a/jobs/1909/artifacts) for an example of what is written when tests fail.