### PR TITLE
Giving the possibility to bring own client cert

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -84,6 +84,7 @@ spec:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
         {{ if not .Values.global.tls.enableAutoEncrypt }}
+        {{ if not .Values.global.tls.bringOwnKey }}
         - name: consul-ca-key
           secret:
             {{- if .Values.global.tls.caKey.secretName }}
@@ -99,6 +100,21 @@ spec:
             # We're using tmpfs here so that
             # client certs are not written to disk
             medium: "Memory"
+        {{- end }}
+        {{- end }}
+        {{ if .Values.global.tls.bringOwnKey }}
+        - name: consul-client-cert
+          secret:
+            {{- if .Values.global.tls.clientCert.secretName }}
+            secretName: {{ .Values.global.tls.clientCert.secretName }}
+            {{- else }}
+            secretName: {{ template "consul.fullname" . }}-cert
+            {{- end }}
+            items:
+            - key: {{ default "tls.crt" .Values.global.tls.clientCert.secretKey }}
+              path: tls.crt
+            - key: {{ default "tls.key" .Values.global.tls.clientKey.secretKey }}
+              path: tls.key
         {{- end }}
         {{- end }}
         {{- range .Values.client.extraVolumes }}
@@ -333,7 +349,7 @@ spec:
             memory: "25Mi"
             cpu: "50m"
       {{- end }}
-      {{- if and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt) }}
+      {{- if and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt) (not .Values.global.tls.bringOwnKey) }}
       - name: client-tls-init
         image: "{{ default .Values.global.image .Values.client.image }}"
         env:

--- a/values.yaml
+++ b/values.yaml
@@ -95,6 +95,26 @@ global:
   tls:
     enabled: false
 
+    # in case you want to come with your own client certificate
+    # set this to true
+    bringOwnKey: false
+
+    # clientCert is a Kubernetes secret containing the certificate
+    # for consul agent used for TLS communications within the Consul cluster.
+    # It can be used to communicate with servers
+    # outside kubernetes and in case you cannot provide a CA.
+    clientCert:
+      secretName: null
+      secretKey: null
+
+    # clientKey is a Kubernetes secret containing the private key
+    # for consul agent used for TLS communications within the Consul cluster.
+    # It can be used to communicate with servers
+    # outside kubernetes and in case you cannot provide a CA.
+    clientKey:
+      secretName: null
+      secretKey: null
+
     # enableAutoEncrypt turns on the auto-encrypt feature on
     # clients and servers.
     # It also switches consul-k8s components to retrieve the CA


### PR DESCRIPTION
In order to bring own client certificate with a cluster of consul servers outside kubernetes. When using any other PKI and managing its own certificate and keys but without having a dedicated CA to give to consul agent pods
Fix #588 