### PR TITLE
acceptance-tests: use new logger with timestamps everywhere

### DIFF
--- a/test/acceptance/framework/k8s/debug.go
+++ b/test/acceptance/framework/k8s/debug.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/logger"
+	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,13 +31,13 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 		testDebugDirectory := filepath.Join(debugDirectory, t.Name(), contextName)
 		require.NoError(t, os.MkdirAll(testDebugDirectory, 0755))
 
-		t.Logf("dumping logs and pod info for %s to %s", labelSelector, testDebugDirectory)
+		logger.Logf(t, "dumping logs and pod info for %s to %s", labelSelector, testDebugDirectory)
 		pods, err := client.CoreV1().Pods(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		require.NoError(t, err)
 
 		for _, pod := range pods.Items {
 			// Get logs for each pod, passing the discard logger to make sure secrets aren't printed to test logs.
-			logs, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "logs", "--all-containers=true", pod.Name)
+			logs, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "logs", "--all-containers=true", pod.Name)
 
 			// Write logs or err to file name <pod.Name>.log
 			logFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.log", pod.Name))
@@ -78,7 +79,7 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 // e.g. 'daemonset' so that this function can run 'kubectl describe daemonset foo'.
 func writeResourceInfoToFile(t *testing.T, resourceName, resourceType, testDebugDirectory string, kubectlOptions *k8s.KubectlOptions) {
 	// Describe resource
-	desc, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, logger.Discard, "describe", resourceType, resourceName)
+	desc, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "describe", resourceType, resourceName)
 
 	// Write resource info or error to file name <resource.Name>-resourceType.txt
 	if err != nil {

--- a/test/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/test/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -167,7 +167,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 			// We are expecting a "connection reset by peer" error because in a case of health checks,
 			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
 			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
-			t.Log("checking that connection is unsuccessful")
+			logger.Log(t, "checking that connection is unsuccessful")
 			k8s.CheckStaticServerConnectionMultipleFailureMessages(
 				t,
 				staticClientOpts,

--- a/test/acceptance/tests/controller/controller_namespaces_test.go
+++ b/test/acceptance/tests/controller/controller_namespaces_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/consul"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -93,7 +94,7 @@ func TestControllerNamespaces(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			t.Logf("creating namespace %q", KubeNS)
+			logger.Logf(t, "creating namespace %q", KubeNS)
 			out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "create", "ns", KubeNS)
 			if err != nil && !strings.Contains(out, "(AlreadyExists)") {
 				require.NoError(t, err)
@@ -119,7 +120,7 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test creation.
 			{
-				t.Log("creating custom resources")
+				logger.Log(t, "creating custom resources")
 				retry.Run(t, func(r *retry.R) {
 					// Retry the kubectl apply because we've seen sporadic
 					// "connection refused" errors where the mutating webhook
@@ -180,26 +181,26 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test updates.
 			{
-				t.Log("patching service-defaults custom resource")
+				logger.Log(t, "patching service-defaults custom resource")
 				patchProtocol := "tcp"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicedefaults", "defaults", "-p", fmt.Sprintf(`{"spec":{"protocol":"%s"}}`, patchProtocol), "--type=merge")
 
-				t.Log("patching service-resolver custom resource")
+				logger.Log(t, "patching service-resolver custom resource")
 				patchRedirectSvc := "baz"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "serviceresolver", "resolver", "-p", fmt.Sprintf(`{"spec":{"redirect":{"service": "%s"}}}`, patchRedirectSvc), "--type=merge")
 
-				t.Log("patching proxy-defaults custom resource")
+				logger.Log(t, "patching proxy-defaults custom resource")
 				patchMeshGatewayMode := "remote"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
-				t.Log("patching service-router custom resource")
+				logger.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicerouter", "router", "-p", fmt.Sprintf(`{"spec":{"routes":[{"match":{"http":{"pathPrefix":"%s"}}}]}}`, patchPathPrefix), "--type=merge")
 
-				t.Log("patching service-splitter custom resource")
+				logger.Log(t, "patching service-splitter custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "servicesplitter", "splitter", "-p", `{"spec": {"splits": [{"weight": 50}, {"weight": 50, "service": "other-splitter"}]}}`, "--type=merge")
 
-				t.Log("patching service-intentions custom resource")
+				logger.Log(t, "patching service-intentions custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "serviceintentions", "intentions", "-p", `{"spec": {"sources": [{"name": "svc2", "action": "deny"}]}}`, "--type=merge")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}
@@ -252,22 +253,22 @@ func TestControllerNamespaces(t *testing.T) {
 
 			// Test a delete.
 			{
-				t.Log("deleting service-defaults custom resource")
+				logger.Log(t, "deleting service-defaults custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicedefaults", "defaults")
 
-				t.Log("deleting service-resolver custom resource")
+				logger.Log(t, "deleting service-resolver custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "serviceresolver", "resolver")
 
-				t.Log("deleting proxy-defaults custom resource")
+				logger.Log(t, "deleting proxy-defaults custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "proxydefaults", "global")
 
-				t.Log("deleting service-router custom resource")
+				logger.Log(t, "deleting service-router custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicerouter", "router")
 
-				t.Log("deleting service-splitter custom resource")
+				logger.Log(t, "deleting service-splitter custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "servicesplitter", "splitter")
 
-				t.Log("deleting service-intentions custom resource")
+				logger.Log(t, "deleting service-intentions custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-n", KubeNS, "serviceintentions", "intentions")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/consul"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -55,7 +56,7 @@ func TestController(t *testing.T) {
 
 			// Test creation.
 			{
-				t.Log("creating custom resources")
+				logger.Log(t, "creating custom resources")
 				retry.Run(t, func(r *retry.R) {
 					// Retry the kubectl apply because we've seen sporadic
 					// "connection refused" errors where the mutating webhook
@@ -121,26 +122,26 @@ func TestController(t *testing.T) {
 
 			// Test updates.
 			{
-				t.Log("patching service-defaults custom resource")
+				logger.Log(t, "patching service-defaults custom resource")
 				patchProtocol := "tcp"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicedefaults", "defaults", "-p", fmt.Sprintf(`{"spec":{"protocol":"%s"}}`, patchProtocol), "--type=merge")
 
-				t.Log("patching service-resolver custom resource")
+				logger.Log(t, "patching service-resolver custom resource")
 				patchRedirectSvc := "baz"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "serviceresolver", "resolver", "-p", fmt.Sprintf(`{"spec":{"redirect":{"service": "%s"}}}`, patchRedirectSvc), "--type=merge")
 
-				t.Log("patching proxy-defaults custom resource")
+				logger.Log(t, "patching proxy-defaults custom resource")
 				patchMeshGatewayMode := "remote"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
-				t.Log("patching service-router custom resource")
+				logger.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicerouter", "router", "-p", fmt.Sprintf(`{"spec":{"routes":[{"match":{"http":{"pathPrefix":"%s"}}}]}}`, patchPathPrefix), "--type=merge")
 
-				t.Log("patching service-splitter custom resource")
+				logger.Log(t, "patching service-splitter custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "servicesplitter", "splitter", "-p", `{"spec": {"splits": [{"weight": 50}, {"weight": 50, "service": "other-splitter"}]}}`, "--type=merge")
 
-				t.Log("patching service-intentions custom resource")
+				logger.Log(t, "patching service-intentions custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "serviceintentions", "intentions", "-p", `{"spec": {"sources": [{"name": "svc2", "action": "deny"}, {"name": "svc3", "permissions": [{"action": "deny", "http": {"pathExact": "/foo", "methods": ["GET", "PUT"]}}]}]}}`, "--type=merge")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}
@@ -194,22 +195,22 @@ func TestController(t *testing.T) {
 
 			// Test a delete.
 			{
-				t.Log("deleting service-defaults custom resource")
+				logger.Log(t, "deleting service-defaults custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicedefaults", "defaults")
 
-				t.Log("deleting service-resolver custom resource")
+				logger.Log(t, "deleting service-resolver custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "serviceresolver", "resolver")
 
-				t.Log("deleting proxy-defaults custom resource")
+				logger.Log(t, "deleting proxy-defaults custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "proxydefaults", "global")
 
-				t.Log("deleting service-router custom resource")
+				logger.Log(t, "deleting service-router custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicerouter", "router")
 
-				t.Log("deleting service-splitter custom resource")
+				logger.Log(t, "deleting service-splitter custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "servicesplitter", "splitter")
 
-				t.Log("deleting service-intentions custom resource")
+				logger.Log(t, "deleting service-intentions custom resource")
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "serviceintentions", "intentions")
 
 				counter := &retry.Counter{Count: 10, Wait: 500 * time.Millisecond}


### PR DESCRIPTION
This is a follow up to #671: change remaining tests and framework functions to use the new logger with timestaamps.