### PR TITLE
Crd controller psps

### DIFF
--- a/templates/controller-clusterrole.yaml
+++ b/templates/controller-clusterrole.yaml
@@ -30,4 +30,12 @@ rules:
       - get
       - patch
       - update
+  {{- if .Values.global.enablePodSecurityPolicies }}
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames:
+      - {{ template "consul.fullname" . }}-controller
+    verbs:
+      - use
+  {{- end }}
 {{- end }}

--- a/templates/controller-podsecuritypolicy.yaml
+++ b/templates/controller-podsecuritypolicy.yaml
@@ -1,1 +1,39 @@
-# todo
+{{- if and .Values.controller.enabled .Values.global.enablePodSecurityPolicies }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-controller
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: controller
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/test/unit/controller-clusterrole.bats
+++ b/test/unit/controller-clusterrole.bats
@@ -18,3 +18,28 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.enablePodSecurityPolicies
+
+@test "controller/ClusterRole: no podsecuritypolicies access with global.enablePodSecurityPolicies=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-clusterrole.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      . | tee /dev/stderr |
+      yq '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
+
+@test "controller/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-clusterrole.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}

--- a/test/unit/controller-podsecuritypolicy.bats
+++ b/test/unit/controller-podsecuritypolicy.bats
@@ -2,4 +2,28 @@
 
 load _helpers
 
-# todo
+@test "controller/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/controller-podsecuritypolicy.yaml  \
+      .
+}
+
+@test "controller/PodSecurityPolicy: disabled by default with controller enabled" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/controller-podsecuritypolicy.yaml  \
+      --set 'controller.enabled=true' \
+      .
+}
+
+@test "controller/PodSecurityPolicy: enabled with controller enabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-podsecuritypolicy.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
This PR adds support for pod security policies.

Testing this is a bit annoying because cert-manager doesn't support pod security policies. We're getting rid of cert manager soon but until then you need to install cert-manager with psps *disabled* and then enable them before installing the controller.

Using a GKE cluster (where it's easiest to enable psps in my experience).

Prereqs (**with psps disabled**):
```
kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager-legacy.yaml
```

Enable PSPs:
```
gcloud beta container clusters update <your-cluster-name> --enable-pod-security-policy --zone us-central1-c
```

Install with:
```yaml
global:
  enablePodSecurityPolicies: true
  imageK8S: lkysow/consul-k8s-dev:aug31-ctrl-acl
controller:
  enabled: true
server:
  replicas: 1
  bootstrapExpect: 1
```

Once installed, create the CRD and see that it is created in consul:
```
cat <<EOF | kubectl apply -f -
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceDefaults
metadata:
  name: servicedefaults-sample
spec:
  protocol: "http"
EOF

kubectl exec ds/consul-consul -- consul config read -kind service-defaults -name servicedefaults-sample
```

Cleanup:
You need to delete the servicedefaults-sample resource first, otherwise the crd won't be uninstalled because it requires all resources using that crd to be deleted but the resource requires its finalizer removed before it gets deleted and if you delete the controller then it won't remove its finalizer (you can manually edit the resource and remove the finalizer yourself if needed).