### PR TITLE
acceptance-tests: expect conn reset by peer errors when health checks are failing

### DIFF
--- a/test/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/test/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -127,7 +127,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 
 			if c.secure {
 				t.Log("checking that the connection is not successful because there's no intention")
-				helpers.CheckStaticServerConnection(t, staticClientOpts, false, staticClientName, "http://localhost:1234")
+				helpers.CheckStaticServerConnectionFailing(t, staticClientOpts, staticClientName, "http://localhost:1234")
 
 				intention := &api.Intention{
 					SourceName:      staticClientName,
@@ -150,7 +150,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 			}
 
 			t.Log("checking that connection is successful")
-			helpers.CheckStaticServerConnection(t, staticClientOpts, true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -49,7 +49,7 @@ func TestConnectInject(t *testing.T) {
 
 			if c.secure {
 				t.Log("checking that the connection is not successful because there's no intention")
-				helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(t), false, staticClientName, "http://localhost:1234")
+				helpers.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 
 				consulClient := consulCluster.SetupConsulClient(t, true)
 
@@ -63,7 +63,7 @@ func TestConnectInject(t *testing.T) {
 			}
 
 			t.Log("checking that connection is successful")
-			helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(t), true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/test/acceptance/tests/connect/health_checks_test.go
+++ b/test/acceptance/tests/connect/health_checks_test.go
@@ -2,10 +2,11 @@ package connect
 
 import (
 	"fmt"
-	"github.com/hashicorp/consul-helm/test/acceptance/framework"
-	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/consul-helm/test/acceptance/framework"
+	"github.com/hashicorp/consul-helm/test/acceptance/helpers"
 )
 
 // Test that health checks work in a default installation and a secure installation with TLS/auto-encrypt permutations.
@@ -56,15 +57,24 @@ func TestHealthChecks(t *testing.T) {
 			// so that it can fetch the healthcheck and its status and assert on this. Right now the health check status
 			// is implied by the traffic passing or not.
 			t.Log("checking that connection is successful")
-			helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(t), true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 
 			// Now create the file so that the readiness probe of the static-server pod fails.
-			helpers.RunKubectl(t, ctx.KubectlOptions(t), "exec", "-it", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
+			helpers.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
 
 			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.
+			// We are expecting a "connection reset by peer" error because in a case of health checks,
+			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
+			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
 			t.Log("checking that connection is unsuccessful")
-			helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(t), false, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnection(
+				t,
+				ctx.KubectlOptions(t),
+				false,
+				staticClientName,
+				"curl: (56) Recv failure: Connection reset by peer",
+				"http://localhost:1234")
 		})
 	}
 }

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -126,7 +126,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				t.Log("testing intentions prevent ingress")
-				helpers.CheckStaticServerConnection(t, nsK8SOptions, false, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+				helpers.CheckStaticServerConnectionFailing(t, nsK8SOptions, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 
 				// Now we create the allow intention.
 				t.Log("creating ingress-gateway => static-server intention")
@@ -143,7 +143,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the static-client pod. It should route to the static-server pod.
 			t.Log("trying calls to ingress gateway")
-			helpers.CheckStaticServerConnection(t, nsK8SOptions, true, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+			helpers.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 		})
 	}
 }
@@ -246,7 +246,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				t.Log("testing intentions prevent ingress")
-				helpers.CheckStaticServerConnection(t, nsK8SOptions, false, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+				helpers.CheckStaticServerConnectionFailing(t, nsK8SOptions, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 
 				// Now we create the allow intention.
 				t.Log("creating ingress-gateway => static-server intention")
@@ -263,7 +263,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the static-client pod. It should route to the static-server pod.
 			t.Log("trying calls to ingress gateway")
-			helpers.CheckStaticServerConnection(t, nsK8SOptions, true, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+			helpers.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, "static-client", "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 		})
 	}
 }

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -91,7 +91,7 @@ func TestIngressGateway(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				t.Log("testing intentions prevent ingress")
-				helpers.CheckStaticServerConnection(t, k8sOptions, false, "static-client", "-H", "Host: static-server.ingress.consul", fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
+				helpers.CheckStaticServerConnectionFailing(t, k8sOptions, "static-client", "-H", "Host: static-server.ingress.consul", fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
 
 				// Now we create the allow intention.
 				t.Log("creating ingress-gateway => static-server intention")
@@ -106,7 +106,7 @@ func TestIngressGateway(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the static-client pod. It should route to the static-server pod.
 			t.Log("trying calls to ingress gateway")
-			helpers.CheckStaticServerConnection(t, k8sOptions, true, "static-client", "-H", "Host: static-server.ingress.consul", fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
+			helpers.CheckStaticServerConnectionSuccessful(t, k8sOptions, "static-client", "-H", "Host: static-server.ingress.consul", fmt.Sprintf("http://%s-consul-ingress-gateway:8080/", releaseName))
 		})
 	}
 }

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -97,7 +97,7 @@ func TestMeshGatewayDefault(t *testing.T) {
 	helpers.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
 	t.Log("checking that connection is successful")
-	helpers.CheckStaticServerConnection(t, primaryContext.KubectlOptions(t), true, staticClientName, "http://localhost:1234")
+	helpers.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
 }
 
 // Test that Connect and wan federation over mesh gateways work in a secure installation,
@@ -214,7 +214,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Log("checking that connection is successful")
-			helpers.CheckStaticServerConnection(t, primaryContext.KubectlOptions(t), true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
@@ -119,7 +119,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 
 			// Test that we can make a call to the terminating gateway
 			t.Log("trying calls to terminating gateway")
-			helpers.CheckStaticServerConnection(t, nsK8SOptions, true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, staticClientName, "http://localhost:1234")
 		})
 	}
 }
@@ -227,7 +227,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 
 			// Test that we can make a call to the terminating gateway
 			t.Log("trying calls to terminating gateway")
-			helpers.CheckStaticServerConnection(t, ns2K8SOptions, true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, ns2K8SOptions, staticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -91,7 +91,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 			// Test that we can make a call to the terminating gateway.
 			t.Log("trying calls to terminating gateway")
-			helpers.CheckStaticServerConnection(t, ctx.KubectlOptions(t), true, staticClientName, "http://localhost:1234")
+			helpers.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 		})
 	}
 }
@@ -181,7 +181,7 @@ func createTerminatingGatewayConfigEntry(t *testing.T, consulClient *api.Client,
 
 func assertNoConnectionAndAddIntention(t *testing.T, consulClient *api.Client, k8sOptions *k8s.KubectlOptions, sourceNS, destinationNS string) {
 	t.Log("testing intentions prevent connections through the terminating gateway")
-	helpers.CheckStaticServerConnection(t, k8sOptions, false, staticClientName, "http://localhost:1234")
+	helpers.CheckStaticServerConnectionFailing(t, k8sOptions, staticClientName, "http://localhost:1234")
 
 	t.Log("creating static-client => static-server intention")
 	_, _, err := consulClient.Connect().IntentionCreate(&api.Intention{

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -9,7 +9,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.15."
+  version_prefix = "1.16."
 }
 
 resource "google_container_cluster" "cluster" {


### PR DESCRIPTION
The behavior currently is that on some cloud providers the error flips back and forth between "connection reset by peer" and "empty reply from server" when health checks are failing. On openshift, we never see `"empty reply from server"`  errors, and so the tests never pass.

* When a connection to the upstream is failing due to a failing health check,
  there will not be a healthy proxy host to connect to, and so we cannot assert
  that we will get "empty reply from server" error as we do in other tests.

* Bump GKE version to 1.16 since 1.15 is now deprecated.