### PR TITLE
Error mirroringK8S=true but Consul NS's disabled

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}
+{{- if and .Values.connectInject.consulNamespaces.mirroringK8S (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if mirroringK8S=true" }}{{ end }}
 {{- if .Values.connectInject.imageEnvoy }}{{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" }}{{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -683,6 +683,17 @@ load _helpers
 #--------------------------------------------------------------------
 # namespaces
 
+@test "connectInject/Deployment: fails if namespaces are disabled and mirroringK8S is true" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'global.enableConsulNamespaces=false' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --set 'connectInject.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.enableConsulNamespaces must be true if mirroringK8S=true" ]]
+}
+
 @test "connectInject/Deployment: namespace options disabled by default" {
   cd `chart_dir`
   local object=$(helm template \


### PR DESCRIPTION
Based on an issue someone had reported. They had set
```yaml
connectInject:
  consulNamespaces:
    mirroringK8S: true
```

But didn't have

```yaml
global:
  enableConsulNamespaces: true
```

This caused us to ignore that configuration.

NOTE: We can't error on `connectInject.consulNamespaces.destinationNS` because that has a default value so it's always set.