### PR TITLE
Set connect-inject mutating webhook failurePolicy to "Ignore"

### DIFF
--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -16,7 +16,7 @@ metadata:
     release: {{ .Release.Name }}
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
-    failurePolicy: Fail
+    failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions:
       - "v1beta1"

--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -218,28 +218,28 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 			}
 			require.NoError(t, ioutil.WriteFile(logFilename, []byte(logs), 0600))
 
-			// Describe pod and write it to a file
+			// Describe pod and write it to a file.
 			writeResourceInfoToFile(t, pod.Name, "pod", testDebugDirectory, kubectlOptions)
 		}
 
-		// Describe any stateful sets
+		// Describe any stateful sets.
 		statefulSets, err := client.AppsV1().StatefulSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		for _, statefulSet := range statefulSets.Items {
-			// Describe stateful set and write it to a file
+			// Describe stateful set and write it to a file.
 			writeResourceInfoToFile(t, statefulSet.Name, "statefulset", testDebugDirectory, kubectlOptions)
 		}
 
-		// Describe any daemonsets
+		// Describe any daemonsets.
 		daemonsets, err := client.AppsV1().DaemonSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		for _, daemonSet := range daemonsets.Items {
-			// Describe daemon set and write it to a file
+			// Describe daemon set and write it to a file.
 			writeResourceInfoToFile(t, daemonSet.Name, "daemonset", testDebugDirectory, kubectlOptions)
 		}
 
-		// Describe any deployments
+		// Describe any deployments.
 		deployments, err := client.AppsV1().Deployments(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		for _, deployment := range deployments.Items {
-			// Describe deployment and write it to a file
+			// Describe deployment and write it to a file.
 			writeResourceInfoToFile(t, deployment.Name, "deployment", testDebugDirectory, kubectlOptions)
 		}
 	}

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -9,7 +9,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.15."
+  version_prefix = "1.16."
 }
 
 resource "google_container_cluster" "cluster" {


### PR DESCRIPTION
Changes proposed in this PR:

*  Set webhook failurePolicy to Ignore:

    Now that we are using "v1" version of the admissionregistration.k8s.io API,
    the failurePolicy for the mutating webhook is "Fail" by default, where
    previously it was "Ignore". We need to explicitly set it to "Ignore"
    so that helm chart components can come up and not be rejected by
    the webhook.

* Upgrade GKE version to 1.16 in tests (1.15 is now deprecated). Version 1.16 will use the `v1` version of the `admissionregistration` API.

* Small bonus change: print info about statefulsets, daemonsets, and deployments when tests fail. Example of what that looks like can be found [here](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/1717/workflows/67a98b1e-6ee6-4c9b-a6b2-f636545160a6/jobs/4213/artifacts).