### PR TITLE
Support ACLs for controller

### DIFF
--- a/templates/controller-clusterrole.yaml
+++ b/templates/controller-clusterrole.yaml
@@ -10,32 +10,41 @@ metadata:
     release: {{ .Release.Name }}
     component: controller
 rules:
-  - apiGroups:
-      - consul.hashicorp.com
-    resources:
-      - servicedefaults
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - consul.hashicorp.com
-    resources:
-      - servicedefaults/status
-    verbs:
-      - get
-      - patch
-      - update
-  {{- if .Values.global.enablePodSecurityPolicies }}
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    resourceNames:
-      - {{ template "consul.fullname" . }}-controller
-    verbs:
-      - use
-  {{- end }}
+- apiGroups:
+  - consul.hashicorp.com
+  resources:
+  - servicedefaults
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - consul.hashicorp.com
+  resources:
+  - servicedefaults/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- if .Values.global.acls.manageSystemACLs }}
+- apiGroups: [""]
+  resources:
+  - secrets
+  resourceNames:
+  - {{ template "consul.fullname" . }}-controller-acl-token
+  verbs:
+  - get
+{{- end }}
+{{- if .Values.global.enablePodSecurityPolicies }}
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames:
+    - {{ template "consul.fullname" . }}-controller
+  verbs:
+    - use
+{{- end }}
 {{- end }}

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -27,6 +27,25 @@ spec:
         release: {{ .Release.Name }}
         component: controller
     spec:
+      {{- if .Values.global.acls.manageSystemACLs }}
+      initContainers:
+      - name: controller-acl-init
+        image: {{ .Values.global.imageK8S }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s acl-init \
+              -secret-name="{{ template "consul.fullname" . }}-controller-acl-token" \
+              -k8s-namespace={{ .Release.Namespace }}
+        resources:
+          requests:
+            memory: "25Mi"
+            cpu: "50m"
+          limits:
+            memory: "25Mi"
+            cpu: "50m"
+      {{- end }}
       containers:
       - args:
         - controller
@@ -38,6 +57,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        {{- if .Values.global.acls.manageSystemACLs }}
+        - name: CONSUL_HTTP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "{{ template "consul.fullname" . }}-controller-acl-token"
+              key: "token"
+        {{- end}}
         - name: CONSUL_HTTP_ADDR
           value: http://$(HOST_IP):8500
         image: {{ .Values.global.imageK8S }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -202,6 +202,10 @@ spec:
                 -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
                 {{- end }}
 
+                {{- if .Values.controller.enabled }}
+                -create-controller-token=true \
+                {{- end }}
+
                 {{- if .Values.global.enableConsulNamespaces }}
                 -enable-namespaces=true \
 

--- a/test/unit/controller-clusterrole.bats
+++ b/test/unit/controller-clusterrole.bats
@@ -43,3 +43,17 @@ load _helpers
       yq '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+#--------------------------------------------------------------------
+# global.acls.manageSystemACLs
+
+@test "controller/ClusterRole: allows secret access with global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-clusterrole.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules | map(select(.resourceNames[0] == "release-name-consul-controller-acl-token")) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}

--- a/test/unit/controller-deployment.bats
+++ b/test/unit/controller-deployment.bats
@@ -42,3 +42,35 @@ load _helpers
       yq '.spec.replicas' | tee /dev/stderr)
   [ "${actual}" = "2" ]
 }
+
+#--------------------------------------------------------------------
+# global.acls.manageSystemACLs
+
+@test "controller/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-deployment.yaml \
+      --set 'controller.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "controller/Deployment: init container is created when global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/controller-deployment.yaml \
+      --set 'controller.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "controller-acl-init" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("consul-k8s acl-init"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1360,3 +1360,27 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("-inject-auth-method-host=foo.com"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# controller
+
+@test "serverACLInit/Job: -create-controller-token not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("create-controller-token"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "serverACLInit/Job: -create-controller-token set when controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("create-controller-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/sync-catalog-clusterrole.bats
+++ b/test/unit/sync-catalog-clusterrole.bats
@@ -63,7 +63,7 @@ load _helpers
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 
-@test "syncCatalog/ClusterRole: allows secret access with global.bootsrapACLs=true" {
+@test "syncCatalog/ClusterRole: allows secret access with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/sync-catalog-clusterrole.yaml  \


### PR DESCRIPTION
This PR adds support for ACLs. It only works for OSS. Ent will be done in another PR.

Prereqs:
```
kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager-legacy.yaml
```

Testing:
```
helm install consul ./ \
  --set controller.enabled=true \
  --set global.imageK8S="lkysow/consul-k8s-dev:aug31-ctrl-acl" \
  --set server.replicas=1 \
  --set server.bootstrapExpect=1 \
  --set global.acls.manageSystemACLs=true \
  --wait

cat <<EOF | kubectl apply -f -
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceDefaults
metadata:
  name: servicedefaults-sample
spec:
  protocol: "http"
EOF

kubectl exec ds/consul-consul -- consul config read -kind service-defaults -name servicedefaults-sample
```

Cleanup:
You need to delete the servicedefaults-sample resource first, otherwise the crd won't be uninstalled because it requires all resources using that crd to be deleted but the resource requires its finalizer removed before it gets deleted and if you delete the controller then it won't remove its finalizer (you can manually edit the resource and remove the finalizer yourself if needed).

Companion with https://github.com/hashicorp/consul-k8s/pull/317