### PR TITLE
Enable envoy sidecar debug logs in acceptance tests

### DIFF
--- a/test/acceptance/framework/consul/consul_cluster.go
+++ b/test/acceptance/framework/consul/consul_cluster.go
@@ -52,10 +52,11 @@ func NewHelmCluster(
 	cfg *config.TestConfig,
 	releaseName string) Cluster {
 
-	// Deploy single-server cluster by default unless helmValues overwrites that
+	// Deploy with the following defaults unless helmValues overwrites it.
 	values := map[string]string{
-		"server.replicas":        "1",
-		"server.bootstrapExpect": "1",
+		"server.replicas":              "1",
+		"server.bootstrapExpect":       "1",
+		"connectInject.envoyExtraArgs": "--log-level debug",
 	}
 	valuesFromConfig, err := cfg.HelmValuesFromConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
* Envoy sidecar debug logs are enabled by default anytime you run acceptance tests