### PR TITLE
pass health checks controller flag only when enabled

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -85,8 +85,10 @@ spec:
                 -envoy-image="{{ .Values.global.imageEnvoy }}" \
                 -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -listen=:8080 \
+                {{- if .Values.connectInject.healthChecks.enabled }}
                 -enable-health-checks-controller={{ .Values.connectInject.healthChecks.enabled }} \
                 -health-checks-reconcile-period={{ .Values.connectInject.healthChecks.reconcilePeriod }} \
+                {{- end }}
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
                 {{- else if .Values.global.acls.manageSystemACLs }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -86,7 +86,7 @@ spec:
                 -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -listen=:8080 \
                 {{- if .Values.connectInject.healthChecks.enabled }}
-                -enable-health-checks-controller={{ .Values.connectInject.healthChecks.enabled }} \
+                -enable-health-checks-controller=true \
                 -health-checks-reconcile-period={{ .Values.connectInject.healthChecks.reconcilePeriod }} \
                 {{- end }}
                 {{- if .Values.connectInject.overrideAuthMethodName }}

--- a/test/acceptance/tests/connect/health_checks_test.go
+++ b/test/acceptance/tests/connect/health_checks_test.go
@@ -40,6 +40,7 @@ func TestHealthChecks(t *testing.T) {
 			cfg := suite.Config()
 
 			helmValues := map[string]string{
+				"global.imageK8S":                    "kschoche/consul-k8s-dev",
 				"connectInject.enabled":              "true",
 				"connectInject.healthChecks.enabled": "true",
 				"global.tls.enabled":                 strconv.FormatBool(c.secure),

--- a/test/acceptance/tests/connect/health_checks_test.go
+++ b/test/acceptance/tests/connect/health_checks_test.go
@@ -40,7 +40,6 @@ func TestHealthChecks(t *testing.T) {
 			cfg := suite.Config()
 
 			helmValues := map[string]string{
-				"global.imageK8S":                    "kschoche/consul-k8s-dev",
 				"connectInject.enabled":              "true",
 				"connectInject.healthChecks.enabled": "true",
 				"global.tls.enabled":                 strconv.FormatBool(c.secure),

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -88,8 +88,11 @@ load _helpers
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-enable-health-checks-controller=false"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+    yq 'any(contains("-enable-health-checks-controller"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-health-checks-reconcile-period"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "connectInject/Deployment: health checks can be enabled" {
@@ -116,8 +119,8 @@ load _helpers
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-enable-health-checks-controller=false"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+    yq 'any(contains("-enable-health-checks-controller"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "connectInject/Deployment: health checks reconcile period set by default" {
@@ -125,6 +128,7 @@ load _helpers
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
+      --set 'connectInject.healthChecks.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -123,7 +123,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: health checks reconcile period set by default" {
+@test "connectInject/Deployment: health checks reconcile period set by default when health checks are enabled" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \


### PR DESCRIPTION
It is unnecessary to pass the health checks controller flag and this does cause some back compatibility issues if someone were to grab the latest consul-helm repo/release and use it against an old consul-k8s release. So make this optional and only pass when health checks are enabled.