### PR TITLE
Bump controller memory request/limit for OpenShift

### DIFF
--- a/test/acceptance/framework/consul_cluster.go
+++ b/test/acceptance/framework/consul_cluster.go
@@ -102,7 +102,9 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 
 	helpers.WritePodsDebugInfoIfFailed(t, h.helmOptions.KubectlOptions, h.debugDirectory, "release="+h.releaseName)
 
-	helm.Delete(t, h.helmOptions, h.releaseName, false)
+	// Ignore the error returned by the helm delete here so that we can
+	// always idempotently clean up resources in the cluster.
+	helm.DeleteE(t, h.helmOptions, h.releaseName, false)
 
 	// Delete PVCs.
 	h.kubernetesClient.CoreV1().PersistentVolumeClaims(h.helmOptions.KubectlOptions.Namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "release=" + h.releaseName})

--- a/test/unit/controller-deployment.bats
+++ b/test/unit/controller-deployment.bats
@@ -428,7 +428,7 @@ load _helpers
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
-  [ "${actual}" = '{"limits":{"cpu":"100m","memory":"30Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}' ]
+  [ "${actual}" = '{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}' ]
 }
 
 @test "controller/Deployment: can set resources" {

--- a/values.yaml
+++ b/values.yaml
@@ -1023,10 +1023,10 @@ controller:
   resources:
     limits:
       cpu: 100m
-      memory: 30Mi
+      memory: 50Mi
     requests:
       cpu: 100m
-      memory: 20Mi
+      memory: 50Mi
 
   # Optional YAML string to specify a nodeSelector config.
   nodeSelector: null


### PR DESCRIPTION
Otherwise, we're seeing intermittent errors creating controller container that look like:

```
Error: container create failed: time="2020-10-15T00:38:06Z" level=warning msg="signal: killed"
time="2020-10-15T00:38:06Z" level=error msg="container_linux.go:349: starting container process caused \"process_linux.go:449: container init caused \\\"read init-p: connection reset by peer\\\"\""
container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"read init-p: connection reset by peer\""
```

The solution to increase memory came from [this](https://www.cloudfoundry.org/blog/the-garden-team-and-the-strange-case-of-a-connection-being-reset/) blog post.