### PR TITLE
Update MutatingWebHook API Version

### DIFF
--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -1,6 +1,6 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 # The MutatingWebhookConfiguration to enable the Connect injector.
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -16,6 +16,7 @@ metadata:
     release: {{ .Release.Name }}
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
+    failurePolicy: Fail
     clientConfig:
       service:
         name: {{ template "consul.fullname" . }}-connect-injector-svc

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -1,6 +1,10 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 # The MutatingWebhookConfiguration to enable the Connect injector.
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-cfg

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -17,6 +17,10 @@ metadata:
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
     failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - "v1beta1"
+      - "v1"
     clientConfig:
       service:
         name: {{ template "consul.fullname" . }}-connect-injector-svc

--- a/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/templates/controller-mutatingwebhookconfiguration.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.enabled }}
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/templates/controller-mutatingwebhookconfiguration.yaml
@@ -21,6 +21,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-proxydefaults
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-proxydefaults.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -40,6 +43,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicedefaults
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-servicedefaults.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -59,6 +65,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-serviceresolver
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-serviceresolver.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -78,6 +87,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicerouter
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-servicerouter.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -97,6 +109,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicesplitter
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-servicesplitter.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -116,6 +131,9 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-serviceintentions
   failurePolicy: Fail
+  admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
   name: mutate-serviceintentions.consul.hashicorp.com
   rules:
     - apiGroups:

--- a/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/templates/controller-mutatingwebhookconfiguration.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.controller.enabled }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "consul.fullname" . }}-controller-mutating-webhook-configuration


### PR DESCRIPTION
`admissionregistration.k8s.io/v1beta1` is [deprecated](https://v1-16.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals) since 1.16 and will be removed in 1.19.

This PR will set the right API Version if it is supported.

**However**, there is a change in behaviour from `v1beta1` to `v1`. Specifically, the default (unspecified) [`failurePolicy`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) changes from `Ignore` to `Fail`. 

The Connect Inject webhook does not have a default `failurePolicy` set whereas the Controller Webhook has it set to `Fail`. Should we set a value for the Connect Inject webhook?