### PR TITLE
Support passing extra arguments to injected envoy binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+IMPROVEMENTS:
+  * Connect: support passing extra arguments to the injected envoy sidecar. [[GH-675](https://github.com/hashicorp/consul-helm/pull/675)]
+
+    To pass extra arguments to envoy, set `connectInject.envoyExtraArgs` in your
+    Helm configuration:
+
+    ```yaml
+    connectInject:
+      enabled: true
+      envoyExtraArgs: "--log-level debug --disable-hot-restart"
+    ```
+
 ## 0.25.0 (Oct 12, 2020)
 
 FEATURES:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -89,6 +89,9 @@ spec:
                 -enable-health-checks-controller=true \
                 -health-checks-reconcile-period={{ .Values.connectInject.healthChecks.reconcilePeriod }} \
                 {{- end }}
+                {{- if .Values.connectInject.envoyExtraArgs }}
+                -envoy-extra-args="{{ .Values.connectInject.envoyExtraArgs }}" \
+                {{- end }}
                 {{- if .Values.connectInject.overrideAuthMethodName }}
                 -acl-auth-method="{{ .Values.connectInject.overrideAuthMethodName }}" \
                 {{- else if .Values.global.acls.manageSystemACLs }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -224,6 +224,31 @@ load _helpers
 
 
 #--------------------------------------------------------------------
+# extra envoy args
+
+@test "connectInject/Deployment: extra envoy args can be set via connectInject" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.envoyExtraArgs=--foo bar --boo baz' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-envoy-extra-args=\"--foo bar --boo baz\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: extra envoy args are not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-envoy-extra-args"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+
+#--------------------------------------------------------------------
 # cert secrets
 
 @test "connectInject/Deployment: no secretName: no tls-{cert,key}-file set" {

--- a/values.yaml
+++ b/values.yaml
@@ -821,6 +821,11 @@ connectInject:
     # at startup is completed.
     reconcilePeriod: "1m"
 
+  # envoyExtraArgs is used to pass arguments to the injected envoy sidecar.
+  # Valid arguments to pass to envoy can be found here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli
+  # e.g "--log-level debug --disable-hot-restart"
+  envoyExtraArgs: null
+
   # Optional priorityClassName.
   priorityClassName: ""
 


### PR DESCRIPTION
When a user sets `connectInject.envoyExtraArgs` value, they can send
arguments to the injected envoy sidecar binary. For example, in a
development environment, we could consider enabling debug logs in all
sidecars.

Sample values file:
```
connectInject:
  enabled: true
  envoyExtraArgs: "--log-level debug --disable-hot-restart"
```

Corresponding consul-k8s PR: https://github.com/hashicorp/consul-k8s/pull/378