### PR TITLE
Set check_update_interval for healthchecks

### DIFF
--- a/templates/client-config-configmap.yaml
+++ b/templates/client-config-configmap.yaml
@@ -20,4 +20,13 @@ data:
       "enable_central_service_config": true
     }
   {{- end }}
+
+  {{- if (and .Values.connectInject.enabled .Values.connectInject.healthChecks.enabled) }}
+  {{/* We set check_update_interval to 0s so that check output is immediately viewable
+       in the UI. */}}
+  config.json: |-
+    {
+      "check_update_interval": "0s"
+    }
+  {{- end }}
 {{- end }}

--- a/test/unit/client-config-configmap.bats
+++ b/test/unit/client-config-configmap.bats
@@ -71,3 +71,26 @@ load _helpers
       yq '.data["central-config.json"] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# connectInject.healthChecks
+
+@test "client/ConfigMap: check_update_interval is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq '.data["config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/ConfigMap: check_update_interval is set when health checks enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.healthChecks.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["config.json"] | contains("check_update_interval")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
The check_update_interval setting controls how often Consul clients
update Consul servers when the output of their checks have changed but
the status hasn't. This
defaults to 5m because often users would create checks that would run
every minute or so and whose output
contained a timestamp that would change on every iteration of the check.
This would cause a lot of writes to the Consul servers even though
the status of the check didn't change.

In our use-case, we only update the check when the pod's readiness
status changes, so we won't be spamming updates. We run into an issue
though because we always set the check to failing when the pod is first
created and then, because of an issue with Consul where you can't set
the check output on first creation, we issue an update to the check with
the same status (critical) but with output "Pod is pending". This output
will take 5 minutes to show up in the UI without this setting. That
might be okay if the pod immediately becomes healthy but if it doesn't
then it's likely going to be confusing for users why the check is
failing but it doesn't have any output.

Additionally, if the pod's readiness probes fail immediately, then we'll
update the output to be something like "Readiness probes failing" but
again, the UI won't be updated because the status is still critical and
so again the UI would show the check failing with no output.

(also rename the test file to match the file it's testing as per our convention).