### PR TITLE
Allow configuring of terminationGracePeriodSeconds

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       tolerations:
         {{ tpl .Values.client.tolerations . | nindent 8 | trim }}
     {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.client.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" . }}-client
 
       {{- if .Values.client.priorityClassName }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" . }}-server
       {{- if not .Values.global.openshift.enabled}}
       securityContext:

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -392,6 +392,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# terminationGracePeriodSeconds
+
+@test "client/DaemonSet: default terminationGracePeriodSeconds is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "10" ]
+}
+
+@test "client/DaemonSet: default terminationGracePeriodSeconds can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.terminationGracePeriodSeconds=30' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "30" ]
+}
+
+#--------------------------------------------------------------------
 # tolerations
 
 @test "client/DaemonSet: tolerations not set by default" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -423,6 +423,29 @@ load _helpers
   [ "${actual}" = 83df36fdaf1b4acb815f1764f9ff2782c520ca012511f282ba9c57a04401a239 ]
 }
 
+
+#--------------------------------------------------------------------
+# terminationGracePeriodSeconds
+
+@test "server/StatefulSet: default terminationGracePeriodSeconds is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml   \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "30" ]
+}
+
+@test "server/StatefulSet: default terminationGracePeriodSeconds can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml   \
+      --set 'server.terminationGracePeriodSeconds=60' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "60" ]
+}
+
 #--------------------------------------------------------------------
 # tolerations
 

--- a/values.yaml
+++ b/values.yaml
@@ -297,6 +297,12 @@ server:
   extraConfig: |
     {}
 
+  # terminationGracePeriodSeconds is the number of seconds Kubernetes will wait
+  # before sending SIGKILL to kill the process during a pod shutdown. Increase this
+  # if you frequently find nodes that have left "uncleanly", resulting in the node
+  # being left in a "critical" state in the catalog
+  terminationGracePeriodSeconds: 30
+
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Consul in the path `/consul/userconfig/<name>/`. The value below is
   # an array of objects, examples are shown below.
@@ -457,6 +463,12 @@ client:
   # client. This should be JSON.
   extraConfig: |
     {}
+
+  # terminationGracePeriodSeconds is the number of seconds Kubernetes will wait
+  # before sending SIGKILL to kill the process during a pod shutdown. Increase this
+  # if you frequently find nodes that have left "uncleanly", resulting in the node
+  # being left in a "critical" state in the catalog
+  terminationGracePeriodSeconds: 10
 
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Consul in the path `/consul/userconfig/<name>/`. The value below is


### PR DESCRIPTION
In an autoscaling cluster that scales up and down somewhat rapidly, I notice that when scaling down, there are times when a node has been deleted (and the pod too), but the node remains in the catalog in a critical state.

This PR allows increasing the time given for the Consul pods to terminate gracefully before they are sent SIGKILL.