### PR TITLE
Run enterprise license job for all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,8 @@ jobs:
             do
               if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 30m -failfast \
                     -enable-enterprise \
+                    -enterprise-license-secret-name=ent-license \
+                    -enterprise-license-secret-key=key \
                     -enable-multi-cluster \
                     -kubeconfig="$primary_kubeconfig" \
                     -secondary-kubeconfig="$secondary_kubeconfig" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,9 @@ jobs:
             eval "$(echo export primary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[0]))"
             eval "$(echo export secondary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[1]))"
 
-            # create an enterprise license secret in the primary cluster
+            # Create an enterprise license secret in the primary cluster.
+            # This license is set as a CircleCI project env variable.
+            # The license expires 15-Oct-2025.
             KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
 
             # We have to run the tests for each package separately so that we can

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ jobs:
             eval "$(echo export primary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[0]))"
             eval "$(echo export secondary_kubeconfig=$(terraform output -state ../../terraform/gke/terraform.tfstate -json | jq -r .kubeconfigs.value[1]))"
 
+            # create an enterprise license secret in the primary cluster
+            KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
+
             # We have to run the tests for each package separately so that we can
             # exit early if any test fails (-failfast only works within a single
             # package).

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -92,7 +92,7 @@ spec:
                 chmod +x ./apply-license.sh
 
                 # Time out after 20 minutes. Use || to support new timeout versions that don't accept -t
-                timeout -t 1200 ./apply-license.sh 2> /dev/null || timeout 1200 ./apply-license.sh 2> /dev/null
+                timeout 1200 ./apply-license.sh || timeout -t 1200 ./apply-license.sh
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: consul-ca-cert

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -81,7 +81,7 @@ spec:
                 #!/bin/sh
                 while true; do
                   echo "Applying license..."
-                  if consul license put "${ENTERPRISE_LICENSE}"; then
+                  if consul license put "${ENTERPRISE_LICENSE}" 2>&1; then
                     echo "License applied successfully"
                     break
                   fi
@@ -92,7 +92,7 @@ spec:
                 chmod +x ./apply-license.sh
 
                 # Time out after 20 minutes. Use || to support new timeout versions that don't accept -t
-                timeout 1200 ./apply-license.sh || timeout -t 1200 ./apply-license.sh
+                timeout -t 1200 ./apply-license.sh 2> /dev/null || timeout 1200 ./apply-license.sh 2> /dev/null
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: consul-ca-cert

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -41,7 +41,7 @@ func TestController(t *testing.T) {
 				"controller.enabled":    "true",
 				"connectInject.enabled": "true",
 				// todo: remove when 1.9.0 is released.
-				"global.image": "hashicorpdev/consul",
+				"global.image": "hashicorp/consul-enterprise:1.9.0-ent-beta2",
 
 				"global.tls.enabled":           strconv.FormatBool(c.secure),
 				"global.tls.enableAutoEncrypt": strconv.FormatBool(c.autoEncrypt),

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -74,6 +74,8 @@ func TestMeshGatewayDefault(t *testing.T) {
 		"server.extraVolumes[0].load":          "true",
 		"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 		"server.extraVolumes[0].items[0].path": "config.json",
+		"server.enterpriseLicense.secretName":  "",
+		"server.enterpriseLicense.secretKey":   "",
 
 		"connectInject.enabled": "true",
 
@@ -183,6 +185,8 @@ func TestMeshGatewaySecure(t *testing.T) {
 				"server.extraVolumes[0].load":          "true",
 				"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 				"server.extraVolumes[0].items[0].path": "config.json",
+				"server.enterpriseLicense.secretName":  "",
+				"server.enterpriseLicense.secretKey":   "",
 
 				"connectInject.enabled": "true",
 

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -74,8 +74,11 @@ func TestMeshGatewayDefault(t *testing.T) {
 		"server.extraVolumes[0].load":          "true",
 		"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 		"server.extraVolumes[0].items[0].path": "config.json",
-		"server.enterpriseLicense.secretName":  "",
-		"server.enterpriseLicense.secretKey":   "",
+
+		// Enterprise license job will fail if it runs in the secondary DC,
+		// so we're explicitly setting these values to empty to avoid that.
+		"server.enterpriseLicense.secretName": "",
+		"server.enterpriseLicense.secretKey":  "",
 
 		"connectInject.enabled": "true",
 
@@ -185,8 +188,11 @@ func TestMeshGatewaySecure(t *testing.T) {
 				"server.extraVolumes[0].load":          "true",
 				"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 				"server.extraVolumes[0].items[0].path": "config.json",
-				"server.enterpriseLicense.secretName":  "",
-				"server.enterpriseLicense.secretKey":   "",
+
+				// Enterprise license job will fail if it runs in the secondary DC,
+				// so we're explicitly setting these values to empty to avoid that.
+				"server.enterpriseLicense.secretName": "",
+				"server.enterpriseLicense.secretKey":  "",
 
 				"connectInject.enabled": "true",
 


### PR DESCRIPTION
This is a followup to #654 

In addition to running tests with a license, update the enterprise license job to not suppress error output. Otherwise, our logs look like:

```
Applying license...
Retrying in 2s...
Applying license...
Retrying in 2s...
Applying license...
Retrying in 2s...
Applying license...
...
```
which makes it hard to debug errors. I've switched the order of `timeout` commands so that we try the newer version first (without the `-t` flag). 