### PR TITLE
support new versions of timeout in ent-license

### DIFF
--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -92,7 +92,7 @@ spec:
                 chmod +x ./apply-license.sh
 
                 # Time out after 20 minutes. Use || to support new timeout versions that dont accept -t
-                timeout -t 1200 ./apply-license.sh || timeout 1200 ./apply-license.sh
+                timeout -t 1200 ./apply-license.sh 2> /dev/null || timeout 1200 ./apply-license.sh 2> /dev/null
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: consul-ca-cert

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -91,8 +91,8 @@ spec:
                 EOF
                 chmod +x ./apply-license.sh
 
-                # Time out after 20 minutes.
-                timeout -t 1200 ./apply-license.sh
+                # Time out after 20 minutes. Use || to support new timeout versions that dont accept -t
+                timeout -t 1200 ./apply-license.sh || timeout 1200 ./apply-license.sh
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: consul-ca-cert

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -91,7 +91,7 @@ spec:
                 EOF
                 chmod +x ./apply-license.sh
 
-                # Time out after 20 minutes. Use || to support new timeout versions that dont accept -t
+                # Time out after 20 minutes. Use || to support new timeout versions that don't accept -t
                 timeout -t 1200 ./apply-license.sh 2> /dev/null || timeout 1200 ./apply-license.sh 2> /dev/null
           {{- if .Values.global.tls.enabled }}
           volumeMounts:


### PR DESCRIPTION
New versions of busybox packaged with consul-1.9 provide a version of `timeout` which does not support the `-t` flag, try it once with and once without if that fails.

I've tested this manually with 1.9.0-beta1 ent and verified it fails without the changes and passes with the changes, and continues to pass in 1.8.x versions.

Resolves #647 