### PR TITLE
Install CRDs only if controller.enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,6 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-k8s-image=hashicorpdev/consul-k8s:crd-controller-base-latest \
-              -consul-image=hashicorpdev/consul
 
       - store_test_results:
           path: /tmp/test-results

--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.controller.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -114,3 +114,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/templates/crd-servicedefaults.yaml
+++ b/templates/crd-servicedefaults.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.controller.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -117,3 +117,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/templates/crd-serviceresolvers.yaml
+++ b/templates/crd-serviceresolvers.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.controller.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -216,3 +216,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/templates/crd-servicerouters.yaml
+++ b/templates/crd-servicerouters.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.controller.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -189,3 +189,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/templates/crd-servicesplitters.yaml
+++ b/templates/crd-servicesplitters.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.controller.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -92,3 +92,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/test/acceptance/tests/controller/controller_namespaces_test.go
+++ b/test/acceptance/tests/controller/controller_namespaces_test.go
@@ -71,6 +71,9 @@ func TestControllerNamespaces(t *testing.T) {
 				"controller.enabled":            "true",
 				"connectInject.enabled":         "true",
 
+				// todo: remove when Helm chart updates to 1.8.4
+				"global.image": "hashicorp/consul-enterprise:1.8.4-ent",
+
 				// When mirroringK8S is set, this setting is ignored.
 				"connectInject.consulNamespaces.consulDestinationNamespace": c.destinationNamespace,
 				"connectInject.consulNamespaces.mirroringK8S":               strconv.FormatBool(c.mirrorK8S),

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -33,7 +33,8 @@ func TestController(t *testing.T) {
 			helmValues := map[string]string{
 				"controller.enabled":    "true",
 				"connectInject.enabled": "true",
-				"global.image":          "hashicorpdev/consul",
+				// todo: remove when 1.9.0 is released.
+				"global.image": "hashicorpdev/consul",
 
 				"global.tls.enabled":           strconv.FormatBool(c.secure),
 				"global.tls.enableAutoEncrypt": strconv.FormatBool(c.autoEncrypt),

--- a/test/unit/crd-proxydefaults.bats
+++ b/test/unit/crd-proxydefaults.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxyDefaults/CustomerResourceDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/crd-proxydefaults.yaml  \
+      .
+}
+
+@test "proxyDefaults/CustomerResourceDefinition: enabled with controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/crd-proxydefaults.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/crd-proxydefaults.bats
+++ b/test/unit/crd-proxydefaults.bats
@@ -15,6 +15,10 @@ load _helpers
       -s templates/crd-proxydefaults.yaml  \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
+      # The generated CRDs have "---" at the top which results in two objects
+      # being detected by yq, the first of which is null. We must therefore use
+      # yq -s so that length operates on both objects at once rather than
+      # individually, which would output false\ntrue and fail the test.
+      yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/crd-servicedefaults.bats
+++ b/test/unit/crd-servicedefaults.bats
@@ -15,6 +15,10 @@ load _helpers
       -s templates/crd-servicedefaults.yaml  \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
+      # The generated CRDs have "---" at the top which results in two objects
+      # being detected by yq, the first of which is null. We must therefore use
+      # yq -s so that length operates on both objects at once rather than
+      # individually, which would output false\ntrue and fail the test.
+      yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/crd-servicedefaults.bats
+++ b/test/unit/crd-servicedefaults.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serviceDefaults/CustomerResourceDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/crd-servicedefaults.yaml  \
+      .
+}
+
+@test "serviceDefaults/CustomerResourceDefinition: enabled with controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/crd-servicedefaults.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/crd-serviceresolvers.bats
+++ b/test/unit/crd-serviceresolvers.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serviceResolvers/CustomerResourceDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/crd-serviceresolvers.yaml  \
+      .
+}
+
+@test "serviceResolvers/CustomerResourceDefinition: enabled with controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/crd-serviceresolvers.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/crd-serviceresolvers.bats
+++ b/test/unit/crd-serviceresolvers.bats
@@ -15,6 +15,10 @@ load _helpers
       -s templates/crd-serviceresolvers.yaml  \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
+      # The generated CRDs have "---" at the top which results in two objects
+      # being detected by yq, the first of which is null. We must therefore use
+      # yq -s so that length operates on both objects at once rather than
+      # individually, which would output false\ntrue and fail the test.
+      yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/crd-servicerouters.bats
+++ b/test/unit/crd-servicerouters.bats
@@ -15,6 +15,10 @@ load _helpers
       -s templates/crd-servicerouters.yaml  \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
+      # The generated CRDs have "---" at the top which results in two objects
+      # being detected by yq, the first of which is null. We must therefore use
+      # yq -s so that length operates on both objects at once rather than
+      # individually, which would output false\ntrue and fail the test.
+      yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/crd-servicerouters.bats
+++ b/test/unit/crd-servicerouters.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serviceRouters/CustomerResourceDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/crd-servicerouters.yaml  \
+      .
+}
+
+@test "serviceRouters/CustomerResourceDefinition: enabled with controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/crd-servicerouters.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/crd-servicesplitters.bats
+++ b/test/unit/crd-servicesplitters.bats
@@ -15,6 +15,10 @@ load _helpers
       -s templates/crd-servicesplitters.yaml  \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
+      # The generated CRDs have "---" at the top which results in two objects
+      # being detected by yq, the first of which is null. We must therefore use
+      # yq -s so that length operates on both objects at once rather than
+      # individually, which would output false\ntrue and fail the test.
+      yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/crd-servicesplitters.bats
+++ b/test/unit/crd-servicesplitters.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "serviceSplitters/CustomerResourceDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/crd-servicesplitters.yaml  \
+      .
+}
+
+@test "serviceSplitters/CustomerResourceDefinition: enabled with controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/crd-servicesplitters.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
Since we're cutting beta off of master, we don't want to install CRDs unless the controller is enabled.

This also runs our acceptance tests off of `hashicorpdev/consul` for OSS and `hashicorp/consul-enterprise:1.8.4-ent` for enterprise. This gets us support for metadata on config entries which we need.