### PR TITLE
Run acceptance tests against a cluster with Pod security policies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
                     -enable-enterprise \
                     -enterprise-license-secret-name=ent-license \
                     -enterprise-license-secret-key=key \
+                    -enable-pod-security-policies \
                     -enable-multi-cluster \
                     -kubeconfig="$primary_kubeconfig" \
                     -secondary-kubeconfig="$secondary_kubeconfig" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,14 @@ Below is the list of available flags:
     The consul-k8s image to use for all tests.
 -debug-directory
     The directory where to write debug information about failed test runs, such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
--enable-multi-cluster
-    If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -enable-enterprise
     If true, the test suite will run tests for enterprise features. Note that some features may require setting the enterprise license flags below.
+-enable-multi-cluster
+    If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
+-enable-openshift
+    If true, the tests will automatically add Openshift Helm value for each Helm install.
+-enable-pod-security-policies
+    If true, the test suite will run tests with pod security policies enabled.
 -enterprise-license-secret-name
     The name of the Kubernetes secret containing the enterprise license.
 -enterprise-license-secret-key

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -29,6 +29,8 @@ type TestConfig struct {
 
 	EnableOpenshift bool
 
+	EnablePodSecurityPolicies bool
+
 	ConsulImage    string
 	ConsulK8SImage string
 
@@ -60,6 +62,10 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 
 	if t.EnableOpenshift {
 		setIfNotEmpty(helmValues, "global.openshift.enabled", "true")
+	}
+
+	if t.EnablePodSecurityPolicies {
+		setIfNotEmpty(helmValues, "global.enablePodSecurityPolicies", "true")
 	}
 
 	setIfNotEmpty(helmValues, "global.image", t.ConsulImage)

--- a/test/acceptance/framework/config/config_test.go
+++ b/test/acceptance/framework/config/config_test.go
@@ -76,6 +76,15 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 				"global.openshift.enabled": "true",
 			},
 		},
