### PR TITLE
update values file comments for health checks and enable health checks by default

### DIFF
--- a/test/unit/connect-inject-clusterrole.bats
+++ b/test/unit/connect-inject-clusterrole.bats
@@ -76,7 +76,19 @@ load _helpers
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs for namespaces
 
-@test "connectInject/ClusterRole: does not allow secret access with global.bootsrapACLs=true" {
+@test "connectInject/ClusterRole: does not allow secret access with global.bootsrapACLs=true and healthChecks.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-clusterrole.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.healthChecks.enabled=false' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
+
+@test "connectInject/ClusterRole: secret access with global.bootsrapACLs=true and healthChecks enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/connect-inject-clusterrole.yaml  \
@@ -84,7 +96,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
+  [ "${actual}" = "1" ]
 }
 
 @test "connectInject/ClusterRole: allow secret access with global.bootsrapACLs=true and global.enableConsulNamespaces=true" {

--- a/values.yaml
+++ b/values.yaml
@@ -809,16 +809,16 @@ connectInject:
   image: null # image for consul-k8s that contains the injector
   default: false # true will inject by default, otherwise requires annotation
 
-  # healthChecks enables propagation of k8s pod health status to Consul service instances.
+  # healthChecks enables Synchronization of Kubernetes health probe status with Consul.
   # NOTE: It is highly recommended to enable TLS with this feature because it requires
   # making calls to Consul clients across the cluster. Without TLS enabled, these calls
   # could leak ACL tokens.
   healthChecks:
-    # Enables the Consul Health Check controller that syncs the readiness checks on
-    # connect-injected services with the agent.
-    enabled: false
-    # reconcilePeriod defines how often a full state reconcile is done after the initial reconcile
-    # at startup is completed.
+    # Enables the Consul Health Check controller which syncs the readiness status of
+    # connect-injected pods with Consul.
+    enabled: true
+    # If `healthChecks.enabled` is set to `true`, `reconcilePeriod` defines how often a full state
+    # reconcile is done after the initial reconcile at startup is completed.
     reconcilePeriod: "1m"
 
   # envoyExtraArgs is used to pass arguments to the injected envoy sidecar.

--- a/values.yaml
+++ b/values.yaml
@@ -809,7 +809,7 @@ connectInject:
   image: null # image for consul-k8s that contains the injector
   default: false # true will inject by default, otherwise requires annotation
 
-  # healthChecks enables Synchronization of Kubernetes health probe status with Consul.
+  # healthChecks enables synchronization of Kubernetes health probe status with Consul.
   # NOTE: It is highly recommended to enable TLS with this feature because it requires
   # making calls to Consul clients across the cluster. Without TLS enabled, these calls
   # could leak ACL tokens.


### PR DESCRIPTION
Updating values.yaml file comments for health checks to be a bit more descriptive.
This also enables health checks by default.