### PR TITLE
Include output if json unmarshall fails

### DIFF
--- a/test/acceptance/framework/consul/consul_cluster.go
+++ b/test/acceptance/framework/consul/consul_cluster.go
@@ -248,7 +248,7 @@ func (h *HelmCluster) checkForPriorInstallations(t *testing.T) {
 	var installedReleases []map[string]string
 
 	err = json.Unmarshal([]byte(output), &installedReleases)
-	require.NoError(t, err)
+	require.NoError(t, err, "unmarshalling %q", output)
 
 	for _, r := range installedReleases {
 		require.NotContains(t, r["chart"], "consul", fmt.Sprintf("detected an existing installation of Consul %s, release name: %s", r["chart"], r["name"]))


### PR DESCRIPTION
Otherwise we just get
```
invalid character 'W' looking for beginning of value
```