### PR TITLE
Update proxy-defaults config type to object

### DIFF
--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -39,7 +39,7 @@ spec:
           properties:
             config:
               description: Config is an arbitrary map of configuration values used by Connect proxies. Any values that your proxy allows can be configured globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
-              type: Any
+              type: object
             expose:
               description: Expose controls the default expose path configuration for Envoy.
               properties:

--- a/test/acceptance/tests/fixtures/crds/proxydefaults.yaml
+++ b/test/acceptance/tests/fixtures/crds/proxydefaults.yaml
@@ -3,5 +3,8 @@ kind: ProxyDefaults
 metadata:
   name: global
 spec:
+  config:
+    foo: '{"http":{"name":"envoy.zipkin","config":{"collector_cluster":"zipkin","collector_endpoint":"/api/v1/spans","shared_span_context":false}}}'
+    members: 3
   meshGateway:
     mode: local


### PR DESCRIPTION
- It was previously updated to 'Any' with an updated to a newer version of codegen. The Any type seems to not treat inputs as expected.
- Updated test fixtures with config to prevent similar bugs in the future.