### PR TITLE
Add timestamps to acceptance test logs

### DIFF
--- a/test/acceptance/helpers/helpers.go
+++ b/test/acceptance/helpers/helpers.go
@@ -36,7 +36,7 @@ func RandomName() string {
 func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespace, podLabelSelector string) {
 	t.Helper()
 
-	t.Log("Waiting for pods to be ready.")
+	Log(t, "Waiting for pods to be ready.")
 
 	// Wait up to 7m.
 	counter := &retry.Counter{Count: 84, Wait: 5 * time.Second}
@@ -178,10 +178,10 @@ func Cleanup(t *testing.T, noCleanupOnFailure bool, cleanup func()) {
 	// might not have the information on whether the test has failed yet.
 	wrappedCleanupFunc := func() {
 		if !(noCleanupOnFailure && t.Failed()) {
-			t.Logf("cleaning up resources for %s", t.Name())
+			Logf(t, "cleaning up resources for %s", t.Name())
 			cleanup()
 		} else {
-			t.Log("skipping resource cleanup")
+			Log(t, "skipping resource cleanup")
 		}
 	}
 
@@ -203,7 +203,7 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 		testDebugDirectory := filepath.Join(debugDirectory, t.Name(), contextName)
 		require.NoError(t, os.MkdirAll(testDebugDirectory, 0755))
 
-		t.Logf("dumping logs and pod info for %s to %s", labelSelector, testDebugDirectory)
+		Logf(t, "dumping logs and pod info for %s to %s", labelSelector, testDebugDirectory)
 		pods, err := client.CoreV1().Pods(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		require.NoError(t, err)
 

--- a/test/acceptance/helpers/log.go
+++ b/test/acceptance/helpers/log.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Log logs using `t.Log` prefixed with a timestamp.
+func Log(t *testing.T, msg string) {
+	Logf(t, "%s", msg)
+}
+
+// Logf logs using `t.Logf` prefixed with a timestamp.
+func Logf(t *testing.T, pattern string, args ...interface{}) {
+	t.Logf("%s: %s", time.Now().Format("15:04:05"), fmt.Sprintf(pattern, args...))
+}

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -51,14 +51,14 @@ func TestBasicInstallation(t *testing.T) {
 			// Create a KV entry
 			randomKey := helpers.RandomName()
 			randomValue := []byte(helpers.RandomName())
-			t.Logf("creating KV entry with key %s", randomKey)
+			helpers.Logf(t, "creating KV entry with key %s", randomKey)
 			_, err := client.KV().Put(&api.KVPair{
 				Key:   randomKey,
 				Value: randomValue,
 			}, nil)
 			require.NoError(t, err)
 
-			t.Logf("reading value for key %s", randomKey)
+			helpers.Logf(t, "reading value for key %s", randomKey)
 			kv, _, err := client.KV().Get(randomKey, nil)
 			require.NoError(t, err)
 			require.Equal(t, kv.Value, randomValue)

--- a/test/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/test/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -87,7 +87,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 				Namespace:   staticClientNamespace,
 			}
 
-			t.Logf("creating namespaces %s and %s", staticServerNamespace, staticClientNamespace)
+			helpers.Logf(t, "creating namespaces %s and %s", staticServerNamespace, staticClientNamespace)
 			helpers.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", staticServerNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticServerNamespace)
@@ -98,7 +98,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticClientNamespace)
 			})
 