+		{
+			"sets enablePodSecurity policies when -enable-pod-security-policies is set",
+			TestConfig{
+				EnablePodSecurityPolicies: true,
+			},
+			map[string]string{
+				"global.enablePodSecurityPolicies": "true",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/acceptance/framework/config/config_test.go
+++ b/test/acceptance/framework/config/config_test.go
@@ -77,7 +77,7 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 			},
 		},
 		{
-			"sets enablePodSecurity policies when -enable-pod-security-policies is set",
+			"sets enablePodSecurityPolicies helm value when -enable-pod-security-policies is set",
 			TestConfig{
 				EnablePodSecurityPolicies: true,
 			},

--- a/test/acceptance/framework/consul/consul_cluster.go
+++ b/test/acceptance/framework/consul/consul_cluster.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
+	policyv1beta "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +38,7 @@ type Cluster interface {
 // HelmCluster implements Cluster and uses Helm
 // to create, destroy, and upgrade consul
 type HelmCluster struct {
+	cfg                config.TestConfig
 	ctx                environment.TestContext
 	helmOptions        *helm.Options
 	releaseName        string
@@ -50,7 +53,12 @@ func NewHelmCluster(
 	helmValues map[string]string,
 	ctx environment.TestContext,
 	cfg *config.TestConfig,
-	releaseName string) Cluster {
+	releaseName string,
+) Cluster {
+
+	if cfg.EnablePodSecurityPolicies {
+		configurePodSecurityPolicies(t, ctx.KubernetesClient(t), cfg, ctx.KubectlOptions(t).Namespace)
+	}
 
 	// Deploy with the following defaults unless helmValues overwrites it.
 	values := map[string]string{
@@ -253,6 +261,113 @@ func (h *HelmCluster) checkForPriorInstallations(t *testing.T) {
 	for _, r := range installedReleases {
 		require.NotContains(t, r["chart"], "consul", fmt.Sprintf("detected an existing installation of Consul %s, release name: %s", r["chart"], r["name"]))
 	}
+}
+
+// configurePodSecurityPolicies creates a simple pod security policy, a cluster role to allow access to the PSP,
+// and a role binding that binds the default service account in the helm installation namespace to the cluster role.
+// We bind the default service account for tests that are spinning up pods without a service account set so that
+// they will not be rejected by the kube pod security policy controller.
+func configurePodSecurityPolicies(t *testing.T, client kubernetes.Interface, cfg *config.TestConfig, namespace string) {
+	pspName := "test-psp"
+
+	// Pod Security Policy
+	{
+		// Check if the pod security policy with this name already exists
+		psp, err := client.PolicyV1beta1().PodSecurityPolicies().Get(context.Background(), pspName, metav1.GetOptions{})
+		// If it doesn't exist, create it.
+		if errors.IsNotFound(err) {
+			// This pod security policy can be used by any tests resources.
+			// This policy is fairly simple and only prevents from running privileged containers.
+			psp = &policyv1beta.PodSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-psp",
+				},
+				Spec: policyv1beta.PodSecurityPolicySpec{
+					Privileged: false,
+					SELinux: policyv1beta.SELinuxStrategyOptions{
+						Rule: policyv1beta.SELinuxStrategyRunAsAny,
+					},
+					SupplementalGroups: policyv1beta.SupplementalGroupsStrategyOptions{
+						Rule: policyv1beta.SupplementalGroupsStrategyRunAsAny,
+					},
+					RunAsUser: policyv1beta.RunAsUserStrategyOptions{
+						Rule: policyv1beta.RunAsUserStrategyRunAsAny,
+					},
+					FSGroup: policyv1beta.FSGroupStrategyOptions{
+						Rule: policyv1beta.FSGroupStrategyRunAsAny,
+					},
+					Volumes: []policyv1beta.FSType{policyv1beta.All},
+				},
+			}
+			_, err = client.PolicyV1beta1().PodSecurityPolicies().Create(context.Background(), psp, metav1.CreateOptions{})
+			require.NoError(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	// Cluster role for the PSP.
+	{
+		// Check if we have a cluster role that authorizes the use of the pod security policy.
+		pspClusterRole, err := client.RbacV1().ClusterRoles().Get(context.Background(), pspName, metav1.GetOptions{})
+
+		// If it doesn't exist, create the clusterrole.
+		if errors.IsNotFound(err) {
+			pspClusterRole = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pspName,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:         []string{"use"},
+						APIGroups:     []string{"policy"},
+						Resources:     []string{"podsecuritypolicies"},
+						ResourceNames: []string{pspName},
+					},
+				},
+			}
+			_, err = client.RbacV1().ClusterRoles().Create(context.Background(), pspClusterRole, metav1.CreateOptions{})
+			require.NoError(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	// A role binding to allow default service account in the installation namespace access to the PSP.
+	{
+		// Check if this cluster role binding already exists.
+		pspRoleBinding, err := client.RbacV1().RoleBindings(namespace).Get(context.Background(), pspName, metav1.GetOptions{})
+
+		if errors.IsNotFound(err) {
+			pspRoleBinding = &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pspName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "default",
+						Namespace: namespace,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: pspName,
+				},
+			}
+
+			_, err = client.RbacV1().RoleBindings(namespace).Create(context.Background(), pspRoleBinding, metav1.CreateOptions{})
+			require.NoError(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		client.PolicyV1beta1().PodSecurityPolicies().Delete(context.Background(), pspName, metav1.DeleteOptions{})
+		client.RbacV1().ClusterRoles().Delete(context.Background(), pspName, metav1.DeleteOptions{})
+		client.RbacV1().RoleBindings(namespace).Delete(context.Background(), pspName, metav1.DeleteOptions{})
+	})
 }
 
 // mergeValues will merge the values in b with values in a and save in a.

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -24,6 +24,8 @@ type TestFlags struct {
 
 	flagEnableOpenshift bool
 
+	flagEnablePodSecurityPolicies bool
+
 	flagConsulImage    string
 	flagConsulK8sImage string
 
@@ -71,6 +73,9 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagEnableOpenshift, "enable-openshift", false,
 		"If true, the tests will automatically add Openshift Helm value for each Helm install.")
 
+	flag.BoolVar(&t.flagEnablePodSecurityPolicies, "enable-pod-security-policies", false,
+		"If true, the test suite will run tests with pod security policies enabled.")
+
 	flag.BoolVar(&t.flagNoCleanupOnFailure, "no-cleanup-on-failure", false,
 		"If true, the tests will not cleanup Kubernetes resources they create when they finish running."+
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
@@ -113,6 +118,8 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		EnterpriseLicenseSecretKey:  t.flagEnterpriseLicenseSecretKey,
 
 		EnableOpenshift: t.flagEnableOpenshift,
+
+		EnablePodSecurityPolicies: t.flagEnablePodSecurityPolicies,
 
 		ConsulImage:    t.flagConsulImage,
 		ConsulK8SImage: t.flagConsulK8sImage,

--- a/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - deployment.yaml
   - serviceaccount.yaml
+  - rolebinding.yaml

--- a/test/acceptance/tests/fixtures/bases/static-client/rolebinding.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-client
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-psp
+subjects:
+  - kind: ServiceAccount
+    name: static-client

--- a/test/acceptance/tests/fixtures/bases/static-server/kustomization.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-server/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - serviceaccount.yaml
+  - rolebinding.yaml

--- a/test/acceptance/tests/fixtures/bases/static-server/rolebinding.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-server/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-psp
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -1,4 +1,4 @@
-provider "google" {
+provider "google-beta" {
   project = var.project
 }
 
@@ -13,6 +13,8 @@ data "google_container_engine_versions" "main" {
 }
 
 resource "google_container_cluster" "cluster" {
+  provider = "google-beta"
+
   count = var.cluster_count
 
   name               = "consul-k8s-${random_id.suffix[count.index].dec}"
@@ -21,6 +23,10 @@ resource "google_container_cluster" "cluster" {
   location           = var.zone
   min_master_version = data.google_container_engine_versions.main.latest_master_version
   node_version       = data.google_container_engine_versions.main.latest_master_version
+
+  pod_security_policy_config {
+    enabled = true
+  }
 }
 
 resource "null_resource" "kubectl" {

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -1,5 +1,6 @@
 provider "google-beta" {
   project = var.project
+  version = "~> 3.49.0"
 }
 
 resource "random_id" "suffix" {


### PR DESCRIPTION
* Enable pod security policies on a GKE cluster. 
* Add `enable-pod-security-policies` flag to acceptance tests framework. When this flag is set, the tests will:
   * set `global.enablePodSecurityPolicies` helm value for all helm installs
   * Create a simple pod security policy, a cluster role that allows access to it, and a role binding, linking psp cluster role to the  default service account in the helm installation namespace. We need these so that test resources we create, like static-client, static-server, and any other test pods we spin up, won't be rejected by the pod security policy controller.
  * Add a role binding to the static-server and static-client base fixtures to bind their service accounts to the psp cluster role.