### PR TITLE
Fix acceptance test err logging

### DIFF
--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -41,27 +42,15 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 	retry.RunWith(counter, t, func(r *retry.R) {
 		pods, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: podLabelSelector})
 		require.NoError(r, err)
-		var numNotReadyContainers int
-		var totalNumContainers int
+
+		var notReadyPods []string
 		for _, pod := range pods.Items {
-			if len(pod.Status.ContainerStatuses) == 0 {
-				r.Errorf("pod %s is pending", pod.Name)
-			}
-			for _, contStatus := range pod.Status.InitContainerStatuses {
-				totalNumContainers++
-				if !contStatus.Ready {
-					numNotReadyContainers++
-				}
-			}
-			for _, contStatus := range pod.Status.ContainerStatuses {
-				totalNumContainers++
-				if !contStatus.Ready {
-					numNotReadyContainers++
-				}
+			if !isReady(pod) {
+				notReadyPods = append(notReadyPods, pod.Name)
 			}
 		}
-		if numNotReadyContainers != 0 {
-			r.Errorf("%d out of %d containers are ready", totalNumContainers-numNotReadyContainers, totalNumContainers)
+		if len(notReadyPods) > 0 {
+			r.Errorf("%d pods are not ready: %s", len(notReadyPods), strings.Join(notReadyPods, ","))
 		}
 	})
 }
@@ -201,17 +190,21 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 		for _, pod := range pods.Items {
 			// Get logs for each pod, passing the discard logger to make sure secrets aren't printed to test logs.
 			logs, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "logs", "--all-containers=true", pod.Name)
-			require.NoError(t, err)
 
-			// Write logs to file name <pod.Name>.log
+			// Write logs or err to file name <pod.Name>.log
 			logFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.log", pod.Name))
+			if err != nil {
+				logs = fmt.Sprintf("Error getting logs: %s: %s", err, logs)
+			}
 			require.NoError(t, ioutil.WriteFile(logFilename, []byte(logs), 0600))
 
 			// Describe pod
 			desc, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "describe", "pod", pod.Name)
-			require.NoError(t, err)
 
-			// Write pod info to file name <pod.Name>.txt
+			// Write pod info or error to file name <pod.Name>.txt
+			if err != nil {
+				desc = fmt.Sprintf("Error describing pod: %s: %s", err, desc)
+			}
 			descFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.txt", pod.Name))
 			require.NoError(t, ioutil.WriteFile(descFilename, []byte(desc), 0600))
 		}
@@ -262,4 +255,23 @@ func labelMapToString(labelMap map[string]string) string {
 	}
 
 	return strings.Join(labels, ",")
+}
+
+// isReady returns true if pod is ready.
+func isReady(pod corev1.Pod) bool {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+
+	for _, contStatus := range pod.Status.InitContainerStatuses {
+		if !contStatus.Ready {
+			return false
+		}
+	}
+	for _, contStatus := range pod.Status.ContainerStatuses {
+		if !contStatus.Ready {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
- print list of pending pods
- log any errors running logs/describe instead of exiting out early

Previously the pods that were actually pending wouldn't be listed on the error:
```
controller_namespaces_test.go:83: Waiting for pods to be ready.
        helpers.go:64: 0 out of 6 containers are ready
        helpers.go:64: 0 out of 7 containers are ready
        helpers.go:64: 1 out of 7 containers are ready
        helpers.go:64: 3 out of 7 containers are ready
        helpers.go:64: 4 out of 7 containers are ready
```
Now the error will look like:
```
    controller_namespaces_test.go:83: Waiting for pods to be ready.
    retry.go:121: helpers.go:65: 7 pods are not ready: test-c04jjt-consul-connect-injector-webhook-deployment-59fwxj64,test-c04jjt-consul-controller-5d5ff77597-zn4vf,test-c04jjt-consul-l6cmn,test-c04jjt-consul-server-0,test-c04jjt-consul-w72ql,test-c04jjt-consul-w7xg7,test-c04jjt-consul-webhook-cert-manager-54759658ff-b7slb
        helpers.go:65: 6 pods are not ready: test-c04jjt-consul-connect-injector-webhook-deployment-59fwxj64,test-c04jjt-consul-controller-5d5ff77597-zn4vf,test-c04jjt-consul-l6cmn,test-c04jjt-consul-w72ql,test-c04jjt-consul-w7xg7,test-c04jjt-consul-webhook-cert-manager-54759658ff-b7slb
        helpers.go:65: 4 pods are not ready: test-c04jjt-consul-connect-injector-webhook-deployment-59fwxj64,test-c04jjt-consul-controller-5d5ff77597-zn4vf,test-c04jjt-consul-w72ql,test-c04jjt-consul-webhook-cert-manager-54759658ff-b7slb
        helpers.go:65: 3 pods are not ready: test-c04jjt-consul-connect-injector-webhook-deployment-59fwxj64,test-c04jjt-consul-controller-5d5ff77597-zn4vf,test-c04jjt-consul-webhook-cert-manager-54759658ff-b7slb
```

Also previously if there was an error getting the logs or running describe for a pod when we were running the "dump info after test fails" function, then that dump function would error out without logging why it errored and without printing the info for the other pods:
```
consul_cluster.go:88: dumping logs and pod info for release=test-ot058m to /tmp/test-results/debug/TestControllerNamespaces/single_destination_namespace_(non-default)/gke_consul-k8s-256002_us-central1-a_consul-k8s-1917263625
    consul_cluster.go:88: 
        	Error Trace:	helpers.go:204
        	            				consul_cluster.go:102
        	            				consul_cluster.go:88
        	            				helpers.go:173
        	            				testing.go:837
        	            				testing.go:867
        	            				testing.go:1033
        	            				panic.go:617
        	            				testing.go:698
        	            				retry.go:123
        	            				retry.go:175
        	            				retry.go:125
        	            				retry.go:94
        	            				helpers.go:41
        	            				consul_cluster.go:96
        	            				controller_namespaces_test.go:83
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestControllerNamespaces/single_destination_namespace_(non-default)
```

Now it will write any errors to the artifact files, e.g.
```
Error getting logs: exit status 1: Error from server (BadRequest): container "sidecar-injector" in pod "test-c04jjt-consul-connect-injector-webhook-deployment-59fwxj64" is waiting to start: trying and failing to pull image
```