### PR TITLE
Fix kubeconfig file permissions for AKS

### DIFF
--- a/test/terraform/aks/main.tf
+++ b/test/terraform/aks/main.tf
@@ -42,7 +42,8 @@ resource "azurerm_kubernetes_cluster" "default" {
 }
 
 resource "local_file" "kubeconfigs" {
-  count    = var.cluster_count
-  content  = azurerm_kubernetes_cluster.default[count.index].kube_config_raw
-  filename = pathexpand("~/.kube/consul-k8s-${random_id.suffix[count.index].dec}")
+  count           = var.cluster_count
+  content         = azurerm_kubernetes_cluster.default[count.index].kube_config_raw
+  filename        = pathexpand("~/.kube/consul-k8s-${random_id.suffix[count.index].dec}")
+  file_permission = "0600"
 }


### PR DESCRIPTION
Helm will give you warnings if the kubeconfig file is world-readable, and our acceptance tests will fail to parse output of helm list showing errors like this:

```
    basic_test.go:48: 
        	Error Trace:	consul_cluster.go:251
        	            				consul_cluster.go:97
        	            				basic_test.go:48
        	Error:      	Received unexpected error:
        	            	invalid character 'W' looking for beginning of value
        	Test:       	TestBasicInstallation/secure:_false,_auto-encrypt:_false
    helpers.go:82: 2020-11-26T00:07:19Z cleaning up resources for TestBasicInstallation/secure:_false,_auto-encrypt:_false
    consul_cluster.go:93: 2020-11-26T00:07:19Z dumping logs and pod info for release=test-kqpy1v to /tmp/test-results/debug/TestBasicInstallation/secure:_false,_auto-encrypt:_false/consul-k8s-2255643996
    command.go:100: 2020-11-26T00:07:19Z Running command helm with args [delete --kubeconfig /home/circleci/.kube/consul-k8s-2255643996 --keep-history --namespace default test-kqpy1v]
    command.go:179: 2020-11-26T00:07:19Z WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/circleci/.kube/consul-k8s-2255643996
    command.go:179: 2020-11-26T00:07:19Z WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/circleci/.kube/consul-k8s-2255643996
    command.go:179: 2020-11-26T00:07:20Z Error: uninstall: Release not loaded: test-kqpy1v: release: not found
    --- FAIL: TestBasicInstallation/secure:_false,_auto-encrypt:_false (1.77s)
```