### PR TITLE
Run Acceptance tests against EKS 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: bats ./test/unit
   unit-helm3:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.6.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.7.0
 
     steps:
       - checkout
@@ -96,7 +96,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.5.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.7.0
 
     steps:
       - run:
@@ -172,7 +172,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.5.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.7.0
 
     steps:
       - checkout
@@ -238,6 +238,86 @@ jobs:
           fail_only: true
           failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
+  acceptance-eks-1-17:
+    environment:
+      - TEST_RESULTS: /tmp/test-results
+    docker:
+      # This image is build from test/docker/Test.dockerfile
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.7.0
+
+    steps:
+      - checkout
+
+      - run:
+          name: assume-role aws creds
+          command: |
+            # assume role has duration of 2 hr
+            CREDENTIALS="$(aws sts assume-role --duration-seconds 7200 --role-arn ${ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
+            echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
+
+      - run:
+          name: terraform init & apply
+          working_directory: test/terraform/eks
+          command: |
+            terraform init
+
+            terraform apply -var cluster_count=2 -auto-approve
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+
+      - run: mkdir -p $TEST_RESULTS
+
+      - run:
+          name: Run acceptance tests
+          working_directory: test/acceptance/tests
+          no_output_timeout: 1h
+          command: |
+            export primary_kubeconfig=$(terraform output -state ../../terraform/eks/terraform.tfstate -json | jq -r .kubeconfigs.value[0])
+            export secondary_kubeconfig=$(terraform output -state ../../terraform/eks/terraform.tfstate -json | jq -r .kubeconfigs.value[1])
+
+            # We have to run the tests for each package separately so that we can
+            # exit early if any test fails (-failfast only works within a single
+            # package).
+            exit_code=0
+            for pkg in $(go list ./...)
+            do
+              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
+                    -enable-enterprise \
+                    -enable-multi-cluster \
+                    -kubeconfig="$primary_kubeconfig" \
+                    -secondary-kubeconfig="$secondary_kubeconfig" \
+                    -debug-directory="$TEST_RESULTS/debug" \
+                    -consul-k8s-image=hashicorpdev/consul-k8s:latest
+              then
+                echo "Tests in ${pkg} failed, aborting early"
+                exit_code=1
+                break
+              fi
+            done
+            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
+            exit $exit_code
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+      - run:
+          name: terraform destroy
+          working_directory: test/terraform/eks
+          command: |
+            terraform destroy -auto-approve
+          when: always
+
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+
   acceptance-openshift:
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -246,7 +326,7 @@ jobs:
       - OC_SECONDARY_NAME: consul-helm-test-3737660519
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.6.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.7.0
 
     steps:
       - checkout
@@ -332,11 +412,11 @@ workflows:
             - go-fmt-and-vet
       - unit-helm2
       - unit-helm3
-      - acceptance:
-          requires:
-            - unit-helm2
-            - unit-helm3
-            - unit-acceptance-framework
+#      - acceptance-eks-1-17:
+#          requires:
+##            - unit-helm2
+##            - unit-helm3
+#            - unit-acceptance-framework
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -12,7 +12,7 @@ FROM circleci/golang:1.14
 USER root
 
 ENV BATS_VERSION "1.1.0"
-ENV TERRAFORM_VERSION "0.12.26"
+ENV TERRAFORM_VERSION "0.13.5"
 
 # base packages
 RUN apt-get install -y \
@@ -53,6 +53,13 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz \
     && tar -zxvf /tmp/oc.tar.gz -C /tmp  \
     && mv /tmp/oc /usr/local/bin/oc
+
+# AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install --bin-dir /usr/local/bin \
+    && rm awscliv2.zip \
+    && rm -rf ./aws
 
 # change the user back to what circleci/golang image has
 USER circleci

--- a/test/terraform/eks/main.tf
+++ b/test/terraform/eks/main.tf
@@ -1,0 +1,77 @@
+provider "aws" {
+  version = ">= 2.28.1"
+  region  = "us-west-2"
+}
+
+resource "random_id" "suffix" {
+  count       = var.cluster_count
+  byte_length = 4
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+module "vpc" {
+  count   = var.cluster_count
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.47.0"
+
+  name                 = "consul-k8s-${random_id.suffix[count.index].dec}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/consul-k8s-${random_id.suffix[count.index].dec}" = "shared"
+    "kubernetes.io/role/elb"                                                = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/consul-k8s-${random_id.suffix[count.index].dec}" = "shared"
+    "kubernetes.io/role/internal-elb"                                       = "1"
+  }
+}
+
+module "eks" {
+  count = var.cluster_count
+
+  source  = "terraform-aws-modules/eks/aws"
+  version = "12.2.0"
+
+  cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
+  cluster_version = "1.17"
+  subnets         = module.vpc[count.index].private_subnets
+
+  vpc_id = module.vpc[count.index].vpc_id
+
+  node_groups = {
+    first = {
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+
+      instance_type = "m5.large"
+    }
+  }
+
+  write_kubeconfig   = true
+  config_output_path = pathexpand("~/.kube/consul-k8s-${random_id.suffix[count.index].dec}")
+}
+
+data "aws_eks_cluster" "cluster" {
+  count = var.cluster_count
+  name  = module.eks[count.index].cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  count = var.cluster_count
+  name  = module.eks[count.index].cluster_id
+}

--- a/test/terraform/eks/outputs.tf
+++ b/test/terraform/eks/outputs.tf
@@ -1,0 +1,3 @@
+output "kubeconfigs" {
+  value = [for cl in module.eks : pathexpand(format("~/.kube/%s", cl.cluster_id))]
+}

--- a/test/terraform/eks/variables.tf
+++ b/test/terraform/eks/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  default     = "us-west-2"
+  description = "AWS region"
+}
+
+variable "cluster_count" {
+  default     = 1
+  description = "The number of Kubernetes clusters to create."
+}


### PR DESCRIPTION
* Add terraform to create EKS clusters
* Update test docker image to use terraform 1.13
  so that we can use "count" with terraform modules.
* Add AWS CLI to the terraform docker image
* Add a circleci job to run acceptance tests against EKS.

Note: Waiting for EKS creds for circleci to be created so that we can run these in CI. I've ran both TF and a subset of tests locally, and it all works.

TODO:
- [] Run tests in CI
- [] Once they pass, move the job to the nightly pipeline