### PR TITLE
Test controller against consul:1.9.0-beta1

### DIFF
--- a/test/acceptance/tests/controller/controller_namespaces_test.go
+++ b/test/acceptance/tests/controller/controller_namespaces_test.go
@@ -30,7 +30,6 @@ const (
 // because in the case of namespaces there isn't a significant distinction in code between auto-encrypt
 // and non-auto-encrypt secure installations, so testing just one is enough.
 func TestControllerNamespaces(t *testing.T) {
-	t.Skip()
 	cfg := suite.Config()
 	if !cfg.EnableEnterprise {
 		t.Skipf("skipping this test because -enable-enterprise is not set")
@@ -77,8 +76,8 @@ func TestControllerNamespaces(t *testing.T) {
 				"controller.enabled":            "true",
 				"connectInject.enabled":         "true",
 
-				// todo: remove when Helm chart updates to 1.8.4
-				"global.image": "hashicorp/consul-enterprise:1.8.4-ent",
+				// todo: remove when Helm chart updates to 1.9.0
+				"global.image":    "hashicorp/consul-enterprise:1.9.0-ent-beta1",
 
 				// When mirroringK8S is set, this setting is ignored.
 				"connectInject.consulNamespaces.consulDestinationNamespace": c.destinationNamespace,

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -38,8 +38,7 @@ func TestController(t *testing.T) {
 			helmValues := map[string]string{
 				"controller.enabled":    "true",
 				"connectInject.enabled": "true",
-				// todo: remove when 1.9.0 is released.
-				"global.image": "hashicorpdev/consul",
+				"global.image":          "consul:1.9.0-beta1",
 
 				"global.tls.enabled":           strconv.FormatBool(c.secure),
 				"global.tls.enableAutoEncrypt": strconv.FormatBool(c.autoEncrypt),


### PR DESCRIPTION
Companion to https://github.com/hashicorp/consul-k8s/pull/362. The only real change in this PR is to uncomment `t.Skip` for namespace tests.