-			t.Log("creating static-server and static-client deployments")
+			helpers.Log(t, "creating static-server and static-client deployments")
 			helpers.DeployKustomize(t, staticServerOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 			helpers.DeployKustomize(t, staticClientOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-namespaces")
 
@@ -126,7 +126,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 			require.Len(t, services, 1)
 
 			if c.secure {
-				t.Log("checking that the connection is not successful because there's no intention")
+				helpers.Log(t, "checking that the connection is not successful because there's no intention")
 				helpers.CheckStaticServerConnectionFailing(t, staticClientOpts, staticClientName, "http://localhost:1234")
 
 				intention := &api.Intention{
@@ -144,12 +144,12 @@ func TestConnectInjectNamespaces(t *testing.T) {
 					intention.DestinationNS = c.destinationNamespace
 				}
 
-				t.Log("creating intention")
+				helpers.Log(t, "creating intention")
 				_, _, err := consulClient.Connect().IntentionCreate(intention, nil)
 				require.NoError(t, err)
 			}
 
-			t.Log("checking that connection is successful")
+			helpers.Log(t, "checking that connection is successful")
 			helpers.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 		})
 	}

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -43,17 +43,17 @@ func TestConnectInject(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			t.Log("creating static-server and static-client deployments")
+			helpers.Log(t, "creating static-server and static-client deployments")
 			helpers.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 			helpers.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
 
 			if c.secure {
-				t.Log("checking that the connection is not successful because there's no intention")
+				helpers.Log(t, "checking that the connection is not successful because there's no intention")
 				helpers.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 
 				consulClient := consulCluster.SetupConsulClient(t, true)
 
-				t.Log("creating intention")
+				helpers.Log(t, "creating intention")
 				_, _, err := consulClient.Connect().IntentionCreate(&api.Intention{
 					SourceName:      staticClientName,
 					DestinationName: staticServerName,
@@ -62,7 +62,7 @@ func TestConnectInject(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			t.Log("checking that connection is successful")
+			helpers.Log(t, "checking that connection is successful")
 			helpers.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 		})
 	}

--- a/test/acceptance/tests/connect/health_checks_test.go
+++ b/test/acceptance/tests/connect/health_checks_test.go
@@ -50,13 +50,13 @@ func TestHealthChecks(t *testing.T) {
 			consulCluster := framework.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 			consulCluster.Create(t)
 
-			t.Log("creating static-server and static-client deployments")
+			helpers.Log(t, "creating static-server and static-client deployments")
 			helpers.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-hc")
 			helpers.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
 			// TODO: it would be nice to add a codepath which makes a connection to the agent where staticServer is running
 			// so that it can fetch the healthcheck and its status and assert on this. Right now the health check status
 			// is implied by the traffic passing or not.
-			t.Log("checking that connection is successful")
+			helpers.Log(t, "checking that connection is successful")
 			helpers.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
 
 			// Now create the file so that the readiness probe of the static-server pod fails.
@@ -67,7 +67,7 @@ func TestHealthChecks(t *testing.T) {
 			// We are expecting a "connection reset by peer" error because in a case of health checks,
 			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
 			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
-			t.Log("checking that connection is unsuccessful")
+			helpers.Log(t, "checking that connection is unsuccessful")
 			helpers.CheckStaticServerConnection(
 				t,
 				ctx.KubectlOptions(t),

--- a/test/acceptance/tests/controller/controller_namespaces_test.go
+++ b/test/acceptance/tests/controller/controller_namespaces_test.go
@@ -93,7 +93,7 @@ func TestControllerNamespaces(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			t.Logf("creating namespace %q", KubeNS)
+			helpers.Logf(t, "creating namespace %q", KubeNS)
 			out, err := helpers.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "create", "ns", KubeNS)
 			if err != nil && !strings.Contains(out, "(AlreadyExists)") {
 				require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test creation.
 			{
-				t.Log("creating custom resources")
+				helpers.Log(t, "creating custom resources")
 				retry.Run(t, func(r *retry.R) {
 					// Retry the kubectl apply because we've seen sporadic
 					// "connection refused" errors where the mutating webhook
@@ -180,26 +180,26 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test updates.
 			{
-				t.Log("patching service-defaults custom resource")
+				helpers.Log(t, "patching service-defaults custom resource")
 				patchProtocol := "tcp"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicedefaults", "defaults", "-p", fmt.Sprintf(`{"spec":{"protocol":"%s"}}`, patchProtocol), "--type=merge")
 
-				t.Log("patching service-resolver custom resource")
+				helpers.Log(t, "patching service-resolver custom resource")
 				patchRedirectSvc := "baz"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "serviceresolver", "resolver", "-p", fmt.Sprintf(`{"spec":{"redirect":{"service": "%s"}}}`, patchRedirectSvc), "--type=merge")
 
-				t.Log("patching proxy-defaults custom resource")
+				helpers.Log(t, "patching proxy-defaults custom resource")
 				patchMeshGatewayMode := "remote"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
-				t.Log("patching service-router custom resource")
+				helpers.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicerouter", "router", "-p", fmt.Sprintf(`{"spec":{"routes":[{"match":{"http":{"pathPrefix":"%s"}}}]}}`, patchPathPrefix), "--type=merge")
 
-				t.Log("patching service-splitter custom resource")
+				helpers.Log(t, "patching service-splitter custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicesplitter", "splitter", "-p", `{"spec": {"splits": [{"weight": 50}, {"weight": 50, "service": "other-splitter"}]}}`, "--type=merge")
 
-				t.Log("patching service-intentions custom resource")
+				helpers.Log(t, "patching service-intentions custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "serviceintentions", "intentions", "-p", `{"spec": {"sources": [{"name": "svc2", "action": "deny"}]}}`, "--type=merge")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}
@@ -252,22 +252,22 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test a delete.
 			{
-				t.Log("deleting service-defaults custom resource")
+				helpers.Log(t, "deleting service-defaults custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicedefaults", "defaults")
 
-				t.Log("deleting service-resolver custom resource")
+				helpers.Log(t, "deleting service-resolver custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "serviceresolver", "resolver")
 
-				t.Log("deleting proxy-defaults custom resource")
+				helpers.Log(t, "deleting proxy-defaults custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "proxydefaults", "global")
 
-				t.Log("deleting service-router custom resource")
+				helpers.Log(t, "deleting service-router custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicerouter", "router")
 
-				t.Log("deleting service-splitter custom resource")
+				helpers.Log(t, "deleting service-splitter custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicesplitter", "splitter")
 
-				t.Log("deleting service-intentions custom resource")
+				helpers.Log(t, "deleting service-intentions custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "serviceintentions", "intentions")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -54,7 +54,7 @@ func TestController(t *testing.T) {
 
 			// Test creation.
 			{
-				t.Log("creating custom resources")
+				helpers.Log(t, "creating custom resources")
 				retry.Run(t, func(r *retry.R) {
 					// Retry the kubectl apply because we've seen sporadic
 					// "connection refused" errors where the mutating webhook
@@ -120,26 +120,26 @@ func TestController(t *testing.T) {
 
 			// Test updates.
 			{
-				t.Log("patching service-defaults custom resource")
+				helpers.Log(t, "patching service-defaults custom resource")
 				patchProtocol := "tcp"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicedefaults", "defaults", "-p", fmt.Sprintf(`{"spec":{"protocol":"%s"}}`, patchProtocol), "--type=merge")
 
-				t.Log("patching service-resolver custom resource")
+				helpers.Log(t, "patching service-resolver custom resource")
 				patchRedirectSvc := "baz"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "serviceresolver", "resolver", "-p", fmt.Sprintf(`{"spec":{"redirect":{"service": "%s"}}}`, patchRedirectSvc), "--type=merge")
 
-				t.Log("patching proxy-defaults custom resource")
+				helpers.Log(t, "patching proxy-defaults custom resource")
 				patchMeshGatewayMode := "remote"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
-				t.Log("patching service-router custom resource")
+				helpers.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicerouter", "router", "-p", fmt.Sprintf(`{"spec":{"routes":[{"match":{"http":{"pathPrefix":"%s"}}}]}}`, patchPathPrefix), "--type=merge")
 
-				t.Log("patching service-splitter custom resource")
+				helpers.Log(t, "patching service-splitter custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicesplitter", "splitter", "-p", `{"spec": {"splits": [{"weight": 50}, {"weight": 50, "service": "other-splitter"}]}}`, "--type=merge")
 
-				t.Log("patching service-intentions custom resource")
+				helpers.Log(t, "patching service-intentions custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "patch", "serviceintentions", "intentions", "-p", `{"spec": {"sources": [{"name": "svc2", "action": "deny"}, {"name": "svc3", "permissions": [{"action": "deny", "http": {"pathExact": "/foo", "methods": ["GET", "PUT"]}}]}]}}`, "--type=merge")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}
@@ -193,22 +193,22 @@ func TestController(t *testing.T) {
 
 			// Test a delete.
 			{
-				t.Log("deleting service-defaults custom resource")
+				helpers.Log(t, "deleting service-defaults custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicedefaults", "defaults")
 
-				t.Log("deleting service-resolver custom resource")
+				helpers.Log(t, "deleting service-resolver custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "serviceresolver", "resolver")
 
-				t.Log("deleting proxy-defaults custom resource")
+				helpers.Log(t, "deleting proxy-defaults custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "proxydefaults", "global")
 
-				t.Log("deleting service-router custom resource")
+				helpers.Log(t, "deleting service-router custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicerouter", "router")
 
-				t.Log("deleting service-splitter custom resource")
+				helpers.Log(t, "deleting service-splitter custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicesplitter", "splitter")
 
-				t.Log("deleting service-intentions custom resource")
+				helpers.Log(t, "deleting service-intentions custom resource")
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "serviceintentions", "intentions")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -46,7 +46,7 @@ func TestMeshGatewayDefault(t *testing.T) {
 
 	// Get the federation secret from the primary cluster and apply it to secondary cluster
 	federationSecretName := fmt.Sprintf("%s-consul-federation", releaseName)
-	t.Logf("retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
+	helpers.Logf(t, "retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
 	federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
 	federationSecret.ResourceVersion = ""
 	require.NoError(t, err)
@@ -86,17 +86,17 @@ func TestMeshGatewayDefault(t *testing.T) {
 	secondaryClient := secondaryConsulCluster.SetupConsulClient(t, false)
 
 	// Verify federation between servers
-	t.Log("verifying federation was successful")
+	helpers.Log(t, "verifying federation was successful")
 	verifyFederation(t, primaryClient, secondaryClient, false)
 
 	// Check that we can connect services over the mesh gateways
-	t.Log("creating static-server in dc2")
+	helpers.Log(t, "creating static-server in dc2")
 	helpers.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 
-	t.Log("creating static-client in dc1")
+	helpers.Log(t, "creating static-client in dc1")
 	helpers.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
-	t.Log("checking that connection is successful")
+	helpers.Log(t, "checking that connection is successful")
 	helpers.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
 }
 
@@ -150,7 +150,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 
 			// Get the federation secret from the primary cluster and apply it to secondary cluster
 			federationSecretName := fmt.Sprintf("%s-consul-federation", releaseName)
-			t.Logf("retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
+			helpers.Logf(t, "retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
 			federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
 			require.NoError(t, err)
 			federationSecret.ResourceVersion = ""
@@ -195,17 +195,17 @@ func TestMeshGatewaySecure(t *testing.T) {
 			secondaryClient := secondaryConsulCluster.SetupConsulClient(t, true)
 
 			// Verify federation between servers
-			t.Log("verifying federation was successful")
+			helpers.Log(t, "verifying federation was successful")
 			verifyFederation(t, primaryClient, secondaryClient, true)
 
 			// Check that we can connect services over the mesh gateways
-			t.Log("creating static-server in dc2")
+			helpers.Log(t, "creating static-server in dc2")
 			helpers.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 
-			t.Log("creating static-client in dc1")
+			helpers.Log(t, "creating static-client in dc1")
 			helpers.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
-			t.Log("creating intention")
+			helpers.Log(t, "creating intention")
 			_, _, err = primaryClient.Connect().IntentionCreate(&api.Intention{
 				SourceName:      staticClientName,
 				DestinationName: "static-server",
@@ -213,7 +213,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			t.Log("checking that connection is successful")
+			helpers.Log(t, "checking that connection is successful")
 			helpers.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
 		})
 	}

--- a/test/acceptance/tests/sync/sync_catalog_namespaces_test.go
+++ b/test/acceptance/tests/sync/sync_catalog_namespaces_test.go
@@ -87,18 +87,18 @@ func TestSyncCatalogNamespaces(t *testing.T) {
 				Namespace:   staticServerNamespace,
 			}
 
-			t.Logf("creating namespace %s", staticServerNamespace)
+			helpers.Logf(t, "creating namespace %s", staticServerNamespace)
 			helpers.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", staticServerNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticServerNamespace)
 			})
 
-			t.Log("creating a static-server with a service")
+			helpers.Log(t, "creating a static-server with a service")
 			helpers.DeployKustomize(t, staticServerOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server")
 
 			consulClient := consulCluster.SetupConsulClient(t, c.secure)
 
-			t.Log("checking that the service has been synced to Consul")
+			helpers.Log(t, "checking that the service has been synced to Consul")
 			var services map[string][]string
 			counter := &retry.Counter{Count: 10, Wait: 5 * time.Second}
 

--- a/test/acceptance/tests/sync/sync_catalog_test.go
+++ b/test/acceptance/tests/sync/sync_catalog_test.go
@@ -58,12 +58,12 @@ func TestSyncCatalog(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			t.Log("creating a static-server with a service")
+			helpers.Log(t, "creating a static-server with a service")
 			helpers.DeployKustomize(t, ctx.KubectlOptions(t), suite.Config().NoCleanupOnFailure, suite.Config().DebugDirectory, "../fixtures/bases/static-server")
 
 			consulClient := consulCluster.SetupConsulClient(t, c.secure)
 
-			t.Log("checking that the service has been synced to Consul")
+			helpers.Log(t, "checking that the service has been synced to Consul")
 			var services map[string][]string
 			syncedServiceName := fmt.Sprintf("static-server-%s", ctx.KubectlOptions(t).Namespace)
 			counter := &retry.Counter{Count: 10, Wait: 5 * time.Second}

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
@@ -61,14 +61,14 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 			// Create the destination namespace in the non-secure case.
 			// In the secure installation, this namespace is created by the server-acl-init job.
 			if !c.secure {
-				t.Logf("creating the %s namespace in Consul", testNamespace)
+				helpers.Logf(t, "creating the %s namespace in Consul", testNamespace)
 				_, _, err := consulClient.Namespaces().Create(&api.Namespace{
 					Name: testNamespace,
 				}, nil)
 				require.NoError(t, err)
 			}
 
-			t.Log("upgrading with terminating gateways enabled")
+			helpers.Log(t, "upgrading with terminating gateways enabled")
 			consulCluster.Upgrade(t, map[string]string{
 				"terminatingGateways.enabled":                     "true",
 				"terminatingGateways.gateways[0].name":            "terminating-gateway",
@@ -76,7 +76,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 				"terminatingGateways.gateways[0].consulNamespace": testNamespace,
 			})
 
-			t.Logf("creating Kubernetes namespace %s", testNamespace)
+			helpers.Logf(t, "creating Kubernetes namespace %s", testNamespace)
 			helpers.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", testNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", testNamespace)
@@ -89,7 +89,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 			}
 
 			// Deploy a static-server that will play the role of an external service
-			t.Log("creating static-server deployment")
+			helpers.Log(t, "creating static-server deployment")
 			helpers.DeployKustomize(t, nsK8SOptions, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server")
 
 			// Register the external service
@@ -106,7 +106,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 			createTerminatingGatewayConfigEntry(t, consulClient, testNamespace, testNamespace)
 
 			// Deploy the static client
-			t.Log("deploying static client")
+			helpers.Log(t, "deploying static client")
 			helpers.DeployKustomize(t, nsK8SOptions, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-namespaces")
 
 			// If ACLs are enabled, test that intentions prevent connections.
@@ -118,7 +118,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 			}
 
 			// Test that we can make a call to the terminating gateway
-			t.Log("trying calls to terminating gateway")
+			helpers.Log(t, "trying calls to terminating gateway")
 			helpers.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, staticClientName, "http://localhost:1234")
 		})
 	}
@@ -172,14 +172,14 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 
 			consulClient := consulCluster.SetupConsulClient(t, c.secure)
 
-			t.Logf("creating Kubernetes namespace %s", testNamespace)
+			helpers.Logf(t, "creating Kubernetes namespace %s", testNamespace)
 			helpers.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", testNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", testNamespace)
 			})
 
 			staticClientNamespace := "ns2"
-			t.Logf("creating Kubernetes namespace %s", staticClientNamespace)
+			helpers.Logf(t, "creating Kubernetes namespace %s", staticClientNamespace)
 			helpers.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", staticClientNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				helpers.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticClientNamespace)
@@ -197,7 +197,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 			}
 
 			// Deploy a static-server that will play the role of an external service.
-			t.Log("creating static-server deployment")
+			helpers.Log(t, "creating static-server deployment")
 			helpers.DeployKustomize(t, ns1K8SOptions, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server")
 
 			// Register the external service
@@ -214,7 +214,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 			createTerminatingGatewayConfigEntry(t, consulClient, "", testNamespace)
 
 			// Deploy the static client
-			t.Log("deploying static client")
+			helpers.Log(t, "deploying static client")
 			helpers.DeployKustomize(t, ns2K8SOptions, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-namespaces")
 
 			// If ACLs are enabled, test that intentions prevent connections.
@@ -226,7 +226,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 			}
 
 			// Test that we can make a call to the terminating gateway
-			t.Log("trying calls to terminating gateway")
+			helpers.Log(t, "trying calls to terminating gateway")
 			helpers.CheckStaticServerConnectionSuccessful(t, ns2K8SOptions, staticClientName, "http://localhost:1234")
 		})
 	}


### PR DESCRIPTION
Introduce functions `Log` and `Logf` to `framework` package.

Motivation: I often find myself trying to correlate test logs with pod logs which is difficult without timestamps.