### PR TITLE
Add datacenter flag to controller deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,8 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=hashicorpdev/consul-k8s:crd-controller-base-latest
+              -consul-k8s-image=ashwinvenkatesh/consul-k8s:meta@sha256:531a8865c4c585b53962bef8ff7e7df375741b16ee4f012d53f348deb30ba5f9 \
+              -consul-image=ashwinvenkatesh/consul:meta@sha256:ba215ab440990e19e87f5fa0952f981dcbf2605175b97899dfec259ee1abeca5
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,7 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=ashwinvenkatesh/consul-k8s:meta@sha256:531a8865c4c585b53962bef8ff7e7df375741b16ee4f012d53f348deb30ba5f9 \
-              -consul-image=ashwinvenkatesh/consul:meta@sha256:ba215ab440990e19e87f5fa0952f981dcbf2605175b97899dfec259ee1abeca5
+              -consul-k8s-image=hashicorpdev/consul-k8s:crd-controller-base-latest
 
       - store_test_results:
           path: /tmp/test-results

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -57,9 +57,9 @@ spec:
         - "-ec"
         - |
           consul-k8s controller \
-            --webhook-tls-cert-dir=/tmp/controller-webhook/certs \
-            --datacenter={{ .Values.global.datacenter }}
-            --enable-leader-election \
+            -webhook-tls-cert-dir=/tmp/controller-webhook/certs \
+            -datacenter={{ .Values.global.datacenter }} \
+            -enable-leader-election \
             {{- if .Values.global.enableConsulNamespaces }}
             -enable-namespaces=true \
             {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -58,6 +58,7 @@ spec:
         - |
           consul-k8s controller \
             --webhook-tls-cert-dir=/tmp/controller-webhook/certs \
+            --datacenter={{ .Values.global.datacenter }}
             --enable-leader-election \
             {{- if .Values.global.enableConsulNamespaces }}
             -enable-namespaces=true \


### PR DESCRIPTION
This is a companion PR to https://github.com/hashicorp/consul-k8s/pull/343 which passes the datacenter flag to the controller.