### PR TITLE
Add helm docs generation script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Run Unit Tests
           command: bats ./test/unit
 
-  go-fmt-and-vet:
+  go-fmt-and-vet-acceptance:
     executor: go
     steps:
       - checkout
@@ -39,7 +39,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run:
           name: go mod download
@@ -48,7 +48,7 @@ jobs:
 
       # Save go module cache if the go.mod file has changed
       - save_cache:
-          key: consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+          key: consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
           paths:
             - "/go/pkg/mod"
 
@@ -76,7 +76,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -199,7 +199,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -273,7 +273,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -355,7 +355,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -440,7 +440,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -465,6 +465,84 @@ jobs:
       - slack/status:
           fail_only: true
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+
+  go-fmt-and-vet-helm-gen:
+    executor: go
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-helm-helm-gen-modcache-v1-{{ checksum "hack/helm-reference-gen/go.mod" }}
+
+      - run:
+          name: go mod download
+          working_directory: hack/helm-reference-gen
+          command: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: consul-helm-helm-gen-modcache-v1-{{ checksum "hack/helm-reference-gen/go.mod" }}
+          paths:
+            - "/go/pkg/mod"
+
+      # check go fmt output because it does not report non-zero when there are fmt changes
+      - run:
+          name: check go fmt
+          command: |
+            files=$(go fmt ./...)
+            if [ -n "$files" ]; then
+              echo "The following file(s) do not conform to go fmt:"
+              echo "$files"
+              exit 1
+            fi
+
+      - run:
+          name: go vet
+          working_directory: hack/helm-reference-gen
+          command: go vet ./...
+
+  unit-helm-gen:
+    executor: go
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-helm-helm-gen-modcache-v1-{{ checksum "hack/helm-reference-gen/go.mod" }}
+
+      - run: mkdir -p $TEST_RESULTS
+
+      - run:
+          name: Run tests
+          working_directory: hack/helm-reference-gen
+          command: |
+            gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml ./... -- -p 4
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+  test-helm-gen:
+    executor: go
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-helm-helm-gen-modcache-v1-{{ checksum "hack/helm-reference-gen/go.mod" }}
+
+      - run: mkdir -p $TEST_RESULTS
+
+      - run:
+          name: Run tests
+          working_directory: hack/helm-reference-gen
+          command: |
+            go run ./... -validate
 
   update-helm-charts-index:
     docker:
@@ -498,10 +576,15 @@ workflows:
   version: 2
   test:
     jobs:
-      - go-fmt-and-vet
+      - go-fmt-and-vet-acceptance
+      - go-fmt-and-vet-helm-gen
       - unit-acceptance-framework:
           requires:
-            - go-fmt-and-vet
+            - go-fmt-and-vet-acceptance
+      - unit-helm-gen:
+          requires:
+            - go-fmt-and-vet-helm-gen
+      - test-helm-gen
       - unit-helm2
       - unit-helm3
       - acceptance:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,4 +378,68 @@ Here are some things to consider before adding a test:
   either Consul itself or consul-k8s? In that case, it should be tested there rather than in the Helm chart.
   For example, we don't expect acceptance tests to include all the permutations of the consul-k8s commands
   and their respective flags. Something like that should be tested in the consul-k8s repository.
+ 
+## Helm Reference Docs
+ 
+The helm reference docs (https://www.consul.io/docs/k8s/helm) are automatically
+generated from our `values.yaml` file.
 
+### Code Generation
+ 
+To generate the docs and update the `helm.mdx` file, run:
+ 
+```bash
+make gen-docs consul=<path-to-consul-repo>
+```
+
+Where `<path-to-consul-repo>` is the relative or absolute path to the `hashicorp/consul`
+repo on disk.
+
+### values.yaml Annotations
+
+The code generation will attempt to parse the `values.yaml` file and extract all
+the information needed to create the documentation but depending on the yaml
+you may need to add some annotations.
+
+#### @type
+If the type is unknown because the field is `null` or you wish to override
+the type, use `@type`:
+
+```yaml
+# My docs
+# @type: string
+myKey: null
+```
+
+#### @default
+The default will be set to the current value but you may want to override
+it for specific use cases:
+
+```yaml
+server:
+  # My docs
+  # @default: global.enabled
+  enabled: "-"
+```
+
+#### @recurse
+In rare cases, we don't want the documentation generation to recurse deeper
+into the object. To stop the recursion, set `@recurse: false`.
+For example, the ingress gateway ports config looks like:
+
+```yaml
+# Port docs
+# @type: array<map>
+# @default: [{port: 8080, port: 8443}]
+# @recurse: false
+ports:
+- port: 8080
+  nodePort: null
+- port: 8443
+  nodePort: null
+```
+
+So that the documentation can look like:
+```markdown
+- `ports` ((#v-ingressgateways-defaults-service-ports)) (`array<map>: [{port: 8080, port: 8443}]`) - Port docs
+```

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,9 @@ TEST_IMAGE?=consul-helm-test
 test-docker:
 	@docker build --rm -t '$(TEST_IMAGE)' -f $(CURDIR)/test/docker/Test.dockerfile $(CURDIR)
 
+# Generate Helm reference docs from values.yaml and update Consul website.
+# Usage: make gen-docs consul=<path-to-consul-repo>
+gen-docs:
+	@cd hack/helm-reference-gen; go run ./... $(consul)
+
 .PHONY: test-docker

--- a/hack/helm-reference-gen/doc_node.go
+++ b/hack/helm-reference-gen/doc_node.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const UnknownKindError = "unknown kind"
+
+// DocNode is a node in the final generated reference document.
+// For example this would be a single DocNode:
+// ```
+// - `global` ((#v-global)) - Holds values that affect multiple components of the chart.
+// ```
+type DocNode struct {
+	// Column is the character column (i.e. indent) this node should be displayed
+	// at.
+	// For example, if this is a root node, then its column will be 0 because it
+	// shouldn't be indented.
+	Column int
+
+	// ParentBreadcrumb is the path to this node's parent from the root.
+	// It is used for the HTML anchor, e.g. `#v-global-name`.
+	// If this node were global.name, then this would be set to "global".
+	ParentBreadcrumb string
+
+	// ParentWasMap is true when the parent of this node was a map.
+	ParentWasMap bool
+
+	// Key is the key of this node, e.g. if `key: value` then Key would be "key".
+	Key string
+
+	// Default is the default value for this node, e.g. if key defaults to false,
+	// Default would be "false".
+	Default string
+
+	// Comment is the YAML comment that described this node.
+	Comment string
+
+	// KindTag is the YAML parsed kind tag from the YAML library. This has values
+	// like "!!seq" and "!!str".
+	KindTag string
+
+	// Children are other nodes that should be displayed as sub-keys of this node.
+	Children []DocNode
+}
+
+// Validate returns an error if this node is invalid, else nil.
+func (n DocNode) Validate() error {
+	if strings.Contains(n.Kind(), UnknownKindError) {
+		return errors.New(n.Kind())
+	}
+	return nil
+}
+
+// HTMLAnchor constructs the HTML anchor to be used to link to this node.
+func (n DocNode) HTMLAnchor() string {
+	return fmt.Sprintf("%s-%s", n.ParentBreadcrumb, strings.ToLower(n.Key))
+}
+
+// FormattedDefault returns the default value for this node formatted properly.
+func (n DocNode) FormattedDefault() string {
+
+	// Check for the annotation first.
+	if match := defaultAnnotation.FindAllStringSubmatch(n.Comment, -1); len(match) > 0 {
+		// Handle it being set > 1 time. Use the last match.
+		return match[len(match)-1][1]
+	}
+
+	// We don't show the default if the kind is a map of arrays because the
+	// default will be too big to show inline.
+	if n.Kind() == "array<map>" {
+		return ""
+	}
+
+	if n.Default != "" {
+		// Don't show multiline string defaults since it wouldn't fit.
+		// We use > 2 because if it's extraConfig, e.g. `{}` then we want to
+		// show it but if it's affinity then it doesn't make sense to show it.
+		if len(strings.Split(n.Default, "\n")) > 2 {
+			return ""
+		}
+		return strings.TrimSpace(n.Default)
+	}
+
+	// If we get here then the default is an empty string. We return quotes
+	// in this case so it's clear it's an empty string. Otherwise it would look
+	// like: `string: ` vs. `string: ""`.
+	return `""`
+}
+
+// FormattedDocumentation returns the formatted documentation for this node.
+func (n DocNode) FormattedDocumentation() string {
+	doc := n.Comment
+
+	// Replace all leading YAML comment characters, e.g.
+	// `# yaml comment` => `yaml comment`.
+	doc = commentPrefix.ReplaceAllString(n.Comment, "")
+
+	// Indent each line of the documentation so it lines up correctly.
+	var indentedLines []string
+	for i, line := range strings.Split(doc, "\n") {
+
+		// If the line is a @type, @default or @recurse annotation we don't include it in
+		// the markdown description.
+		// This check must be before the i == 0 check because if there's only
+		// one line in the description and it's the type description then we
+		// want to discard it.
+		if len(typeAnnotation.FindStringSubmatch(line)) > 0 ||
+			len(defaultAnnotation.FindStringSubmatch(line)) > 0 ||
+			len(recurseAnnotation.FindStringSubmatch(line)) > 0 {
+			continue
+		}
+
+		var indentedLine string
+		// The first line is printed inline with the key information so it
+		// doesn't need to be indented, e.g.
+		// `key - first line docs`
+		if i == 0 {
+			indentedLine = line
+		} else if line != "" {
+			indent := n.Column + 1
+			if n.ParentWasMap {
+				indent = n.Column
+			}
+			indentedLine = strings.Repeat(" ", indent) + line
+		} else {
+			// No need to add whitespace indent to a newline.
+		}
+		indentedLines = append(indentedLines, indentedLine)
+	}
+
+	// Trim all final newlines and whitespace.
+	return strings.TrimRight(strings.Join(indentedLines, "\n"), "\n ")
+}
+
+// Kind returns the kind of this node, e.g. string, boolean, etc.
+func (n DocNode) Kind() string {
+
+	// Check for the annotation first.
+	if match := typeAnnotation.FindAllStringSubmatch(n.Comment, -1); len(match) > 0 {
+		// Handle it being set > 1 time. Use the last match.
+		return match[len(match)-1][1]
+	}
+
+	// Special case for secretName, secretKey so they don't need to set
+	// # type: string.
+	if n.Key == "secretName" || n.Key == "secretKey" {
+		return "string"
+	}
+
+	// The YAML kind tag looks like "!!str".
+	switch strings.TrimLeft(n.KindTag, "!") {
+	case "str":
+		return "string"
+	case "int":
+		return "integer"
+	case "bool":
+		return "boolean"
+	case "map":
+		return "map"
+	default:
+		return fmt.Sprintf("%s '%v'", UnknownKindError, n.KindTag)
+	}
+}
+
+// LeadingIndent returns the leading indentation for the first line of this
+// node.
+func (n DocNode) LeadingIndent() string {
+	indent := n.Column - 1
+	if n.ParentWasMap {
+		indent = n.Column - 3
+	}
+	return strings.Repeat(" ", indent)
+}

--- a/hack/helm-reference-gen/fixtures/full-values.golden
+++ b/hack/helm-reference-gen/fixtures/full-values.golden
@@ -1,0 +1,1518 @@
+- `global` ((#v-global)) - Holds values that affect multiple components of the chart.
+
+  - `enabled` ((#v-global-enabled)) (`boolean: true`) - The master enabled/disabled setting. If true, servers,
+    clients, Consul DNS and the Consul UI will be enabled. Each component can override
+    this default via its component-specific "enabled" config. If false, no components
+    will be installed by default and per-component opt-in is required, such as by
+    setting `server.enabled` to true.
+
+  - `name` ((#v-global-name)) (`string: null`) - Set the prefix used for all resources in the Helm chart. If not set,
+    the prefix will be `<helm release name>-consul`.
+
+  - `domain` ((#v-global-domain)) (`string: consul`) - The domain Consul will answer DNS queries for
+    (see `-domain` (https://consul.io/docs/agent/options#_domain)) and the domain services synced from
+    Consul into Kubernetes will have, e.g. `service-name.service.consul`.
+
+  - `image` ((#v-global-image)) (`string: hashicorp/consul:1.9.0`) - The name (and tag) of the Consul Docker image for clients and servers.
+    This can be overridden per component. This should be pinned to a specific
+    version tag, otherwise you may inadvertently upgrade your Consul version.
+
+    Examples:
+
+    ```yaml
+    # Consul 1.5.0
+    image: "consul:1.5.0"
+    # Consul Enterprise 1.5.0
+    image: "hashicorp/consul-enterprise:1.5.0-ent"
+    ```
+
+  - `imagePullSecrets` ((#v-global-imagepullsecrets)) (`array<map>`) - Array of objects containing image pull secret names that will be applied to each service account.
+    This can be used to reference image pull secrets if using a custom consul or consul-k8s Docker image.
+    See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry for reference.
+
+    Example:
+
+    ```yaml
+    imagePullSecrets:
+      - name: pull-secret-name
+      - name: pull-secret-name-2
+    ```
+
+  - `imageK8S` ((#v-global-imagek8s)) (`string: hashicorp/consul-k8s:0.21.0`) - The name (and tag) of the consul-k8s (https://github.com/hashicorp/consul-k8s)
+    Docker image that is used for functionality such the catalog sync.
+    This can be overridden per component.
+
+  - `datacenter` ((#v-global-datacenter)) (`string: dc1`) - The name of the datacenter that the agents should
+    register as. This can't be changed once the Consul cluster is up and running
+    since Consul doesn't support an automatic way to change this value currently:
+    https://github.com/hashicorp/consul/issues/1858.
+
+  - `enablePodSecurityPolicies` ((#v-global-enablepodsecuritypolicies)) (`boolean: false`) - Controls whether pod security policies are created for the Consul components
+    created by this chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
+
+  - `gossipEncryption` ((#v-global-gossipencryption)) - Configures which Kubernetes secret to retrieve Consul's
+    gossip encryption key from (see [-encrypt](/docs/agent/options#_encrypt)). If secretName or
+    secretKey are not set, gossip encryption will not be enabled. The secret must
+    be in the same namespace that Consul is installed into.
+
+    The secret can be created by running:
+
+    ```shell
+    $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)
+    ```
+
+    To reference, use:
+
+    ```yaml
+    global:
+      gossipEncryption:
+        secretName: consul-gossip-encryption-key
+        secretKey: key
+    ```
+
+    - `secretName` ((#v-global-gossipencryption-secretname)) (`string: ""`) - secretName is the name of the Kubernetes secret that holds the gossip
+      encryption key. The secret must be in the same namespace that Consul is installed into.
+
+    - `secretKey` ((#v-global-gossipencryption-secretkey)) (`string: ""`) - secretKey is the key within the Kubernetes secret that holds the gossip
+      encryption key.
+
+  - `tls` ((#v-global-tls)) - Enables TLS (https://learn.hashicorp.com/tutorials/consul/gossip-encryption-secure)
+    across the cluster to verify authenticity of the Consul servers and clients.
+    Requires Consul v1.4.1+ and consul-k8s v0.16.2+
+
+    - `enabled` ((#v-global-tls-enabled)) (`boolean: false`) - If true, the Helm chart will enable TLS for Consul
+      servers and clients and all consul-k8s components, as well as generate certificate
+      authority (optional) and server and client certificates.
+
+    - `enableAutoEncrypt` ((#v-global-tls-enableautoencrypt)) (`boolean: false`) - If true, turns on the auto-encrypt feature on clients and servers.
+      It also switches consul-k8s components to retrieve the CA from the servers
+      via the API. Requires Consul 1.7.1+ and consul-k8s 0.13.0
+
+    - `serverAdditionalDNSSANs` ((#v-global-tls-serveradditionaldnssans)) (`array<string>: []`) - A list of additional DNS names to set as Subject Alternative Names (SANs)
+      in the server certificate. This is useful when you need to access the
+      Consul server(s) externally, for example, if you're using the UI.
+
+    - `serverAdditionalIPSANs` ((#v-global-tls-serveradditionalipsans)) (`array<string>: []`) - A list of additional IP addresses to set as Subject Alternative Names (SANs)
+      in the server certificate. This is useful when you need to access the
+      Consul server(s) externally, for example, if you're using the UI.
+
+    - `verify` ((#v-global-tls-verify)) (`boolean: true`) - If true, `verify_outgoing`, `verify_server_hostname`,
+      and `verify_incoming_rpc` will be set to `true` for Consul servers and clients.
+      Set this to false to incrementally roll out TLS on an existing Consul cluster.
+      Please see https://consul.io/docs/k8s/operations/tls-on-existing-cluster
+      for more details.
+
+    - `httpsOnly` ((#v-global-tls-httpsonly)) (`boolean: true`) - If true, the Helm chart will configure Consul to disable the HTTP port on
+      both clients and servers and to only accept HTTPS connections.
+
+    - `caCert` ((#v-global-tls-cacert)) - A Kubernetes secret containing the certificate of the CA to use for
+      TLS communication within the Consul cluster. If you have generated the CA yourself
+      with the consul CLI, you could use the following command to create the secret
+      in Kubernetes:
+
+      ```bash
+      kubectl create secret generic consul-ca-cert \
+          --from-file='tls.crt=./consul-agent-ca.pem'
+      ```
+
+      - `secretName` ((#v-global-tls-cacert-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+      - `secretKey` ((#v-global-tls-cacert-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+    - `caKey` ((#v-global-tls-cakey)) - A Kubernetes secret containing the private key of the CA to use for
+      TLS communication within the Consul cluster. If you have generated the CA yourself
+      with the consul CLI, you could use the following command to create the secret
+      in Kubernetes:
+
+      ```bash
+      kubectl create secret generic consul-ca-key \
+          --from-file='tls.key=./consul-agent-ca-key.pem'
+      ```
+
+      Note that we need the CA key so that we can generate server and client certificates.
+      It is particularly important for the client certificates since they need to have host IPs
+      as Subject Alternative Names. In the future, we may support bringing your own server
+      certificates.
+
+      - `secretName` ((#v-global-tls-cakey-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+      - `secretKey` ((#v-global-tls-cakey-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+  - `enableConsulNamespaces` ((#v-global-enableconsulnamespaces)) (`boolean: false`) - <EnterpriseAlert inline /> `enableConsulNamespaces` indicates that you are running
+    Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
+    like to make use of configuration beyond registering everything into
+    the `default` Consul namespace. Requires consul-k8s v0.12+. Additional configuration
+    options are found in the `consulNamespaces` section of both the catalog sync
+    and connect injector.
+
+  - `acls` ((#v-global-acls)) - Configure ACLs.
+
+    - `manageSystemACLs` ((#v-global-acls-managesystemacls)) (`boolean: false`) - If true, the Helm chart will automatically manage ACL tokens and policies
+      for all Consul and consul-k8s components.
+      This requires Consul >= 1.4 and consul-k8s >= 0.14.0.
+
+    - `bootstrapToken` ((#v-global-acls-bootstraptoken)) - A Kubernetes secret containing the bootstrap token to use for
+      creating policies and tokens for all Consul and consul-k8s components.
+      If set, we will skip ACL bootstrapping of the servers and will only
+      initialize ACLs for the Consul clients and consul-k8s system components.
+      Requires consul-k8s >= 0.14.0.
+
+      - `secretName` ((#v-global-acls-bootstraptoken-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+      - `secretKey` ((#v-global-acls-bootstraptoken-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+    - `createReplicationToken` ((#v-global-acls-createreplicationtoken)) (`boolean: false`) - If true, an ACL token will be created that can be used in secondary
+      datacenters for replication. This should only be set to true in the
+      primary datacenter since the replication token must be created from that
+      datacenter.
+      In secondary datacenters, the secret needs to be imported from the primary
+      datacenter and referenced via `global.acls.replicationToken`.
+      Requires consul-k8s >= 0.13.0.
+
+    - `replicationToken` ((#v-global-acls-replicationtoken)) - replicationToken references a secret containing the replication ACL token.
+      This token will be used by secondary datacenters to perform ACL replication
+      and create ACL tokens and policies.
+      This value is ignored if `bootstrapToken` is also set.
+      Requires consul-k8s >= 0.13.0.
+
+      - `secretName` ((#v-global-acls-replicationtoken-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+      - `secretKey` ((#v-global-acls-replicationtoken-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+  - `federation` ((#v-global-federation)) - Configure federation.
+
+    - `enabled` ((#v-global-federation-enabled)) (`boolean: false`) - If enabled, this datacenter will be federation-capable. Only federation
+      via mesh gateways is supported.
+      Mesh gateways and servers will be configured to allow federation.
+      Requires `global.tls.enabled`, `meshGateway.enabled` and `connectInject.enabled`
+      to be true.
+
+    - `createFederationSecret` ((#v-global-federation-createfederationsecret)) (`boolean: false`) - If true, the chart will create a Kubernetes secret that can be imported
+      into secondary datacenters so they can federate with this datacenter. The
+      secret contains all the information secondary datacenters need to contact
+      and authenticate with this datacenter. This should only be set to true
+      in your primary datacenter. The secret name is
+      `<global.name>-federation` (if setting `global.name`), otherwise
+      `<helm-release-name>-consul-federation`. Requires consul-k8s 0.15.0+.
+
+  - `lifecycleSidecarContainer` ((#v-global-lifecyclesidecarcontainer)) - The lifecycle sidecar ensures the Consul services
+    are always registered with their local Consul clients and is used by the
+    ingress/terminating/mesh gateways as well as with every Connect-injected service.
+
+    - `resources` ((#v-global-lifecyclesidecarcontainer-resources))
+
+      - `requests` ((#v-global-lifecyclesidecarcontainer-resources-requests))
+
+        - `memory` ((#v-global-lifecyclesidecarcontainer-resources-requests-memory)) (`string: 25Mi`)
+
+        - `cpu` ((#v-global-lifecyclesidecarcontainer-resources-requests-cpu)) (`string: 20m`)
+
+      - `limits` ((#v-global-lifecyclesidecarcontainer-resources-limits))
+
+        - `memory` ((#v-global-lifecyclesidecarcontainer-resources-limits-memory)) (`string: 50Mi`)
+
+        - `cpu` ((#v-global-lifecyclesidecarcontainer-resources-limits-cpu)) (`string: 20m`)
+
+  - `imageEnvoy` ((#v-global-imageenvoy)) (`string: envoyproxy/envoy-alpine:v1.16.0`) - The name (and tag) of the Envoy Docker image used for the
+    connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
+    See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
+
+  - `openshift` ((#v-global-openshift)) - Configuration for running this Helm chart on the Red Hat OpenShift platform.
+    This Helm chart currently supports OpenShift v4.x+.
+
+    - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
+      its components on OpenShift.
+
+- `server` ((#v-server)) - Server, when enabled, configures a server cluster to run. This should
+  be disabled if you plan on connecting to a Consul cluster external to
+  the Kube cluster.
+
+  - `enabled` ((#v-server-enabled)) (`boolean: global.enabled`) - If true, the chart will install all the resources necessary for a
+    Consul server cluster. If you're running Consul externally and want agents
+    within Kubernetes to join that cluster, this should probably be false.
+
+  - `image` ((#v-server-image)) (`string: null`) - The name of the Docker image (including any tag) for the containers running
+    Consul server agents.
+
+  - `replicas` ((#v-server-replicas)) (`integer: 3`) - The number of server agents to run. This determines the fault tolerance of
+    the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
+    for more information.
+
+  - `bootstrapExpect` ((#v-server-bootstrapexpect)) (`integer: 3`) - For new clusters, this is the number of servers to wait for before performing
+    the initial leader election and bootstrap of the cluster. This must be less
+    than or equal to `server.replicas`. This value is only used
+    when bootstrapping new clusters, it has no effect during ongoing cluster maintenance.
+
+  - `enterpriseLicense` ((#v-server-enterpriselicense)) - <EnterpriseAlert inline /> This value refers to a Kubernetes secret that you have created
+    that contains your enterprise license. It is required if you are using an
+    enterprise binary. Defining it here applies it to your cluster once a leader
+    has been elected. If you are not using an enterprise image or if you plan to
+    introduce the license key via another route, then set these fields to null.
+    Note: the job to apply license runs on both Helm installs and upgrades.
+
+    - `secretName` ((#v-server-enterpriselicense-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the enterprise license.
+      The secret must be in the same namespace that Consul is installed into.
+
+    - `secretKey` ((#v-server-enterpriselicense-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the enterprise license.
+
+  - `storage` ((#v-server-storage)) (`string: 10Gi`) - This defines the disk size for configuring the
+    servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
+    desired size. For manually defined persistent volumes, this should be set to
+    the disk size of the attached volume.
+
+  - `storageClass` ((#v-server-storageclass)) (`string: null`) - The StorageClass to use for the servers' StatefulSet storage. It must be
+    able to be dynamically provisioned if you want the storage
+    to be automatically created. For example, to use local
+    (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
+    storage classes, the PersistentVolumeClaims would need to be manually created.
+    A `null` value will use the Kubernetes cluster's default StorageClass. If a default
+    StorageClass does not exist, you will need to create one.
+
+  - `connect` ((#v-server-connect)) (`boolean: true`) - This will enable/disable [Connect](/docs/connect). Setting this to true
+    _will not_ automatically secure pod communication, this
+    setting will only enable usage of the feature. Consul will automatically initialize
+    a new CA and set of certificates. Additional Connect settings can be configured
+    by setting the `server.extraConfig` value.
+
+  - `resources` ((#v-server-resources)) - The resource requests (CPU, memory, etc.)
+    for each of the server agents. This should be a YAML map corresponding to a Kubernetes
+    ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#resourcerequirements-v1-core)
+    object. NOTE: The use of a YAML string is deprecated.
+
+    Example:
+
+    ```yaml
+    resources:
+      requests:
+        memory: '100Mi'
+        cpu: '100m'
+      limits:
+        memory: '100Mi'
+        cpu: '100m'
+    ```
+
+    - `requests` ((#v-server-resources-requests))
+
+      - `memory` ((#v-server-resources-requests-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-server-resources-requests-cpu)) (`string: 100m`)
+
+    - `limits` ((#v-server-resources-limits))
+
+      - `memory` ((#v-server-resources-limits-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-server-resources-limits-cpu)) (`string: 100m`)
+
+  - `updatePartition` ((#v-server-updatepartition)) (`integer: 0`) - This value is used to carefully
+    control a rolling update of Consul server agents. This value specifies the
+    partition (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions)
+    for performing a rolling update. Please read the linked Kubernetes documentation
+    for more information.
+
+  - `disruptionBudget` ((#v-server-disruptionbudget)) - This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+    for the server cluster.
+
+    - `enabled` ((#v-server-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the server
+      cluster. If this is enabled, it will only register the budget so long as
+      the server cluster is enabled.
+
+    - `maxUnavailable` ((#v-server-disruptionbudget-maxunavailable)) (`integer: null`) - The maximum number of unavailable pods. By default, this will be
+      automatically computed based on the `server.replicas` value to be `(n/2)-1`.
+      If you need to set this to `0`, you will need to add a
+      --set 'server.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
+      command because of a limitation in the Helm templating language.
+
+  - `extraConfig` ((#v-server-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+    servers. This will be saved as-is into a ConfigMap that is read by the Consul
+    server agents. This can be used to add additional configuration that
+    isn't directly exposed by the chart.
+
+    Example:
+
+    ```yaml
+    extraConfig: |
+      {
+        "log_level": "DEBUG"
+      }
+    ```
+
+    This can also be set using Helm's `--set` flag using the following syntax:
+
+    ```shell
+    --set 'server.extraConfig="{"log_level": "DEBUG"}"'
+    ```
+
+  - `extraVolumes` ((#v-server-extravolumes)) (`array<map>`) - A list of extra volumes to mount for server agents. This
+    is useful for bringing in extra data that can be referenced by other configurations
+    at a well known path, such as TLS certificates or Gossip encryption keys. The
+    value of this should be a list of objects.
+
+    Example:
+
+    ```yaml
+    extraVolumes:
+    - type: 'secret'
+      name: 'consul-certs'
+      load: false
+    ```
+    Each object supports the following keys:
+
+    - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+
+    - `name` - Name of the configMap or secret to be mounted. This also controls
+      the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+
+    - `load` - If true, then the agent will be
+      configured to automatically load HCL/JSON configuration files from this volume
+      with `-config-dir`. This defaults to false.
+
+  - `affinity` ((#v-server-affinity)) (`string`) - This value defines the affinity (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+    for server pods. It defaults to allowing only a single pod on each node, which
+    minimizes risk of the cluster becoming unusable if a node is lost. If you need
+    to run more pods per node (for example, testing on Minikube), set this value
+    to `null`.
+
+    Example:
+
+    ```yaml
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "consul.name" . }}
+                release: "{{ .Release.Name }}"
+                component: server
+          topologyKey: kubernetes.io/hostname
+    ```
+
+  - `tolerations` ((#v-server-tolerations)) (`string: ""`) - Toleration settings for server pods. This
+    should be a multi-line string matching the Tolerations
+    (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+
+  - `nodeSelector` ((#v-server-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    labels for server pod assignment, formatted as a multi-line string.
+
+    Example:
+    ```yaml
+    nodeSelector: |
+      beta.kubernetes.io/arch: amd64
+    ```
+
+  - `priorityClassName` ((#v-server-priorityclassname)) (`string: ""`) - This value references an existing
+    Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+    that can be assigned to server pods.
+
+  - `extraLabels` ((#v-server-extralabels)) - Extra labels to attach to the server pods. This should be a YAML map.
+
+    Example:
+    ```yaml
+    extraLabels:
+      labelKey: "label-value"
+      anotherLabelKey: "another-label-value"
+    ```
+
+  - `annotations` ((#v-server-annotations)) (`string: null`) - This value defines additional annotations for
+    server pods. This should be a formatted as a multi-line string.
+
+    ```yaml
+    annotations: |
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    ```
+
+  - `service` ((#v-server-service)) - Server service properties.
+
+    - `annotations` ((#v-server-service-annotations)) (`string: null`) - Annotations to apply to the server service.
+
+      ```yaml
+      annotations: |
+        "annotation-key": "annotation-value"
+      ```
+
+  - `extraEnvironmentVars` ((#v-server-extraenvironmentvars)) - extraEnvironmentVars is a list of extra environment variables to set within the stateful set.
+    These could be used to include proxy settings required for cloud auto-join
+    feature, in case kubernetes cluster is behind egress http proxies. Additionally,
+    it could be used to configure custom consul parameters.
+
+- `externalServers` ((#v-externalservers)) - Configuration for Consul servers when the servers are running outside of Kubernetes.
+  When running external servers, configuring these values is recommended
+  if setting `global.tls.enableAutoEncrypt` to true (requires consul-k8s >= 0.13.0)
+  or `global.acls.manageSystemACLs` to true (requires consul-k8s >= 0.14.0).
+
+  - `enabled` ((#v-externalservers-enabled)) (`boolean: false`) - If true, the Helm chart will be configured to talk to the external servers.
+     If setting this to true, you must also set `server.enabled` to false.
+
+  - `hosts` ((#v-externalservers-hosts)) (`array<string>: []`) - An array of external Consul server hosts that are used to make
+    HTTPS connections from the components in this Helm chart.
+    Valid values include IPs, DNS names, or Cloud auto-join string.
+    The port must be provided separately below.
+    Note: `client.join` must also be set to the hosts that should be
+    used to join the cluster. In most cases, the `client.join` values
+    should be the same, however, they may be different if you
+    wish to use separate hosts for the HTTPS connections.
+
+  - `httpsPort` ((#v-externalservers-httpsport)) (`integer: 8501`) - The HTTPS port of the Consul servers.
+
+  - `tlsServerName` ((#v-externalservers-tlsservername)) (`string: null`) - The server name to use as the SNI host header when connecting with HTTPS.
+
+  - `useSystemRoots` ((#v-externalservers-usesystemroots)) (`boolean: false`) - If true, consul-k8s components will ignore the CA set in
+    `global.tls.caCert` when making HTTPS calls to Consul servers and
+    will instead use the consul-k8s image's system CAs for TLS verification.
+    If false, consul-k8s components will use `global.tls.caCert` when
+    making HTTPS calls to Consul servers.
+    **NOTE:** This does not affect Consul's internal RPC communication which will
+    always use `global.tls.caCert`.
+
+  - `k8sAuthMethodHost` ((#v-externalservers-k8sauthmethodhost)) (`string: null`) - If you are setting `global.acls.manageSystemACLs` and
+    `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
+    This address must be reachable from the Consul servers.
+    Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
+    Requires consul-k8s >= 0.14.0.
+
+    You could retrieve this value from your `kubeconfig` by running:
+
+    ```shell
+    kubectl config view \
+      -o jsonpath="{.clusters[?(@.name=='<your cluster name>')].cluster.server}"
+    ```
+
+- `client` ((#v-client)) - Values that configure running a Consul client on Kubernetes nodes.
+
+  - `enabled` ((#v-client-enabled)) (`boolean: global.enabled`) - If true, the chart will install all
+    the resources necessary for a Consul client on every Kubernetes node. This _does not_ require
+    `server.enabled`, since the agents can be configured to join an external cluster.
+
+  - `image` ((#v-client-image)) (`string: null`) - The name of the Docker image (including any tag) for the containers
+    running Consul client agents.
+
+  - `join` ((#v-client-join)) (`array<string>: null`) - A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
+    If this is `null` (default), then the clients will attempt to automatically
+    join the server cluster running within Kubernetes.
+    This means that with `server.enabled` set to true, clients will automatically
+    join that cluster. If `server.enabled` is not true, then a value must be
+    specified so the clients can join a valid cluster.
+
+  - `dataDirectoryHostPath` ((#v-client-datadirectoryhostpath)) (`string: null`) - An absolute path to a directory on the host machine to use as the Consul
+    client data directory. If set to the empty string or null, the Consul agent
+    will store its data in the Pod's local filesystem (which will
+    be lost if the Pod is deleted). Security Warning: If setting this, Pod Security
+    Policies _must_ be enabled on your cluster and in this Helm chart (via the
+    `global.enablePodSecurityPolicies` setting) to prevent other pods from
+    mounting the same host path and gaining access to all of Consul's data.
+    Consul's data is not encrypted at rest.
+
+  - `grpc` ((#v-client-grpc)) (`boolean: true`) - If true, agents will enable their GRPC listener on
+    port 8502 and expose it to the host. This will use slightly more resources, but is
+    required for Connect.
+
+  - `exposeGossipPorts` ((#v-client-exposegossipports)) (`boolean: false`) - If true, the Helm chart will expose the clients' gossip ports as hostPorts.
+    This is only necessary if pod IPs in the k8s cluster are not directly routable
+    and the Consul servers are outside of the k8s cluster.
+    This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
+
+  - `resources` ((#v-client-resources)) - Resource settings for Client agents.
+    NOTE: The use of a YAML string is deprecated. Instead, set directly as a
+    YAML map.
+
+    - `requests` ((#v-client-resources-requests))
+
+      - `memory` ((#v-client-resources-requests-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-client-resources-requests-cpu)) (`string: 100m`)
+
+    - `limits` ((#v-client-resources-limits))
+
+      - `memory` ((#v-client-resources-limits-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-client-resources-limits-cpu)) (`string: 100m`)
+
+  - `extraConfig` ((#v-client-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+    clients. This will be saved as-is into a ConfigMap that is read by the Consul
+    client agents. This can be used to add additional configuration that
+    isn't directly exposed by the chart.
+
+    Example:
+    ```yaml
+    extraConfig: |
+      {
+        "log_level": "DEBUG"
+      }
+    ```
+
+    This can also be set using Helm's `--set` flag using the following syntax:
+
+    ```shell
+    --set 'client.extraConfig="{"log_level": "DEBUG"}"'
+    ```
+
+  - `extraVolumes` ((#v-client-extravolumes)) (`array<map>`) - A list of extra volumes to mount for client agents. This
+    is useful for bringing in extra data that can be referenced by other configurations
+    at a well known path, such as TLS certificates or Gossip encryption keys. The
+    value of this should be a list of objects.
+
+    Example:
+
+    ```yaml
+    extraVolumes:
+    - type: 'secret'
+      name: 'consul-certs'
+      load: false
+    ```
+    Each object supports the following keys:
+
+    - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+
+    - `name` - Name of the configMap or secret to be mounted. This also controls
+      the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+
+    - `load` - If true, then the agent will be
+      configured to automatically load HCL/JSON configuration files from this volume
+      with `-config-dir`. This defaults to false.
+
+  - `tolerations` ((#v-client-tolerations)) (`string: ""`) - Toleration Settings for Client pods
+    This should be a multi-line string matching the Toleration array
+    in a PodSpec.
+    The example below will allow Client pods to run on every node
+    regardless of taints
+    tolerations: |
+      - operator: "Exists"
+
+  - `nodeSelector` ((#v-client-nodeselector)) (`string: null`) - nodeSelector labels for client pod assignment, formatted as a multi-line string.
+    ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+
+    Example:
+    ```yaml
+    nodeSelector: |
+      beta.kubernetes.io/arch: amd64
+    ```
+
+  - `affinity` ((#v-client-affinity)) (`string: ""`) - Affinity Settings for Client pods, formatted as a multi-line YAML string.
+    ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+
+    Example:
+    ```yaml
+    affinity: |
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: DoesNotExist
+    ```
+
+  - `priorityClassName` ((#v-client-priorityclassname)) (`string: ""`) - This value references an existing
+    Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+    that can be assigned to client pods.
+
+  - `annotations` ((#v-client-annotations)) (`string: null`) - This value defines additional annotations for
+    client pods. This should be a formatted as a multi-line string.
+
+    ```yaml
+    annotations: |
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    ```
+
+  - `extraEnvironmentVars` ((#v-client-extraenvironmentvars)) - extraEnvironmentVars is a list of extra environment variables to set within the stateful set.
+    These could be used to include proxy settings required for cloud auto-join
+    feature, in case kubernetes cluster is behind egress http proxies. Additionally,
+    it could be used to configure custom consul parameters.
+
+  - `dnsPolicy` ((#v-client-dnspolicy)) (`string: null`) - This value defines the Pod DNS policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
+    for client pods to use.
+
+  - `hostNetwork` ((#v-client-hostnetwork)) (`boolean: false`) - hostNetwork defines whether or not we use host networking instead of hostPort in the event
+    that a CNI plugin doesn't support `hostPort`. This has security implications and is not recommended
+    as doing so gives the consul client unnecessary access to all network traffic on the host.
+    In most cases, pod network and host network are on different networks so this should be
+    combined with `dnsPolicy: ClusterFirstWithHostNet`
+
+  - `updateStrategy` ((#v-client-updatestrategy)) (`string: null`) - updateStrategy for the DaemonSet.
+    See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+    This should be a multi-line string mapping directly to the updateStrategy
+
+    Example:
+    ```yaml
+     updateStrategy: |
+       rollingUpdate:
+         maxUnavailable: 5
+       type: RollingUpdate
+    ```
+
+  - `snapshotAgent` ((#v-client-snapshotagent)) - <EnterpriseAlert inline /> Values for setting up and running snapshot agents
+    (https://consul.io/commands/snapshot/agent)
+    within the Consul clusters. They are required to be co-located with Consul clients,
+    so will inherit the clients' nodeSelector, tolerations and affinity.
+
+    - `enabled` ((#v-client-snapshotagent-enabled)) (`boolean: false`) - If true, the chart will install resources necessary to run the snapshot agent.
+
+    - `replicas` ((#v-client-snapshotagent-replicas)) (`integer: 2`) - The number of snapshot agents to run.
+
+    - `configSecret` ((#v-client-snapshotagent-configsecret)) - A Kubernetes secret that should be manually created to contain the entire
+      config to be used on the snapshot agent.
+      This is the preferred method of configuration since there are usually storage
+      credentials present. Please see Snapshot agent config (https://consul.io/commands/snapshot/agent#config-file-options)
+      for details.
+
+      - `secretName` ((#v-client-snapshotagent-configsecret-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+      - `secretKey` ((#v-client-snapshotagent-configsecret-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+    - `resources` ((#v-client-snapshotagent-resources)) - Resource settings for snapshot agent pods.
+
+      - `requests` ((#v-client-snapshotagent-resources-requests))
+
+        - `memory` ((#v-client-snapshotagent-resources-requests-memory)) (`string: 50Mi`)
+
+        - `cpu` ((#v-client-snapshotagent-resources-requests-cpu)) (`string: 50m`)
+
+      - `limits` ((#v-client-snapshotagent-resources-limits))
+
+        - `memory` ((#v-client-snapshotagent-resources-limits-memory)) (`string: 50Mi`)
+
+        - `cpu` ((#v-client-snapshotagent-resources-limits-cpu)) (`string: 50m`)
+
+    - `caCert` ((#v-client-snapshotagent-cacert)) (`string: null`) - Optional PEM-encoded CA certificate that will be added to the trusted system CAs.
+      Useful if using an S3-compatible storage exposing a self-signed certificate.
+
+      Example:
+      ```yaml
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIC7jCCApSgAwIBAgIRAIq2zQEVexqxvtxP6J0bXAwwCgYIKoZIzj0EAwIwgbkx
+        ...
+      ```
+
+- `dns` ((#v-dns)) - Configuration for DNS configuration within the Kubernetes cluster.
+  This creates a service that routes to all agents (client or server)
+  for serving DNS requests. This DOES NOT automatically configure kube-dns
+  today, so you must still manually configure a `stubDomain` with kube-dns
+  for this to have any effect:
+  https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configure-stub-domain-and-upstream-dns-servers
+
+  - `enabled` ((#v-dns-enabled)) (`boolean: -`)
+
+  - `type` ((#v-dns-type)) (`string: ClusterIP`) - type can be used to control the type of service created. For
+    example, setting this to "LoadBalancer" will create an external load
+    balancer (for supported K8S installations)
+
+  - `clusterIP` ((#v-dns-clusterip)) (`string: null`) - Set a predefined cluster IP for the DNS service.
+    Useful if you need to reference the DNS service's IP
+    address in CoreDNS config.
+
+  - `annotations` ((#v-dns-annotations)) (`string: null`) - Extra annotations to attach to the dns service
+    This should be a multi-line string of
+    annotations to apply to the dns Service
+
+  - `additionalSpec` ((#v-dns-additionalspec)) (`string: null`) - Additional ServiceSpec values
+    This should be a multi-line string mapping directly to a Kubernetes
+    ServiceSpec object.
+
+- `ui` ((#v-ui)) - Values that configure the Consul UI.
+
+  - `enabled` ((#v-ui-enabled)) (`boolean: global.enabled`) - If true, the UI will be enabled. This will
+    only _enable_ the UI, it doesn't automatically register any service for external
+    access. The UI will only be enabled on server agents. If `server.enabled` is
+    false, then this setting has no effect. To expose the UI in some way, you must
+    configure `ui.service`.
+
+  - `service` ((#v-ui-service)) - True if you want to create a Service entry for the Consul UI.
+
+    serviceType can be used to control the type of service created. For
+    example, setting this to "LoadBalancer" will create an external load
+    balancer (for supported K8S installations) to access the UI.
+
+    - `enabled` ((#v-ui-service-enabled)) (`boolean: true`) - This will enable/disable registering a
+      Kubernetes Service for the Consul UI. This value only takes effect if `ui.enabled` is
+      true and taking effect.
+
+    - `type` ((#v-ui-service-type)) (`string: null`) - The service type to register.
+
+    - `annotations` ((#v-ui-service-annotations)) (`string: null`) - Annotations to apply to the UI service.
+
+      Example:
+      ```yaml
+        annotations: |
+          "annotation-key": "annotation-value"
+      ```
+
+    - `additionalSpec` ((#v-ui-service-additionalspec)) (`string: null`) - Additional ServiceSpec values
+      This should be a multi-line string mapping directly to a Kubernetes
+      ServiceSpec object.
+
+- `syncCatalog` ((#v-synccatalog)) - syncCatalog will run the catalog sync process to sync K8S with Consul
+  services. This can run bidirectional (default) or unidirectionally (Consul
+  to K8S or K8S to Consul only).
+
+  This process assumes that a Consul agent is available on the host IP.
+  This is done automatically if clients are enabled. If clients are not
+  enabled then set the node selection so that it chooses a node with a
+  Consul agent.
+
+  - `enabled` ((#v-synccatalog-enabled)) (`boolean: false`) - True if you want to enable the catalog sync. Set to "-" to inherit from
+    global.enabled.
+
+  - `image` ((#v-synccatalog-image)) (`string: null`) - The name of the Docker image (including any tag) for consul-k8s
+    to run the sync program.
+
+  - `default` ((#v-synccatalog-default)) (`boolean: true`) - If true, all valid services in K8S are
+    synced by default. If false, the service must be annotated
+    (https://consul.io/docs/k8s/service-sync#sync-enable-disable) properly to sync.
+    In either case an annotation can override the default.
+
+  - `priorityClassName` ((#v-synccatalog-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+  - `toConsul` ((#v-synccatalog-toconsul)) (`boolean: true`) - toConsul and toK8S control whether syncing is enabled to Consul or K8S
+    as a destination. If both of these are disabled, the sync will do nothing.
+
+  - `toK8S` ((#v-synccatalog-tok8s)) (`boolean: true`) - If true, will sync Consul services to Kubernetes. This can be disabled to
+    have a one-way sync.
+
+  - `k8sPrefix` ((#v-synccatalog-k8sprefix)) (`string: null`) - k8sPrefix is the service prefix to prepend to services before registering
+    with Kubernetes. For example "consul-" will register all services
+    prepended with "consul-". (Consul -> Kubernetes sync)
+
+  - `k8sAllowNamespaces` ((#v-synccatalog-k8sallownamespaces)) (`array<string>: ["*"]`) - k8sAllowNamespaces is a list of k8s namespaces to sync the k8s services from.
+    If a k8s namespace is not included  in this list or is listed in `k8sDenyNamespaces`,
+    services in that k8s namespace will not be synced even if they are explicitly
+    annotated. Use `["*"]` to automatically allow all k8s namespaces.
+
+    For example, `["namespace1", "namespace2"]` will only allow services in the k8s
+    namespaces `namespace1` and `namespace2` to be synced and registered
+    with Consul. All other k8s namespaces will be ignored.
+
+    To deny all namespaces, set this to `[]`.
+
+    Note: `k8sDenyNamespaces` takes precedence over values defined here.
+    Requires consul-k8s v0.12+
+
+  - `k8sDenyNamespaces` ((#v-synccatalog-k8sdenynamespaces)) (`array<string>: ["kube-system", "kube-public"]`) - k8sDenyNamespaces is a list of k8s namespaces that should not have their
+    services synced. This list takes precedence over `k8sAllowNamespaces`.
+    `*` is not supported because then nothing would be allowed to sync.
+    Requires consul-k8s v0.12+.
+
+    For example, if `k8sAllowNamespaces` is `["*"]` and `k8sDenyNamespaces` is
+    `["namespace1", "namespace2"]`, then all k8s namespaces besides `namespace1`
+    and `namespace2` will be synced.
+
+  - `k8sSourceNamespace` ((#v-synccatalog-k8ssourcenamespace)) (`string: null`) - [DEPRECATED] Use k8sAllowNamespaces and k8sDenyNamespaces instead. For
+    backwards compatibility, if both this and the allow/deny lists are set,
+    the allow/deny lists will be ignored.
+    k8sSourceNamespace is the Kubernetes namespace to watch for service
+    changes and sync to Consul. If this is not set then it will default
+    to all namespaces.
+
+  - `consulNamespaces` ((#v-synccatalog-consulnamespaces)) - <EnterpriseAlert inline /> These settings manage the catalog sync's interaction with
+    Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+    Also, `global.enableConsulNamespaces` must be true.
+
+    - `consulDestinationNamespace` ((#v-synccatalog-consulnamespaces-consuldestinationnamespace)) (`string: default`) - consulDestinationNamespace is the name of the Consul namespace to register all
+      k8s services into. If the Consul namespace does not already exist,
+      it will be created. This will be ignored if `mirroringK8S` is true.
+
+    - `mirroringK8S` ((#v-synccatalog-consulnamespaces-mirroringk8s)) (`boolean: false`) - mirroringK8S causes k8s services to be registered into a Consul namespace
+      of the same name as their k8s namespace, optionally prefixed if
+      `mirroringK8SPrefix` is set below. If the Consul namespace does not
+      already exist, it will be created. Turning this on overrides the
+      `consulDestinationNamespace` setting.
+      `addK8SNamespaceSuffix` may no longer be needed if enabling this option.
+
+    - `mirroringK8SPrefix` ((#v-synccatalog-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
+      to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+      service in the k8s `staging` namespace will be registered into the
+      `k8s-staging` Consul namespace.
+
+  - `addK8SNamespaceSuffix` ((#v-synccatalog-addk8snamespacesuffix)) (`boolean: true`) - addK8SNamespaceSuffix appends Kubernetes namespace suffix to
+    each service name synced to Consul, separated by a dash.
+    For example, for a service 'foo' in the default namespace,
+    the sync process will create a Consul service named 'foo-default'.
+    Set this flag to true to avoid registering services with the same name
+    but in different namespaces as instances for the same Consul service.
+    Namespace suffix is not added if 'annotationServiceName' is provided.
+
+  - `consulPrefix` ((#v-synccatalog-consulprefix)) (`string: null`) - consulPrefix is the service prefix which prepends itself
+    to Kubernetes services registered within Consul
+    For example, "k8s-" will register all services prepended with "k8s-".
+    (Kubernetes -> Consul sync)
+    consulPrefix is ignored when 'annotationServiceName' is provided.
+    NOTE: Updating this property to a non-null value for an existing installation will result in deregistering
+    of existing services in Consul and registering them with a new name.
+
+  - `k8sTag` ((#v-synccatalog-k8stag)) (`string: null`) - k8sTag is an optional tag that is applied to all of the Kubernetes services
+    that are synced into Consul. If nothing is set, defaults to "k8s".
+    (Kubernetes -> Consul sync)
+
+  - `consulNodeName` ((#v-synccatalog-consulnodename)) (`string: k8s-sync`) - consulNodeName defines the Consul synthetic node that all services
+    will be registered to.
+    NOTE: Changing the node name and upgrading the Helm chart will leave
+    all of the previously sync'd services registered with Consul and
+    register them again under the new Consul node name. The out-of-date
+    registrations will need to be explicitly removed.
+
+  - `syncClusterIPServices` ((#v-synccatalog-syncclusteripservices)) (`boolean: true`) - syncClusterIPServices syncs services of the ClusterIP type, which may
+    or may not be broadly accessible depending on your Kubernetes cluster.
+    Set this to false to skip syncing ClusterIP services.
+
+  - `nodePortSyncType` ((#v-synccatalog-nodeportsynctype)) (`string: ExternalFirst`) - nodePortSyncType configures the type of syncing that happens for NodePort
+    services. The valid options are: ExternalOnly, InternalOnly, ExternalFirst.
+
+    - ExternalOnly will only use a node's ExternalIP address for the sync
+    - InternalOnly use's the node's InternalIP address
+    - ExternalFirst will preferentially use the node's ExternalIP address, but
+      if it doesn't exist, it will use the node's InternalIP address instead.
+
+  - `aclSyncToken` ((#v-synccatalog-aclsynctoken)) - aclSyncToken refers to a Kubernetes secret that you have created that contains
+    an ACL token for your Consul cluster which allows the sync process the correct
+    permissions. This is only needed if ACLs are enabled on the Consul cluster.
+
+    - `secretName` ((#v-synccatalog-aclsynctoken-secretname)) (`string: null`) - The name of the Kubernetes secret.
+
+    - `secretKey` ((#v-synccatalog-aclsynctoken-secretkey)) (`string: null`) - The key of the Kubernetes secret.
+
+  - `nodeSelector` ((#v-synccatalog-nodeselector)) (`string: null`) - This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    labels for catalog sync pod assignment, formatted as a multi-line string.
+
+    Example:
+    ```yaml
+    nodeSelector: |
+      beta.kubernetes.io/arch: amd64
+    ```
+
+  - `affinity` ((#v-synccatalog-affinity)) (`string: null`) - Affinity Settings
+    This should be a multi-line string matching the affinity object
+
+  - `tolerations` ((#v-synccatalog-tolerations)) (`string: null`) - Toleration Settings
+    This should be a multi-line string matching the Toleration array
+    in a PodSpec.
+
+  - `resources` ((#v-synccatalog-resources)) - Resource settings for sync catalog pods.
+
+    - `requests` ((#v-synccatalog-resources-requests))
+
+      - `memory` ((#v-synccatalog-resources-requests-memory)) (`string: 50Mi`)
+
+      - `cpu` ((#v-synccatalog-resources-requests-cpu)) (`string: 50m`)
+
+    - `limits` ((#v-synccatalog-resources-limits))
+
+      - `memory` ((#v-synccatalog-resources-limits-memory)) (`string: 50Mi`)
+
+      - `cpu` ((#v-synccatalog-resources-limits-cpu)) (`string: 50m`)
+
+  - `logLevel` ((#v-synccatalog-loglevel)) (`string: info`) - Log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+
+  - `consulWriteInterval` ((#v-synccatalog-consulwriteinterval)) (`string: null`) - Override the default interval to perform syncing operations creating Consul services.
+
+- `connectInject` ((#v-connectinject)) - ConnectInject will enable the automatic Connect sidecar injector.
+
+  - `enabled` ((#v-connectinject-enabled)) (`boolean: false`) - True if you want to enable connect injection. Set to "-" to inherit from
+    global.enabled.
+
+  - `image` ((#v-connectinject-image)) (`string: null`) - image for consul-k8s that contains the injector
+
+  - `default` ((#v-connectinject-default)) (`boolean: false`) - If true, the injector will inject the
+    Connect sidecar into all pods by default. Otherwise, pods must specify the
+    injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
+    to opt-in to Connect injection. If this is true, pods can use the same annotation
+    to explicitly opt-out of injection.
+
+  - `healthChecks` ((#v-connectinject-healthchecks)) - healthChecks enables synchronization of Kubernetes health probe status with Consul.
+    NOTE: It is highly recommended to enable TLS with this feature because it requires
+    making calls to Consul clients across the cluster. Without TLS enabled, these calls
+    could leak ACL tokens should the cluster network become compromised.
+
+    - `enabled` ((#v-connectinject-healthchecks-enabled)) (`boolean: true`) - Enables the Consul Health Check controller which syncs the readiness status of
+      connect-injected pods with Consul.
+
+    - `reconcilePeriod` ((#v-connectinject-healthchecks-reconcileperiod)) (`string: 1m`) - If `healthChecks.enabled` is set to `true`, `reconcilePeriod` defines how often a full state
+      reconcile is done after the initial reconcile at startup is completed.
+
+  - `envoyExtraArgs` ((#v-connectinject-envoyextraargs)) (`string: null`) - envoyExtraArgs is used to pass arguments to the injected envoy sidecar.
+    Valid arguments to pass to envoy can be found here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli
+    e.g "--log-level debug --disable-hot-restart"
+
+  - `priorityClassName` ((#v-connectinject-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+  - `imageConsul` ((#v-connectinject-imageconsul)) (`string: null`) - The Docker image for Consul to use when performing Connect injection.
+    Defaults to global.image.
+
+  - `logLevel` ((#v-connectinject-loglevel)) (`string: info`) - Log verbosity level. One of "debug", "info", "warn", or "error".
+
+  - `resources` ((#v-connectinject-resources)) - Resource settings for connect inject pods.
+
+    - `requests` ((#v-connectinject-resources-requests))
+
+      - `memory` ((#v-connectinject-resources-requests-memory)) (`string: 50Mi`)
+
+      - `cpu` ((#v-connectinject-resources-requests-cpu)) (`string: 50m`)
+
+    - `limits` ((#v-connectinject-resources-limits))
+
+      - `memory` ((#v-connectinject-resources-limits-memory)) (`string: 50Mi`)
+
+      - `cpu` ((#v-connectinject-resources-limits-cpu)) (`string: 50m`)
+
+  - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string: null`) - namespaceSelector is the selector for restricting the webhook to only
+    specific namespaces. This should be set to a multiline string.
+    See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+    for more details.
+
+    Example:
+    ```yaml
+    namespaceSelector: |
+      matchLabels:
+        namespace-label: label-value
+    ```
+
+  - `k8sAllowNamespaces` ((#v-connectinject-k8sallownamespaces)) (`array<string>: ["*"]`) - k8sAllowNamespaces is a list of k8s namespaces to allow Connect sidecar
+    injection in. If a k8s namespace is not included or is listed in `k8sDenyNamespaces`,
+    pods in that k8s namespace will not be injected even if they are explicitly
+    annotated. Use `["*"]` to automatically allow all k8s namespaces.
+
+    For example, `["namespace1", "namespace2"]` will only allow pods in the k8s
+    namespaces `namespace1` and `namespace2` to have Connect sidecars injected
+    and registered with Consul. All other k8s namespaces will be ignored.
+
+    To deny all namespaces, set this to `[]`.
+
+    Note: `k8sDenyNamespaces` takes precedence over values defined here and
+    `namespaceSelector` takes precedence over both since it is applied first.
+    `kube-system` and `kube-public` are never injected, even if included here.
+    Requires consul-k8s v0.12+
+
+  - `k8sDenyNamespaces` ((#v-connectinject-k8sdenynamespaces)) (`array<string>: []`) - k8sDenyNamespaces is a list of k8s namespaces that should not allow Connect
+    sidecar injection. This list takes precedence over `k8sAllowNamespaces`.
+    `*` is not supported because then nothing would be allowed to be injected.
+
+    For example, if `k8sAllowNamespaces` is `["*"]` and k8sDenyNamespaces is
+    `["namespace1", "namespace2"]`, then all k8s namespaces besides "namespace1"
+    and "namespace2" will be available for injection.
+
+    Note: `namespaceSelector` takes precedence over this since it is applied first.
+    `kube-system` and `kube-public` are never injected.
+    Requires consul-k8s v0.12+.
+
+  - `consulNamespaces` ((#v-connectinject-consulnamespaces)) - <EnterpriseAlert inline /> These settings manage the connect injector's interaction with
+    Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+    Also, `global.enableConsulNamespaces` must be true.
+
+    - `consulDestinationNamespace` ((#v-connectinject-consulnamespaces-consuldestinationnamespace)) (`string: default`) - consulDestinationNamespace is the name of the Consul namespace to register all
+      k8s pods into. If the Consul namespace does not already exist,
+      it will be created. This will be ignored if `mirroringK8S` is true.
+
+    - `mirroringK8S` ((#v-connectinject-consulnamespaces-mirroringk8s)) (`boolean: false`) - mirroringK8S causes k8s pods to be registered into a Consul namespace
+      of the same name as their k8s namespace, optionally prefixed if
+      `mirroringK8SPrefix` is set below. If the Consul namespace does not
+      already exist, it will be created. Turning this on overrides the
+      `consulDestinationNamespace` setting.
+
+    - `mirroringK8SPrefix` ((#v-connectinject-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
+      to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+      pod in the k8s `staging` namespace will be registered into the
+      `k8s-staging` Consul namespace.
+
+  - `certs` ((#v-connectinject-certs)) - The certs section configures how the webhook TLS certs are configured.
+    These are the TLS certs for the Kube apiserver communicating to the
+    webhook. By default, the injector will generate and manage its own certs,
+    but this requires the ability for the injector to update its own
+    MutatingWebhookConfiguration. In a production environment, custom certs
+    should probably be used. Configure the values below to enable this.
+
+    - `secretName` ((#v-connectinject-certs-secretname)) (`string: null`) - secretName is the name of the secret that has the TLS certificate and
+      private key to serve the injector webhook. If this is null, then the
+      injector will default to its automatic management mode that will assign
+      a service account to the injector to generate its own certificates.
+
+    - `caBundle` ((#v-connectinject-certs-cabundle)) (`string: ""`) - caBundle is a base64-encoded PEM-encoded certificate bundle for the
+      CA that signed the TLS certificate that the webhook serves. This must
+      be set if secretName is non-null.
+
+    - `certName` ((#v-connectinject-certs-certname)) (`string: tls.crt`) - certName and keyName are the names of the files within the secret for
+      the TLS cert and private key, respectively. These have reasonable
+      defaults but can be customized if necessary.
+
+    - `keyName` ((#v-connectinject-certs-keyname)) (`string: tls.key`)
+
+  - `nodeSelector` ((#v-connectinject-nodeselector)) (`string: null`) - nodeSelector labels for connectInject pod assignment, formatted as a multi-line string.
+    ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    Example:
+
+    ```yaml
+    nodeSelector: |
+      beta.kubernetes.io/arch: amd64
+    ```
+
+  - `affinity` ((#v-connectinject-affinity)) (`string: null`) - Affinity Settings
+    This should be a multi-line string matching the affinity object
+
+  - `tolerations` ((#v-connectinject-tolerations)) (`string: null`) - Toleration Settings
+    This should be a multi-line string matching the Toleration array
+    in a PodSpec.
+
+  - `aclBindingRuleSelector` ((#v-connectinject-aclbindingruleselector)) (`string: serviceaccount.name!=default`) - aclBindingRuleSelector accepts a query that defines which Service Accounts
+    can authenticate to Consul and receive an ACL token during Connect injection.
+    The default setting, i.e. serviceaccount.name!=default, prevents the
+    'default' Service Account from logging in.
+    If set to an empty string all service accounts can log in.
+    This only has effect if ACLs are enabled.
+
+    See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
+    and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
+    for more details.
+    Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
+
+  - `overrideAuthMethodName` ((#v-connectinject-overrideauthmethodname)) (`string: ""`) - If you are not using global.acls.manageSystemACLs and instead manually setting up an
+    auth method for Connect inject, set this to the name of your auth method.
+
+  - `aclInjectToken` ((#v-connectinject-aclinjecttoken)) - aclInjectToken refers to a Kubernetes secret that you have created that contains
+    an ACL token for your Consul cluster which allows the Connect injector the correct
+    permissions. This is only needed if Consul namespaces <EnterpriseAlert inline /> and ACLs
+    are enabled on the Consul cluster and you are not setting
+    `global.acls.manageSystemACLs` to `true`.
+    This token needs to have `operator = "write"` privileges to be able to
+    create Consul namespaces.
+
+    - `secretName` ((#v-connectinject-aclinjecttoken-secretname)) (`string: null`)
+
+    - `secretKey` ((#v-connectinject-aclinjecttoken-secretkey)) (`string: null`)
+
+  - `centralConfig` ((#v-connectinject-centralconfig)) - Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
+
+    - `enabled` ((#v-connectinject-centralconfig-enabled)) (`boolean: true`) - enabled controls whether central config is enabled on all servers and clients.
+      See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+      If changing this after installation, servers and clients must be restarted
+      for the change to take effect.
+
+    - `defaultProtocol` ((#v-connectinject-centralconfig-defaultprotocol)) (`string: null`) - defaultProtocol allows you to specify a convenience default protocol if
+      most of your services are of the same protocol type. The individual annotation
+      on any given pod will override this value.
+      Valid values are "http", "http2", "grpc" and "tcp".
+
+    - `proxyDefaults` ((#v-connectinject-centralconfig-proxydefaults)) (`string: {}`) - proxyDefaults is a raw json string that will be written as the value of
+      the "config" key of the global proxy-defaults config entry.
+      See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
+      NOTE: Changes to this value after the chart is first installed have *no*
+      effect. In order to change the proxy-defaults config after installation,
+      you must use the Consul API.
+
+  - `sidecarProxy` ((#v-connectinject-sidecarproxy))
+
+    - `resources` ((#v-connectinject-sidecarproxy-resources)) - Set default resources for sidecar proxy. If null, that resource won't
+      be set.
+      These settings can be overridden on a per-pod basis via these annotations:
+      - `consul.hashicorp.com/sidecar-proxy-cpu-limit`
+      - `consul.hashicorp.com/sidecar-proxy-cpu-request`
+      - `consul.hashicorp.com/sidecar-proxy-memory-limit`
+      - `consul.hashicorp.com/sidecar-proxy-memory-request`
+
+      - `requests` ((#v-connectinject-sidecarproxy-resources-requests))
+
+        - `memory` ((#v-connectinject-sidecarproxy-resources-requests-memory)) (`string: null`) - Recommended default: 100Mi
+
+        - `cpu` ((#v-connectinject-sidecarproxy-resources-requests-cpu)) (`string: null`) - Recommended default: 100m
+
+      - `limits` ((#v-connectinject-sidecarproxy-resources-limits))
+
+        - `memory` ((#v-connectinject-sidecarproxy-resources-limits-memory)) (`string: null`) - Recommended default: 100Mi
+
+        - `cpu` ((#v-connectinject-sidecarproxy-resources-limits-cpu)) (`string: null`) - Recommended default: 100m
+
+  - `initContainer` ((#v-connectinject-initcontainer)) - Resource settings for the Connect injected init container.
+
+    - `resources` ((#v-connectinject-initcontainer-resources))
+
+      - `requests` ((#v-connectinject-initcontainer-resources-requests))
+
+        - `memory` ((#v-connectinject-initcontainer-resources-requests-memory)) (`string: 25Mi`)
+
+        - `cpu` ((#v-connectinject-initcontainer-resources-requests-cpu)) (`string: 50m`)
+
+      - `limits` ((#v-connectinject-initcontainer-resources-limits))
+
+        - `memory` ((#v-connectinject-initcontainer-resources-limits-memory)) (`string: 150Mi`)
+
+        - `cpu` ((#v-connectinject-initcontainer-resources-limits-cpu)) (`string: 50m`)
+
+- `controller` ((#v-controller)) - Controller handles config entry custom resources.
+  Requires consul >= 1.8.4.
+  ServiceIntentions require consul 1.9+.
+
+  - `enabled` ((#v-controller-enabled)) (`boolean: false`)
+
+  - `replicas` ((#v-controller-replicas)) (`integer: 1`)
+
+  - `logLevel` ((#v-controller-loglevel)) (`string: info`) - Log verbosity level. One of "debug", "info", "warn", or "error".
+
+  - `resources` ((#v-controller-resources)) - Resource settings for controller pods.
+
+    - `limits` ((#v-controller-resources-limits))
+
+      - `cpu` ((#v-controller-resources-limits-cpu)) (`string: 100m`)
+
+      - `memory` ((#v-controller-resources-limits-memory)) (`string: 50Mi`)
+
+    - `requests` ((#v-controller-resources-requests))
+
+      - `cpu` ((#v-controller-resources-requests-cpu)) (`string: 100m`)
+
+      - `memory` ((#v-controller-resources-requests-memory)) (`string: 50Mi`)
+
+  - `nodeSelector` ((#v-controller-nodeselector)) (`string: null`) - Optional YAML string to specify a nodeSelector config.
+
+  - `tolerations` ((#v-controller-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
+
+  - `affinity` ((#v-controller-affinity)) (`string: null`) - Affinity Settings
+    This should be a multi-line string matching the affinity object
+
+  - `priorityClassName` ((#v-controller-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+- `meshGateway` ((#v-meshgateway)) - Mesh Gateways enable Consul Connect to work across Consul datacenters.
+
+  - `enabled` ((#v-meshgateway-enabled)) (`boolean: false`) - If mesh gateways are enabled, a Deployment will be created that runs
+    gateways and Consul Connect will be configured to use gateways.
+    See https://www.consul.io/docs/connect/mesh_gateway.html
+    Requirements: consul 1.6.0+ and consul-k8s 0.15.0+ if using
+    global.acls.manageSystemACLs.
+
+  - `globalMode` ((#v-meshgateway-globalmode)) (`string: local`) - Globally configure which mode the gateway should run in.
+    Can be set to either "remote", "local", "none" or empty string or null.
+    See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
+    a description of each mode.
+    If set to anything other than "" or null, connectInject.centralConfig.enabled
+    should be set to true so that the global config will actually be used.
+    If set to the empty string, no global default will be set and the gateway mode
+    will need to be set individually for each service.
+
+  - `replicas` ((#v-meshgateway-replicas)) (`integer: 2`) - Number of replicas for the Deployment.
+
+  - `wanAddress` ((#v-meshgateway-wanaddress)) - What gets registered as WAN address for the gateway.
+
+    - `source` ((#v-meshgateway-wanaddress-source)) (`string: Service`) - source configures where to retrieve the WAN address (and possibly port)
+      for the mesh gateway from.
+      Can be set to either: Service, NodeIP, NodeName or Static.
+
+      Service - Determine the address based on the service type.
+
+        If service.type=LoadBalancer use the external IP or hostname of
+        the service. Use the port set by service.port.
+
+        If service.type=NodePort use the Node IP. The port will be set to
+        service.nodePort so service.nodePort cannot be null.
+
+        If service.type=ClusterIP use the ClusterIP. The port will be set to
+        service.port.
+
+        service.type=ExternalName is not supported.
+
+      NodeIP - The node IP as provided by the Kubernetes downward API.
+
+      NodeName - The name of the node as provided by the Kubernetes downward
+        API. This is useful if the node names are DNS entries that
+        are routable from other datacenters.
+
+      Static - Use the address hardcoded in meshGateway.wanAddress.static.
+
+    - `port` ((#v-meshgateway-wanaddress-port)) (`integer: 443`) - Port that gets registered for WAN traffic.
+      If source is set to "Service" then this setting will have no effect.
+      See the documentation for source as to which port will be used in that
+      case.
+
+    - `static` ((#v-meshgateway-wanaddress-static)) (`string: ""`) - If source is set to "Static" then this value will be used as the WAN
+      address of the mesh gateways. This is useful if you've configured a
+      DNS entry to point to your mesh gateways.
+
+  - `service` ((#v-meshgateway-service)) - The service option configures the Service that fronts the Gateway Deployment.
+
+    - `enabled` ((#v-meshgateway-service-enabled)) (`boolean: true`) - Whether to create a Service or not.
+
+    - `type` ((#v-meshgateway-service-type)) (`string: LoadBalancer`) - Type of service, ex. LoadBalancer, ClusterIP.
+
+    - `port` ((#v-meshgateway-service-port)) (`integer: 443`) - Port that the service will be exposed on.
+      The targetPort will be set to meshGateway.containerPort.
+
+    - `nodePort` ((#v-meshgateway-service-nodeport)) (`integer: null`) - Optionally hardcode the nodePort of the service if using a NodePort service.
+      If not set and using a NodePort service, Kubernetes will automatically assign
+      a port.
+
+    - `annotations` ((#v-meshgateway-service-annotations)) (`string: null`) - Annotations to apply to the mesh gateway service.
+      Example:
+
+      ```yaml
+        annotations: |
+          "annotation-key": "annotation-value"
+      ```
+
+    - `additionalSpec` ((#v-meshgateway-service-additionalspec)) (`string: null`) - Optional YAML string that will be appended to the Service spec.
+
+  - `hostNetwork` ((#v-meshgateway-hostnetwork)) (`boolean: false`) - If set to true, gateway Pods will run on the host network.
+
+  - `dnsPolicy` ((#v-meshgateway-dnspolicy)) (`string: null`) - dnsPolicy to use.
+
+  - `consulServiceName` ((#v-meshgateway-consulservicename)) (`string: mesh-gateway`) - Consul service name for the mesh gateways.
+    Cannot be set to anything other than "mesh-gateway" if
+    global.acls.manageSystemACLs is true since the ACL token
+    generated is only for the name 'mesh-gateway'.
+
+  - `containerPort` ((#v-meshgateway-containerport)) (`integer: 8443`) - Port that the gateway will run on inside the container.
+
+  - `hostPort` ((#v-meshgateway-hostport)) (`integer: null`) - Optional hostPort for the gateway to be exposed on.
+    This can be used with wanAddress.port and wanAddress.useNodeIP
+    to expose the gateways directly from the node.
+    If hostNetwork is true, this must be null or set to the same port as
+    containerPort.
+    NOTE: Cannot set to 8500 or 8502 because those are reserved for the Consul
+    agent.
+
+  - `resources` ((#v-meshgateway-resources)) - Resource settings for mesh gateway pods.
+    NOTE: The use of a YAML string is deprecated. Instead, set directly as a
+    YAML map.
+
+    - `requests` ((#v-meshgateway-resources-requests))
+
+      - `memory` ((#v-meshgateway-resources-requests-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-meshgateway-resources-requests-cpu)) (`string: 100m`)
+
+    - `limits` ((#v-meshgateway-resources-limits))
+
+      - `memory` ((#v-meshgateway-resources-limits-memory)) (`string: 100Mi`)
+
+      - `cpu` ((#v-meshgateway-resources-limits-cpu)) (`string: 100m`)
+
+  - `initCopyConsulContainer` ((#v-meshgateway-initcopyconsulcontainer)) - Resource settings for the `copy-consul-bin` init container.
+
+    - `resources` ((#v-meshgateway-initcopyconsulcontainer-resources))
+
+      - `requests` ((#v-meshgateway-initcopyconsulcontainer-resources-requests))
+
+        - `memory` ((#v-meshgateway-initcopyconsulcontainer-resources-requests-memory)) (`string: 25Mi`)
+
+        - `cpu` ((#v-meshgateway-initcopyconsulcontainer-resources-requests-cpu)) (`string: 50m`)
+
+      - `limits` ((#v-meshgateway-initcopyconsulcontainer-resources-limits))
+
+        - `memory` ((#v-meshgateway-initcopyconsulcontainer-resources-limits-memory)) (`string: 150Mi`)
+
+        - `cpu` ((#v-meshgateway-initcopyconsulcontainer-resources-limits-cpu)) (`string: 50m`)
+
+  - `affinity` ((#v-meshgateway-affinity)) (`string`) - By default, we set an anti-affinity so that two gateway pods won't be
+    on the same node. NOTE: Gateways require that Consul client agents are
+    also running on the nodes alongside each gateway pod.
+
+  - `tolerations` ((#v-meshgateway-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
+
+  - `nodeSelector` ((#v-meshgateway-nodeselector)) (`string: null`) - Optional YAML string to specify a nodeSelector config.
+
+  - `priorityClassName` ((#v-meshgateway-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+  - `annotations` ((#v-meshgateway-annotations)) (`string: null`) - Annotations to apply to the mesh gateway deployment.
+    Example:
+
+    ```yaml
+      annotations: |
+        "annotation-key": "annotation-value"
+    ```
+
+- `ingressGateways` ((#v-ingressgateways)) - Configuration options for ingress gateways. Default values for all
+  ingress gateways are defined in `ingressGateways.defaults`. Any of
+  these values may be overridden in `ingressGateways.gateways` for a
+  specific gateway with the exception of annotations. Annotations will
+  include both the default annotations and any additional ones defined
+  for a specific gateway.
+  Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+  global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
+
+  - `enabled` ((#v-ingressgateways-enabled)) (`boolean: false`) - Enable ingress gateway deployment. Requires `connectInject.enabled=true`
+    and `client.enabled=true`.
+
+  - `defaults` ((#v-ingressgateways-defaults)) - Defaults sets default values for all gateway fields. With the exception
+    of annotations, defining any of these values in the `gateways` list
+    will override the default values provided here. Annotations will
+    include both the default annotations and any additional ones defined
+    for a specific gateway.
+
+    - `replicas` ((#v-ingressgateways-defaults-replicas)) (`integer: 2`) - Number of replicas for each ingress gateway defined.
+
+    - `service` ((#v-ingressgateways-defaults-service)) - The service options configure the Service that fronts the gateway Deployment.
+
+      - `type` ((#v-ingressgateways-defaults-service-type)) (`string: ClusterIP`) - Type of service: LoadBalancer, ClusterIP or NodePort. If using NodePort service
+        type, you must set the desired nodePorts in the `ports` setting below.
+
+      - `ports` ((#v-ingressgateways-defaults-service-ports)) (`array<map>: [{port: 8080, port: 8443}]`) - Ports that will be exposed on the service and gateway container. Any
+        ports defined as ingress listeners on the gateway's Consul configuration
+        entry should be included here. The first port will be used as part of
+        the Consul service registration for the gateway and be listed in its
+        SRV record. If using a NodePort service type, you must specify the
+        desired nodePort for each exposed port.
+
+      - `annotations` ((#v-ingressgateways-defaults-service-annotations)) (`string: null`) - Annotations to apply to the ingress gateway service. Annotations defined
+        here will be applied to all ingress gateway services in addition to any
+        service annotations defined for a specific gateway in `ingressGateways.gateways`.
+        Example:
+        ```yaml
+          annotations: |
+            "annotation-key": "annotation-value"
+        ````
+
+      - `additionalSpec` ((#v-ingressgateways-defaults-service-additionalspec)) (`string: null`) - Optional YAML string that will be appended to the Service spec.
+
+    - `resources` ((#v-ingressgateways-defaults-resources)) - Resource limits for all ingress gateway pods
+
+      - `requests` ((#v-ingressgateways-defaults-resources-requests))
+
+        - `memory` ((#v-ingressgateways-defaults-resources-requests-memory)) (`string: 100Mi`)
+
+        - `cpu` ((#v-ingressgateways-defaults-resources-requests-cpu)) (`string: 100m`)
+
+      - `limits` ((#v-ingressgateways-defaults-resources-limits))
+
+        - `memory` ((#v-ingressgateways-defaults-resources-limits-memory)) (`string: 100Mi`)
+
+        - `cpu` ((#v-ingressgateways-defaults-resources-limits-cpu)) (`string: 100m`)
+
+    - `initCopyConsulContainer` ((#v-ingressgateways-defaults-initcopyconsulcontainer)) - Resource settings for the `copy-consul-bin` init container.
+
+      - `resources` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources))
+
+        - `requests` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-requests))
+
+          - `memory` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-requests-memory)) (`string: 25Mi`)
+
+          - `cpu` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-requests-cpu)) (`string: 50m`)
+
+        - `limits` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-limits))
+
+          - `memory` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-limits-memory)) (`string: 150Mi`)
+
+          - `cpu` ((#v-ingressgateways-defaults-initcopyconsulcontainer-resources-limits-cpu)) (`string: 50m`)
+
+    - `affinity` ((#v-ingressgateways-defaults-affinity)) (`string`) - By default, we set an anti-affinity so that two of the same gateway pods
+      won't be on the same node. NOTE: Gateways require that Consul client agents are
+      also running on the nodes alongside each gateway pod.
+
+    - `tolerations` ((#v-ingressgateways-defaults-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
+
+    - `nodeSelector` ((#v-ingressgateways-defaults-nodeselector)) (`string: null`) - Optional YAML string to specify a nodeSelector config.
+
+    - `priorityClassName` ((#v-ingressgateways-defaults-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+    - `annotations` ((#v-ingressgateways-defaults-annotations)) (`string: null`) - Annotations to apply to the ingress gateway deployment. Annotations defined
+      here will be applied to all ingress gateway deployments in addition to any
+      annotations defined for a specific gateway in `ingressGateways.gateways`.
+      Example:
+      ```yaml
+        annotations: |
+          "annotation-key": "annotation-value"
+      ```
+
+    - `consulNamespace` ((#v-ingressgateways-defaults-consulnamespace)) (`string: default`) - <EnterpriseAlert inline /> `consulNamespace` defines the Consul namespace to register
+      the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+      Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+      Note: The Consul namespace MUST exist before the gateway is deployed.
+
+  - `gateways` ((#v-ingressgateways-gateways)) (`array<map>`) - Gateways is a list of gateway objects. The only required field for
+    each is `name`, though they can also contain any of the fields in
+    `defaults`. Values defined here override the defaults except in the
+    case of annotations where both will be applied.
+
+    - `name` ((#v-ingressgateways-gateways-name)) (`string: ingress-gateway`)
+
+- `terminatingGateways` ((#v-terminatinggateways)) - Configuration options for terminating gateways. Default values for all
+  terminating gateways are defined in `terminatingGateways.defaults`. Any of
+  these values may be overridden in `terminatingGateways.gateways` for a
+  specific gateway with the exception of annotations. Annotations will
+  include both the default annotations and any additional ones defined
+  for a specific gateway.
+  Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+  global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
+
+  - `enabled` ((#v-terminatinggateways-enabled)) (`boolean: false`) - Enable terminating gateway deployment. Requires `connectInject.enabled=true`
+    and `client.enabled=true`.
+
+  - `defaults` ((#v-terminatinggateways-defaults)) - Defaults sets default values for all gateway fields. With the exception
+    of annotations, defining any of these values in the `gateways` list
+    will override the default values provided here. Annotations will
+    include both the default annotations and any additional ones defined
+    for a specific gateway.
+
+    - `replicas` ((#v-terminatinggateways-defaults-replicas)) (`integer: 2`) - Number of replicas for each terminating gateway defined.
+
+    - `extraVolumes` ((#v-terminatinggateways-defaults-extravolumes)) (`array<map>`) - A list of extra volumes to mount. These will be exposed to Consul in the path `/consul/userconfig/<name>/`.
+
+      Example:
+      ```yaml
+      extraVolumes:
+      - type: 'secret'
+        name: 'my-secret'
+        items: # optional items array
+          - key: key
+            path: path # secret will now mount to /consul/userconfig/my-secret/path
+      ```
+
+    - `resources` ((#v-terminatinggateways-defaults-resources)) - Resource limits for all terminating gateway pods
+
+      - `requests` ((#v-terminatinggateways-defaults-resources-requests))
+
+        - `memory` ((#v-terminatinggateways-defaults-resources-requests-memory)) (`string: 100Mi`)
+
+        - `cpu` ((#v-terminatinggateways-defaults-resources-requests-cpu)) (`string: 100m`)
+
+      - `limits` ((#v-terminatinggateways-defaults-resources-limits))
+
+        - `memory` ((#v-terminatinggateways-defaults-resources-limits-memory)) (`string: 100Mi`)
+
+        - `cpu` ((#v-terminatinggateways-defaults-resources-limits-cpu)) (`string: 100m`)
+
+    - `initCopyConsulContainer` ((#v-terminatinggateways-defaults-initcopyconsulcontainer)) - Resource settings for the `copy-consul-bin` init container.
+
+      - `resources` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources))
+
+        - `requests` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-requests))
+
+          - `memory` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-requests-memory)) (`string: 25Mi`)
+
+          - `cpu` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-requests-cpu)) (`string: 50m`)
+
+        - `limits` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-limits))
+
+          - `memory` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-limits-memory)) (`string: 150Mi`)
+
+          - `cpu` ((#v-terminatinggateways-defaults-initcopyconsulcontainer-resources-limits-cpu)) (`string: 50m`)
+
+    - `affinity` ((#v-terminatinggateways-defaults-affinity)) (`string`) - By default, we set an anti-affinity so that two of the same gateway pods
+      won't be on the same node. NOTE: Gateways require that Consul client agents are
+      also running on the nodes alongside each gateway pod.
+
+    - `tolerations` ((#v-terminatinggateways-defaults-tolerations)) (`string: null`) - Optional YAML string to specify tolerations.
+
+    - `nodeSelector` ((#v-terminatinggateways-defaults-nodeselector)) (`string: null`) - Optional YAML string to specify a nodeSelector config.
+
+    - `priorityClassName` ((#v-terminatinggateways-defaults-priorityclassname)) (`string: ""`) - Optional priorityClassName.
+
+    - `annotations` ((#v-terminatinggateways-defaults-annotations)) (`string: null`) - Annotations to apply to the terminating gateway deployment. Annotations defined
+      here will be applied to all terminating gateway deployments in addition to any
+      annotations defined for a specific gateway in `terminatingGateways.gateways`.
+      Example:
+      ```yaml
+        annotations: |
+          "annotation-key": "annotation-value"
+      ```
+
+    - `consulNamespace` ((#v-terminatinggateways-defaults-consulnamespace)) (`string: default`) - <EnterpriseAlert inline /> `consulNamespace` defines the Consul namespace to register
+      the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+      Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+      Note: The Consul namespace MUST exist before the gateway is deployed.
+
+  - `gateways` ((#v-terminatinggateways-gateways)) (`array<map>`) - Gateways is a list of gateway objects. The only required field for
+    each is `name`, though they can also contain any of the fields in
+    `defaults`. Values defined here override the defaults except in the
+    case of annotations where both will be applied.
+
+    - `name` ((#v-terminatinggateways-gateways-name)) (`string: terminating-gateway`)
+
+- `tests` ((#v-tests)) - Control whether a test Pod manifest is generated when running helm template.
+  When using helm install, the test Pod is not submitted to the cluster so this
+  is only useful when running helm template.
+
+  - `enabled` ((#v-tests-enabled)) (`boolean: true`)

--- a/hack/helm-reference-gen/fixtures/full-values.yaml
+++ b/hack/helm-reference-gen/fixtures/full-values.yaml
@@ -1,0 +1,1762 @@
+# Available parameters and their default values for the Consul chart.
+
+# Holds values that affect multiple components of the chart.
+global:
+  # The master enabled/disabled setting. If true, servers,
+  # clients, Consul DNS and the Consul UI will be enabled. Each component can override
+  # this default via its component-specific "enabled" config. If false, no components
+  # will be installed by default and per-component opt-in is required, such as by
+  # setting `server.enabled` to true.
+  enabled: true
+
+  # Set the prefix used for all resources in the Helm chart. If not set,
+  # the prefix will be `<helm release name>-consul`.
+  # @type: string
+  name: null
+
+  # The domain Consul will answer DNS queries for
+  # (see `-domain` (https://consul.io/docs/agent/options#_domain)) and the domain services synced from
+  # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
+  domain: consul
+
+  # The name (and tag) of the Consul Docker image for clients and servers.
+  # This can be overridden per component. This should be pinned to a specific
+  # version tag, otherwise you may inadvertently upgrade your Consul version.
+  #
+  # Examples:
+  #
+  # ```yaml
+  # # Consul 1.5.0
+  # image: "consul:1.5.0"
+  # # Consul Enterprise 1.5.0
+  # image: "hashicorp/consul-enterprise:1.5.0-ent"
+  # ```
+  image: "hashicorp/consul:1.9.0"
+
+  # Array of objects containing image pull secret names that will be applied to each service account.
+  # This can be used to reference image pull secrets if using a custom consul or consul-k8s Docker image.
+  # See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry for reference.
+  #
+  # Example:
+  #
+  # ```yaml
+  # imagePullSecrets:
+  #   - name: pull-secret-name
+  #   - name: pull-secret-name-2
+  # ```
+  # @type: array<map>
+  imagePullSecrets: []
+
+  # The name (and tag) of the consul-k8s (https://github.com/hashicorp/consul-k8s)
+  # Docker image that is used for functionality such the catalog sync.
+  # This can be overridden per component.
+  imageK8S: "hashicorp/consul-k8s:0.21.0"
+
+  # The name of the datacenter that the agents should
+  # register as. This can't be changed once the Consul cluster is up and running
+  # since Consul doesn't support an automatic way to change this value currently:
+  # https://github.com/hashicorp/consul/issues/1858.
+  datacenter: dc1
+
+  # Controls whether pod security policies are created for the Consul components
+  # created by this chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
+  enablePodSecurityPolicies: false
+
+  # Configures which Kubernetes secret to retrieve Consul's
+  # gossip encryption key from (see [-encrypt](/docs/agent/options#_encrypt)). If secretName or
+  # secretKey are not set, gossip encryption will not be enabled. The secret must
+  # be in the same namespace that Consul is installed into.
+  #
+  # The secret can be created by running:
+  #
+  # ```shell
+  # $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)
+  # ```
+  #
+  # To reference, use:
+  #
+  # ```yaml
+  # global:
+  #   gossipEncryption:
+  #     secretName: consul-gossip-encryption-key
+  #     secretKey: key
+  # ```
+  gossipEncryption:
+    # secretName is the name of the Kubernetes secret that holds the gossip
+    # encryption key. The secret must be in the same namespace that Consul is installed into.
+    secretName: ""
+    # secretKey is the key within the Kubernetes secret that holds the gossip
+    # encryption key.
+    secretKey: ""
+
+  # Enables TLS (https://learn.hashicorp.com/tutorials/consul/gossip-encryption-secure)
+  # across the cluster to verify authenticity of the Consul servers and clients.
+  # Requires Consul v1.4.1+ and consul-k8s v0.16.2+
+  tls:
+    # If true, the Helm chart will enable TLS for Consul
+    # servers and clients and all consul-k8s components, as well as generate certificate
+    # authority (optional) and server and client certificates.
+    enabled: false
+
+    # If true, turns on the auto-encrypt feature on clients and servers.
+    # It also switches consul-k8s components to retrieve the CA from the servers
+    # via the API. Requires Consul 1.7.1+ and consul-k8s 0.13.0
+    enableAutoEncrypt: false
+
+    # A list of additional DNS names to set as Subject Alternative Names (SANs)
+    # in the server certificate. This is useful when you need to access the
+    # Consul server(s) externally, for example, if you're using the UI.
+    # @type: array<string>
+    serverAdditionalDNSSANs: []
+
+    # A list of additional IP addresses to set as Subject Alternative Names (SANs)
+    # in the server certificate. This is useful when you need to access the
+    # Consul server(s) externally, for example, if you're using the UI.
+    # @type: array<string>
+    serverAdditionalIPSANs: []
+
+    # If true, `verify_outgoing`, `verify_server_hostname`,
+    # and `verify_incoming_rpc` will be set to `true` for Consul servers and clients.
+    # Set this to false to incrementally roll out TLS on an existing Consul cluster.
+    # Please see https://consul.io/docs/k8s/operations/tls-on-existing-cluster
+    # for more details.
+    verify: true
+
+    # If true, the Helm chart will configure Consul to disable the HTTP port on
+    # both clients and servers and to only accept HTTPS connections.
+    httpsOnly: true
+
+    # A Kubernetes secret containing the certificate of the CA to use for
+    # TLS communication within the Consul cluster. If you have generated the CA yourself
+    # with the consul CLI, you could use the following command to create the secret
+    # in Kubernetes:
+    #
+    # ```bash
+    # kubectl create secret generic consul-ca-cert \
+    #     --from-file='tls.crt=./consul-agent-ca.pem'
+    # ```
+    caCert:
+      # The name of the Kubernetes secret.
+      secretName: null
+      # The key of the Kubernetes secret.
+      secretKey: null
+
+    # A Kubernetes secret containing the private key of the CA to use for
+    # TLS communication within the Consul cluster. If you have generated the CA yourself
+    # with the consul CLI, you could use the following command to create the secret
+    # in Kubernetes:
+    #
+    # ```bash
+    # kubectl create secret generic consul-ca-key \
+    #     --from-file='tls.key=./consul-agent-ca-key.pem'
+    # ```
+    #
+    # Note that we need the CA key so that we can generate server and client certificates.
+    # It is particularly important for the client certificates since they need to have host IPs
+    # as Subject Alternative Names. In the future, we may support bringing your own server
+    # certificates.
+    caKey:
+      # The name of the Kubernetes secret.
+      secretName: null
+      # The key of the Kubernetes secret.
+      secretKey: null
+
+  # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
+  # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
+  # like to make use of configuration beyond registering everything into
+  # the `default` Consul namespace. Requires consul-k8s v0.12+. Additional configuration
+  # options are found in the `consulNamespaces` section of both the catalog sync
+  # and connect injector.
+  enableConsulNamespaces: false
+
+  # Configure ACLs.
+  acls:
+
+    # If true, the Helm chart will automatically manage ACL tokens and policies
+    # for all Consul and consul-k8s components.
+    # This requires Consul >= 1.4 and consul-k8s >= 0.14.0.
+    manageSystemACLs: false
+
+    # A Kubernetes secret containing the bootstrap token to use for
+    # creating policies and tokens for all Consul and consul-k8s components.
+    # If set, we will skip ACL bootstrapping of the servers and will only
+    # initialize ACLs for the Consul clients and consul-k8s system components.
+    # Requires consul-k8s >= 0.14.0.
+    bootstrapToken:
+      # The name of the Kubernetes secret.
+      secretName: null
+      # The key of the Kubernetes secret.
+      secretKey: null
+
+    # If true, an ACL token will be created that can be used in secondary
+    # datacenters for replication. This should only be set to true in the
+    # primary datacenter since the replication token must be created from that
+    # datacenter.
+    # In secondary datacenters, the secret needs to be imported from the primary
+    # datacenter and referenced via `global.acls.replicationToken`.
+    # Requires consul-k8s >= 0.13.0.
+    createReplicationToken: false
+
+    # replicationToken references a secret containing the replication ACL token.
+    # This token will be used by secondary datacenters to perform ACL replication
+    # and create ACL tokens and policies.
+    # This value is ignored if `bootstrapToken` is also set.
+    # Requires consul-k8s >= 0.13.0.
+    replicationToken:
+      # The name of the Kubernetes secret.
+      secretName: null
+      # The key of the Kubernetes secret.
+      secretKey: null
+
+  # Configure federation.
+  federation:
+    # If enabled, this datacenter will be federation-capable. Only federation
+    # via mesh gateways is supported.
+    # Mesh gateways and servers will be configured to allow federation.
+    # Requires `global.tls.enabled`, `meshGateway.enabled` and `connectInject.enabled`
+    # to be true.
+    enabled: false
+
+    # If true, the chart will create a Kubernetes secret that can be imported
+    # into secondary datacenters so they can federate with this datacenter. The
+    # secret contains all the information secondary datacenters need to contact
+    # and authenticate with this datacenter. This should only be set to true
+    # in your primary datacenter. The secret name is
+    # `<global.name>-federation` (if setting `global.name`), otherwise
+    # `<helm-release-name>-consul-federation`. Requires consul-k8s 0.15.0+.
+    createFederationSecret: false
+
+  # The lifecycle sidecar ensures the Consul services
+  # are always registered with their local Consul clients and is used by the
+  # ingress/terminating/mesh gateways as well as with every Connect-injected service.
+  lifecycleSidecarContainer:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "20m"
+      limits:
+        memory: "50Mi"
+        cpu: "20m"
+
+  # The name (and tag) of the Envoy Docker image used for the
+  # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
+  # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.16.0"
+
+  # Configuration for running this Helm chart on the Red Hat OpenShift platform.
+  # This Helm chart currently supports OpenShift v4.x+.
+  openshift:
+    # If true, the Helm chart will create necessary configuration for running
+    # its components on OpenShift.
+    enabled: false
+
+# Server, when enabled, configures a server cluster to run. This should
+# be disabled if you plan on connecting to a Consul cluster external to
+# the Kube cluster.
+server:
+
+  # If true, the chart will install all the resources necessary for a
+  # Consul server cluster. If you're running Consul externally and want agents
+  # within Kubernetes to join that cluster, this should probably be false.
+  # @default: global.enabled
+  # @type: boolean
+  enabled: "-"
+
+  # The name of the Docker image (including any tag) for the containers running
+  # Consul server agents.
+  # @type: string
+  image: null
+
+  # The number of server agents to run. This determines the fault tolerance of
+  # the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
+  # for more information.
+  replicas: 3
+
+  # For new clusters, this is the number of servers to wait for before performing
+  # the initial leader election and bootstrap of the cluster. This must be less
+  # than or equal to `server.replicas`. This value is only used
+  # when bootstrapping new clusters, it has no effect during ongoing cluster maintenance.
+  bootstrapExpect: 3
+
+  # [Enterprise Only] This value refers to a Kubernetes secret that you have created
+  # that contains your enterprise license. It is required if you are using an
+  # enterprise binary. Defining it here applies it to your cluster once a leader
+  # has been elected. If you are not using an enterprise image or if you plan to
+  # introduce the license key via another route, then set these fields to null.
+  # Note: the job to apply license runs on both Helm installs and upgrades.
+  enterpriseLicense:
+    # The name of the Kubernetes secret that holds the enterprise license.
+    # The secret must be in the same namespace that Consul is installed into.
+    secretName: null
+    # The key within the Kubernetes secret that holds the enterprise license.
+    secretKey: null
+
+  # This defines the disk size for configuring the
+  # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
+  # desired size. For manually defined persistent volumes, this should be set to
+  # the disk size of the attached volume.
+  storage: 10Gi
+
+  # The StorageClass to use for the servers' StatefulSet storage. It must be
+  # able to be dynamically provisioned if you want the storage
+  # to be automatically created. For example, to use local
+  # (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
+  # storage classes, the PersistentVolumeClaims would need to be manually created.
+  # A `null` value will use the Kubernetes cluster's default StorageClass. If a default
+  # StorageClass does not exist, you will need to create one.
+  # @type: string
+  storageClass: null
+
+  # This will enable/disable [Connect](/docs/connect). Setting this to true
+  # _will not_ automatically secure pod communication, this
+  # setting will only enable usage of the feature. Consul will automatically initialize
+  # a new CA and set of certificates. Additional Connect settings can be configured
+  # by setting the `server.extraConfig` value.
+  connect: true
+
+  # The resource requests (CPU, memory, etc.)
+  # for each of the server agents. This should be a YAML map corresponding to a Kubernetes
+  # ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#resourcerequirements-v1-core)
+  # object. NOTE: The use of a YAML string is deprecated.
+  #
+  # Example:
+  #
+  # ```yaml
+  # resources:
+  #   requests:
+  #     memory: '100Mi'
+  #     cpu: '100m'
+  #   limits:
+  #     memory: '100Mi'
+  #     cpu: '100m'
+  # ```
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "100Mi"
+      cpu: "100m"
+
+  # This value is used to carefully
+  # control a rolling update of Consul server agents. This value specifies the
+  # partition (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions)
+  # for performing a rolling update. Please read the linked Kubernetes documentation
+  # for more information.
+  updatePartition: 0
+
+  # This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # for the server cluster.
+  disruptionBudget:
+    # This will enable/disable registering a PodDisruptionBudget for the server
+    # cluster. If this is enabled, it will only register the budget so long as
+    # the server cluster is enabled.
+    enabled: true
+
+    # The maximum number of unavailable pods. By default, this will be
+    # automatically computed based on the `server.replicas` value to be `(n/2)-1`.
+    # If you need to set this to `0`, you will need to add a
+    # --set 'server.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
+    # command because of a limitation in the Helm templating language.
+    # @type: integer
+    maxUnavailable: null
+
+  # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  # servers. This will be saved as-is into a ConfigMap that is read by the Consul
+  # server agents. This can be used to add additional configuration that
+  # isn't directly exposed by the chart.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraConfig: |
+  #   {
+  #     "log_level": "DEBUG"
+  #   }
+  # ```
+  #
+  # This can also be set using Helm's `--set` flag using the following syntax:
+  #
+  # ```shell
+  # --set 'server.extraConfig="{"log_level": "DEBUG"}"'
+  # ```
+  extraConfig: |
+    {}
+
+  # A list of extra volumes to mount for server agents. This
+  # is useful for bringing in extra data that can be referenced by other configurations
+  # at a well known path, such as TLS certificates or Gossip encryption keys. The
+  # value of this should be a list of objects.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraVolumes:
+  # - type: 'secret'
+  #   name: 'consul-certs'
+  #   load: false
+  # ```
+  # Each object supports the following keys:
+  #
+  # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+  #
+  # - `name` - Name of the configMap or secret to be mounted. This also controls
+  #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+  #
+  # - `load` - If true, then the agent will be
+  #   configured to automatically load HCL/JSON configuration files from this volume
+  #   with `-config-dir`. This defaults to false.
+  #
+  # @type: array<map>
+  extraVolumes: []
+
+  # This value defines the affinity (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  # for server pods. It defaults to allowing only a single pod on each node, which
+  # minimizes risk of the cluster becoming unusable if a node is lost. If you need
+  # to run more pods per node (for example, testing on Minikube), set this value
+  # to `null`.
+  #
+  # Example:
+  #
+  # ```yaml
+  # affinity: |
+  #   podAntiAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       - labelSelector:
+  #           matchLabels:
+  #             app: {{ template "consul.name" . }}
+  #             release: "{{ .Release.Name }}"
+  #             component: server
+  #       topologyKey: kubernetes.io/hostname
+  # ```
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: "{{ .Release.Name }}"
+              component: server
+          topologyKey: kubernetes.io/hostname
+
+  # Toleration settings for server pods. This
+  # should be a multi-line string matching the Tolerations
+  # (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+  tolerations: ""
+
+  # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  # labels for server pod assignment, formatted as a multi-line string.
+  #
+  # Example:
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  #
+  # @type: string
+  nodeSelector: null
+
+  # This value references an existing
+  # Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+  # that can be assigned to server pods.
+  priorityClassName: ""
+
+  # Extra labels to attach to the server pods. This should be a YAML map.
+  #
+  # Example:
+  # ```yaml
+  # extraLabels:
+  #   labelKey: "label-value"
+  #   anotherLabelKey: "another-label-value"
+  # ```
+  #
+  # @type: map
+  extraLabels: null
+
+  # This value defines additional annotations for
+  # server pods. This should be a formatted as a multi-line string.
+  #
+  # ```yaml
+  # annotations: |
+  #   "sample/annotation1": "foo"
+  #   "sample/annotation2": "bar"
+  # ```
+  #
+  # @type: string
+  annotations: null
+
+  # Server service properties.
+  service:
+    # Annotations to apply to the server service.
+    #
+    # ```yaml
+    # annotations: |
+    #   "annotation-key": "annotation-value"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
+  # extraEnvironmentVars is a list of extra environment variables to set within the stateful set.
+  # These could be used to include proxy settings required for cloud auto-join
+  # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
+  # it could be used to configure custom consul parameters.
+  # @type: map
+  extraEnvironmentVars: {}
+
+# Configuration for Consul servers when the servers are running outside of Kubernetes.
+# When running external servers, configuring these values is recommended
+# if setting `global.tls.enableAutoEncrypt` to true (requires consul-k8s >= 0.13.0)
+# or `global.acls.manageSystemACLs` to true (requires consul-k8s >= 0.14.0).
+externalServers:
+  # If true, the Helm chart will be configured to talk to the external servers.
+  #  If setting this to true, you must also set `server.enabled` to false.
+  enabled: false
+
+  # An array of external Consul server hosts that are used to make
+  # HTTPS connections from the components in this Helm chart.
+  # Valid values include IPs, DNS names, or Cloud auto-join string.
+  # The port must be provided separately below.
+  # Note: `client.join` must also be set to the hosts that should be
+  # used to join the cluster. In most cases, the `client.join` values
+  # should be the same, however, they may be different if you
+  # wish to use separate hosts for the HTTPS connections.
+  # @type: array<string>
+  hosts: []
+
+  # The HTTPS port of the Consul servers.
+  httpsPort: 8501
+
+  # The server name to use as the SNI host header when connecting with HTTPS.
+  # @type: string
+  tlsServerName: null
+
+  # If true, consul-k8s components will ignore the CA set in
+  # `global.tls.caCert` when making HTTPS calls to Consul servers and
+  # will instead use the consul-k8s image's system CAs for TLS verification.
+  # If false, consul-k8s components will use `global.tls.caCert` when
+  # making HTTPS calls to Consul servers.
+  # **NOTE:** This does not affect Consul's internal RPC communication which will
+  # always use `global.tls.caCert`.
+  useSystemRoots: false
+
+  # If you are setting `global.acls.manageSystemACLs` and
+  # `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
+  # This address must be reachable from the Consul servers.
+  # Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
+  # Requires consul-k8s >= 0.14.0.
+  #
+  # You could retrieve this value from your `kubeconfig` by running:
+  #
+  # ```shell
+  # kubectl config view \
+  #   -o jsonpath="{.clusters[?(@.name=='<your cluster name>')].cluster.server}"
+  # ```
+  #
+  # @type: string
+  k8sAuthMethodHost: null
+
+# Values that configure running a Consul client on Kubernetes nodes.
+client:
+  # If true, the chart will install all
+  # the resources necessary for a Consul client on every Kubernetes node. This _does not_ require
+  # `server.enabled`, since the agents can be configured to join an external cluster.
+  # @default: global.enabled
+  # @type: boolean
+  enabled: "-"
+
+  # The name of the Docker image (including any tag) for the containers
+  # running Consul client agents.
+  # @type: string
+  image: null
+
+  # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
+  # If this is `null` (default), then the clients will attempt to automatically
+  # join the server cluster running within Kubernetes.
+  # This means that with `server.enabled` set to true, clients will automatically
+  # join that cluster. If `server.enabled` is not true, then a value must be
+  # specified so the clients can join a valid cluster.
+  # @type: array<string>
+  join: null
+
+  # An absolute path to a directory on the host machine to use as the Consul
+  # client data directory. If set to the empty string or null, the Consul agent
+  # will store its data in the Pod's local filesystem (which will
+  # be lost if the Pod is deleted). Security Warning: If setting this, Pod Security
+  # Policies _must_ be enabled on your cluster and in this Helm chart (via the
+  # `global.enablePodSecurityPolicies` setting) to prevent other pods from
+  # mounting the same host path and gaining access to all of Consul's data.
+  # Consul's data is not encrypted at rest.
+  # @type: string
+  dataDirectoryHostPath: null
+
+  # If true, agents will enable their GRPC listener on
+  # port 8502 and expose it to the host. This will use slightly more resources, but is
+  # required for Connect.
+  grpc: true
+
+  # If true, the Helm chart will expose the clients' gossip ports as hostPorts.
+  # This is only necessary if pod IPs in the k8s cluster are not directly routable
+  # and the Consul servers are outside of the k8s cluster.
+  # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
+  exposeGossipPorts: false
+
+  # Resource settings for Client agents.
+  # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
+  # YAML map.
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "100Mi"
+      cpu: "100m"
+
+  # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  # clients. This will be saved as-is into a ConfigMap that is read by the Consul
+  # client agents. This can be used to add additional configuration that
+  # isn't directly exposed by the chart.
+  #
+  # Example:
+  # ```yaml
+  # extraConfig: |
+  #   {
+  #     "log_level": "DEBUG"
+  #   }
+  # ```
+  #
+  # This can also be set using Helm's `--set` flag using the following syntax:
+  #
+  # ```shell
+  # --set 'client.extraConfig="{"log_level": "DEBUG"}"'
+  # ```
+  extraConfig: |
+    {}
+
+  # A list of extra volumes to mount for client agents. This
+  # is useful for bringing in extra data that can be referenced by other configurations
+  # at a well known path, such as TLS certificates or Gossip encryption keys. The
+  # value of this should be a list of objects.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraVolumes:
+  # - type: 'secret'
+  #   name: 'consul-certs'
+  #   load: false
+  # ```
+  # Each object supports the following keys:
+  #
+  # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+  #
+  # - `name` - Name of the configMap or secret to be mounted. This also controls
+  #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+  #
+  # - `load` - If true, then the agent will be
+  #   configured to automatically load HCL/JSON configuration files from this volume
+  #   with `-config-dir`. This defaults to false.
+  #
+  # @type: array<map>
+  extraVolumes: []
+
+  # Toleration Settings for Client pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  # The example below will allow Client pods to run on every node
+  # regardless of taints
+  # tolerations: |
+  #   - operator: "Exists"
+  tolerations: ""
+
+  # nodeSelector labels for client pod assignment, formatted as a multi-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  #
+  # Example:
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  # @type: string
+  nodeSelector: null
+
+  # Affinity Settings for Client pods, formatted as a multi-line YAML string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  #
+  # Example:
+  # ```yaml
+  # affinity: |
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: node-role.kubernetes.io/master
+  #           operator: DoesNotExist
+  # ```
+  # @type: string
+  affinity: {}
+
+  # This value references an existing
+  # Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)
+  # that can be assigned to client pods.
+  priorityClassName: ""
+
+  # This value defines additional annotations for
+  # client pods. This should be a formatted as a multi-line string.
+  #
+  # ```yaml
+  # annotations: |
+  #   "sample/annotation1": "foo"
+  #   "sample/annotation2": "bar"
+  # ```
+  #
+  # @type: string
+  annotations: null
+
+  # extraEnvironmentVars is a list of extra environment variables to set within the stateful set.
+  # These could be used to include proxy settings required for cloud auto-join
+  # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
+  # it could be used to configure custom consul parameters.
+  # @type: map
+  extraEnvironmentVars: {}
+
+  # This value defines the Pod DNS policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
+  # for client pods to use.
+  # @type: string
+  dnsPolicy: null
+
+  # hostNetwork defines whether or not we use host networking instead of hostPort in the event
+  # that a CNI plugin doesn't support `hostPort`. This has security implications and is not recommended
+  # as doing so gives the consul client unnecessary access to all network traffic on the host.
+  # In most cases, pod network and host network are on different networks so this should be
+  # combined with `dnsPolicy: ClusterFirstWithHostNet`
+  hostNetwork: false
+
+  # updateStrategy for the DaemonSet.
+  # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+  # This should be a multi-line string mapping directly to the updateStrategy
+  #
+  # Example:
+  # ```yaml
+  #  updateStrategy: |
+  #    rollingUpdate:
+  #      maxUnavailable: 5
+  #    type: RollingUpdate
+  # ```
+  # @type: string
+  updateStrategy: null
+
+  # [Enterprise Only] Values for setting up and running snapshot agents
+  # (https://consul.io/commands/snapshot/agent)
+  # within the Consul clusters. They are required to be co-located with Consul clients,
+  # so will inherit the clients' nodeSelector, tolerations and affinity.
+  snapshotAgent:
+    # If true, the chart will install resources necessary to run the snapshot agent.
+    enabled: false
+
+    # The number of snapshot agents to run.
+    replicas: 2
+
+    # A Kubernetes secret that should be manually created to contain the entire
+    # config to be used on the snapshot agent.
+    # This is the preferred method of configuration since there are usually storage
+    # credentials present. Please see Snapshot agent config (https://consul.io/commands/snapshot/agent#config-file-options)
+    # for details.
+    configSecret:
+      # The name of the Kubernetes secret.
+      secretName: null
+      # The key of the Kubernetes secret.
+      secretKey: null
+
+    # Resource settings for snapshot agent pods.
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "50Mi"
+        cpu: "50m"
+
+    # Optional PEM-encoded CA certificate that will be added to the trusted system CAs.
+    # Useful if using an S3-compatible storage exposing a self-signed certificate.
+    #
+    # Example:
+    # ```yaml
+    # caCert: |
+    #   -----BEGIN CERTIFICATE-----
+    #   MIIC7jCCApSgAwIBAgIRAIq2zQEVexqxvtxP6J0bXAwwCgYIKoZIzj0EAwIwgbkx
+    #   ...
+    # ```
+    # @type: string
+    caCert: null
+
+# Configuration for DNS configuration within the Kubernetes cluster.
+# This creates a service that routes to all agents (client or server)
+# for serving DNS requests. This DOES NOT automatically configure kube-dns
+# today, so you must still manually configure a `stubDomain` with kube-dns
+# for this to have any effect:
+# https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configure-stub-domain-and-upstream-dns-servers
+dns:
+  # @type: boolean
+  enabled: "-"
+
+  # type can be used to control the type of service created. For
+  # example, setting this to "LoadBalancer" will create an external load
+  # balancer (for supported K8S installations)
+  type: ClusterIP
+
+  # Set a predefined cluster IP for the DNS service.
+  # Useful if you need to reference the DNS service's IP
+  # address in CoreDNS config.
+  # @type: string
+  clusterIP: null
+
+  # Extra annotations to attach to the dns service
+  # This should be a multi-line string of
+  # annotations to apply to the dns Service
+  # @type: string
+  annotations: null
+
+  # Additional ServiceSpec values
+  # This should be a multi-line string mapping directly to a Kubernetes
+  # ServiceSpec object.
+  # @type: string
+  additionalSpec: null
+
+# Values that configure the Consul UI.
+ui:
+  # If true, the UI will be enabled. This will
+  # only _enable_ the UI, it doesn't automatically register any service for external
+  # access. The UI will only be enabled on server agents. If `server.enabled` is
+  # false, then this setting has no effect. To expose the UI in some way, you must
+  # configure `ui.service`.
+  # @default: global.enabled
+  # @type: boolean
+  enabled: "-"
+
+  # True if you want to create a Service entry for the Consul UI.
+  #
+  # serviceType can be used to control the type of service created. For
+  # example, setting this to "LoadBalancer" will create an external load
+  # balancer (for supported K8S installations) to access the UI.
+  service:
+    # This will enable/disable registering a
+    # Kubernetes Service for the Consul UI. This value only takes effect if `ui.enabled` is
+    # true and taking effect.
+    enabled: true
+
+    # The service type to register.
+    # @type: string
+    type: null
+
+    # Annotations to apply to the UI service.
+    #
+    # Example:
+    # ```yaml
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    # ```
+    # @type: string
+    annotations: null
+
+    # Additional ServiceSpec values
+    # This should be a multi-line string mapping directly to a Kubernetes
+    # ServiceSpec object.
+    # @type: string
+    additionalSpec: null
+
+# syncCatalog will run the catalog sync process to sync K8S with Consul
+# services. This can run bidirectional (default) or unidirectionally (Consul
+# to K8S or K8S to Consul only).
+#
+# This process assumes that a Consul agent is available on the host IP.
+# This is done automatically if clients are enabled. If clients are not
+# enabled then set the node selection so that it chooses a node with a
+# Consul agent.
+syncCatalog:
+  # True if you want to enable the catalog sync. Set to "-" to inherit from
+  # global.enabled.
+  enabled: false
+
+  # The name of the Docker image (including any tag) for consul-k8s
+  # to run the sync program.
+  # @type: string
+  image: null
+
+  # If true, all valid services in K8S are
+  # synced by default. If false, the service must be annotated
+  # (https://consul.io/docs/k8s/service-sync#sync-enable-disable) properly to sync.
+  # In either case an annotation can override the default.
+  default: true
+
+  # Optional priorityClassName.
+  priorityClassName: ""
+
+  # toConsul and toK8S control whether syncing is enabled to Consul or K8S
+  # as a destination. If both of these are disabled, the sync will do nothing.
+  toConsul: true
+
+  # If true, will sync Consul services to Kubernetes. This can be disabled to
+  # have a one-way sync.
+  toK8S: true
+
+  # k8sPrefix is the service prefix to prepend to services before registering
+  # with Kubernetes. For example "consul-" will register all services
+  # prepended with "consul-". (Consul -> Kubernetes sync)
+  # @type: string
+  k8sPrefix: null
+
+  # k8sAllowNamespaces is a list of k8s namespaces to sync the k8s services from.
+  # If a k8s namespace is not included  in this list or is listed in `k8sDenyNamespaces`,
+  # services in that k8s namespace will not be synced even if they are explicitly
+  # annotated. Use `["*"]` to automatically allow all k8s namespaces.
+  #
+  # For example, `["namespace1", "namespace2"]` will only allow services in the k8s
+  # namespaces `namespace1` and `namespace2` to be synced and registered
+  # with Consul. All other k8s namespaces will be ignored.
+  #
+  # To deny all namespaces, set this to `[]`.
+  #
+  # Note: `k8sDenyNamespaces` takes precedence over values defined here.
+  # Requires consul-k8s v0.12+
+  # @type: array<string>
+  k8sAllowNamespaces: ["*"]
+
+  # k8sDenyNamespaces is a list of k8s namespaces that should not have their
+  # services synced. This list takes precedence over `k8sAllowNamespaces`.
+  # `*` is not supported because then nothing would be allowed to sync.
+  # Requires consul-k8s v0.12+.
+  #
+  # For example, if `k8sAllowNamespaces` is `["*"]` and `k8sDenyNamespaces` is
+  # `["namespace1", "namespace2"]`, then all k8s namespaces besides `namespace1`
+  # and `namespace2` will be synced.
+  # @type: array<string>
+  k8sDenyNamespaces: ["kube-system", "kube-public"]
+
+  # [DEPRECATED] Use k8sAllowNamespaces and k8sDenyNamespaces instead. For
+  # backwards compatibility, if both this and the allow/deny lists are set,
+  # the allow/deny lists will be ignored.
+  # k8sSourceNamespace is the Kubernetes namespace to watch for service
+  # changes and sync to Consul. If this is not set then it will default
+  # to all namespaces.
+  # @type: string
+  k8sSourceNamespace: null
+
+  # [Enterprise Only] These settings manage the catalog sync's interaction with
+  # Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+  # Also, `global.enableConsulNamespaces` must be true.
+  consulNamespaces:
+    # consulDestinationNamespace is the name of the Consul namespace to register all
+    # k8s services into. If the Consul namespace does not already exist,
+    # it will be created. This will be ignored if `mirroringK8S` is true.
+    consulDestinationNamespace: "default"
+
+    # mirroringK8S causes k8s services to be registered into a Consul namespace
+    # of the same name as their k8s namespace, optionally prefixed if
+    # `mirroringK8SPrefix` is set below. If the Consul namespace does not
+    # already exist, it will be created. Turning this on overrides the
+    # `consulDestinationNamespace` setting.
+    # `addK8SNamespaceSuffix` may no longer be needed if enabling this option.
+    mirroringK8S: false
+
+    # If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
+    # to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+    # service in the k8s `staging` namespace will be registered into the
+    # `k8s-staging` Consul namespace.
+    mirroringK8SPrefix: ""
+
+  # addK8SNamespaceSuffix appends Kubernetes namespace suffix to
+  # each service name synced to Consul, separated by a dash.
+  # For example, for a service 'foo' in the default namespace,
+  # the sync process will create a Consul service named 'foo-default'.
+  # Set this flag to true to avoid registering services with the same name
+  # but in different namespaces as instances for the same Consul service.
+  # Namespace suffix is not added if 'annotationServiceName' is provided.
+  addK8SNamespaceSuffix: true
+
+  # consulPrefix is the service prefix which prepends itself
+  # to Kubernetes services registered within Consul
+  # For example, "k8s-" will register all services prepended with "k8s-".
+  # (Kubernetes -> Consul sync)
+  # consulPrefix is ignored when 'annotationServiceName' is provided.
+  # NOTE: Updating this property to a non-null value for an existing installation will result in deregistering
+  # of existing services in Consul and registering them with a new name.
+  # @type: string
+  consulPrefix: null
+
+  # k8sTag is an optional tag that is applied to all of the Kubernetes services
+  # that are synced into Consul. If nothing is set, defaults to "k8s".
+  # (Kubernetes -> Consul sync)
+  # @type: string
+  k8sTag: null
+
+  # consulNodeName defines the Consul synthetic node that all services
+  # will be registered to.
+  # NOTE: Changing the node name and upgrading the Helm chart will leave
+  # all of the previously sync'd services registered with Consul and
+  # register them again under the new Consul node name. The out-of-date
+  # registrations will need to be explicitly removed.
+  consulNodeName: "k8s-sync"
+
+  # syncClusterIPServices syncs services of the ClusterIP type, which may
+  # or may not be broadly accessible depending on your Kubernetes cluster.
+  # Set this to false to skip syncing ClusterIP services.
+  syncClusterIPServices: true
+
+  # nodePortSyncType configures the type of syncing that happens for NodePort
+  # services. The valid options are: ExternalOnly, InternalOnly, ExternalFirst.
+  #
+  # - ExternalOnly will only use a node's ExternalIP address for the sync
+  # - InternalOnly use's the node's InternalIP address
+  # - ExternalFirst will preferentially use the node's ExternalIP address, but
+  #   if it doesn't exist, it will use the node's InternalIP address instead.
+  nodePortSyncType: ExternalFirst
+
+  # aclSyncToken refers to a Kubernetes secret that you have created that contains
+  # an ACL token for your Consul cluster which allows the sync process the correct
+  # permissions. This is only needed if ACLs are enabled on the Consul cluster.
+  aclSyncToken:
+    # The name of the Kubernetes secret.
+    secretName: null
+    # The key of the Kubernetes secret.
+    secretKey: null
+
+  # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  # labels for catalog sync pod assignment, formatted as a multi-line string.
+  #
+  # Example:
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  #
+  # @type: string
+  nodeSelector: null
+
+  # Affinity Settings
+  # This should be a multi-line string matching the affinity object
+  # @type: string
+  affinity: null
+
+  # Toleration Settings
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  # @type: string
+  tolerations: null
+
+  # Resource settings for sync catalog pods.
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "50m"
+    limits:
+      memory: "50Mi"
+      cpu: "50m"
+
+  # Log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+  logLevel: info
+
+  # Override the default interval to perform syncing operations creating Consul services.
+  # @type: string
+  consulWriteInterval: null
+
+# ConnectInject will enable the automatic Connect sidecar injector.
+connectInject:
+  # True if you want to enable connect injection. Set to "-" to inherit from
+  # global.enabled.
+  enabled: false
+
+  # image for consul-k8s that contains the injector
+  # @type: string
+  image: null
+
+  # If true, the injector will inject the
+  # Connect sidecar into all pods by default. Otherwise, pods must specify the
+  # injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
+  # to opt-in to Connect injection. If this is true, pods can use the same annotation
+  # to explicitly opt-out of injection.
+  default: false
+
+  # healthChecks enables synchronization of Kubernetes health probe status with Consul.
+  # NOTE: It is highly recommended to enable TLS with this feature because it requires
+  # making calls to Consul clients across the cluster. Without TLS enabled, these calls
+  # could leak ACL tokens should the cluster network become compromised.
+  healthChecks:
+    # Enables the Consul Health Check controller which syncs the readiness status of
+    # connect-injected pods with Consul.
+    enabled: true
+    # If `healthChecks.enabled` is set to `true`, `reconcilePeriod` defines how often a full state
+    # reconcile is done after the initial reconcile at startup is completed.
+    reconcilePeriod: "1m"
+
+  # envoyExtraArgs is used to pass arguments to the injected envoy sidecar.
+  # Valid arguments to pass to envoy can be found here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli
+  # e.g "--log-level debug --disable-hot-restart"
+  # @type: string
+  envoyExtraArgs: null
+
+  # Optional priorityClassName.
+  priorityClassName: ""
+
+  # The Docker image for Consul to use when performing Connect injection.
+  # Defaults to global.image.
+  # @type: string
+  imageConsul: null
+
+  # Log verbosity level. One of "debug", "info", "warn", or "error".
+  logLevel: info
+
+  # Resource settings for connect inject pods.
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "50m"
+    limits:
+      memory: "50Mi"
+      cpu: "50m"
+
+  # namespaceSelector is the selector for restricting the webhook to only
+  # specific namespaces. This should be set to a multiline string.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+  # for more details.
+  #
+  # Example:
+  # ```yaml
+  # namespaceSelector: |
+  #   matchLabels:
+  #     namespace-label: label-value
+  # ```
+  # @type: string
+  namespaceSelector: null
+
+  # k8sAllowNamespaces is a list of k8s namespaces to allow Connect sidecar
+  # injection in. If a k8s namespace is not included or is listed in `k8sDenyNamespaces`,
+  # pods in that k8s namespace will not be injected even if they are explicitly
+  # annotated. Use `["*"]` to automatically allow all k8s namespaces.
+  #
+  # For example, `["namespace1", "namespace2"]` will only allow pods in the k8s
+  # namespaces `namespace1` and `namespace2` to have Connect sidecars injected
+  # and registered with Consul. All other k8s namespaces will be ignored.
+  #
+  # To deny all namespaces, set this to `[]`.
+  #
+  # Note: `k8sDenyNamespaces` takes precedence over values defined here and
+  # `namespaceSelector` takes precedence over both since it is applied first.
+  # `kube-system` and `kube-public` are never injected, even if included here.
+  # Requires consul-k8s v0.12+
+  # @type: array<string>
+  k8sAllowNamespaces: ["*"]
+
+  # k8sDenyNamespaces is a list of k8s namespaces that should not allow Connect
+  # sidecar injection. This list takes precedence over `k8sAllowNamespaces`.
+  # `*` is not supported because then nothing would be allowed to be injected.
+  #
+  # For example, if `k8sAllowNamespaces` is `["*"]` and k8sDenyNamespaces is
+  # `["namespace1", "namespace2"]`, then all k8s namespaces besides "namespace1"
+  # and "namespace2" will be available for injection.
+  #
+  # Note: `namespaceSelector` takes precedence over this since it is applied first.
+  # `kube-system` and `kube-public` are never injected.
+  # Requires consul-k8s v0.12+.
+  # @type: array<string>
+  k8sDenyNamespaces: []
+
+  # [Enterprise Only] These settings manage the connect injector's interaction with
+  # Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+  # Also, `global.enableConsulNamespaces` must be true.
+  consulNamespaces:
+    # consulDestinationNamespace is the name of the Consul namespace to register all
+    # k8s pods into. If the Consul namespace does not already exist,
+    # it will be created. This will be ignored if `mirroringK8S` is true.
+    consulDestinationNamespace: "default"
+
+    # mirroringK8S causes k8s pods to be registered into a Consul namespace
+    # of the same name as their k8s namespace, optionally prefixed if
+    # `mirroringK8SPrefix` is set below. If the Consul namespace does not
+    # already exist, it will be created. Turning this on overrides the
+    # `consulDestinationNamespace` setting.
+    mirroringK8S: false
+
+    # If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
+    # to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+    # pod in the k8s `staging` namespace will be registered into the
+    # `k8s-staging` Consul namespace.
+    mirroringK8SPrefix: ""
+
+  # The certs section configures how the webhook TLS certs are configured.
+  # These are the TLS certs for the Kube apiserver communicating to the
+  # webhook. By default, the injector will generate and manage its own certs,
+  # but this requires the ability for the injector to update its own
+  # MutatingWebhookConfiguration. In a production environment, custom certs
+  # should probably be used. Configure the values below to enable this.
+  certs:
+    # secretName is the name of the secret that has the TLS certificate and
+    # private key to serve the injector webhook. If this is null, then the
+    # injector will default to its automatic management mode that will assign
+    # a service account to the injector to generate its own certificates.
+    secretName: null
+
+    # caBundle is a base64-encoded PEM-encoded certificate bundle for the
+    # CA that signed the TLS certificate that the webhook serves. This must
+    # be set if secretName is non-null.
+    caBundle: ""
+
+    # certName and keyName are the names of the files within the secret for
+    # the TLS cert and private key, respectively. These have reasonable
+    # defaults but can be customized if necessary.
+    certName: tls.crt
+    keyName: tls.key
+
+  # nodeSelector labels for connectInject pod assignment, formatted as a multi-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  #
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  # @type: string
+  nodeSelector: null
+
+  # Affinity Settings
+  # This should be a multi-line string matching the affinity object
+  # @type: string
+  affinity: null
+
+  # Toleration Settings
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  # @type: string
+  tolerations: null
+
+  # aclBindingRuleSelector accepts a query that defines which Service Accounts
+  # can authenticate to Consul and receive an ACL token during Connect injection.
+  # The default setting, i.e. serviceaccount.name!=default, prevents the
+  # 'default' Service Account from logging in.
+  # If set to an empty string all service accounts can log in.
+  # This only has effect if ACLs are enabled.
+  #
+  # See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
+  # and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
+  # for more details.
+  # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
+  aclBindingRuleSelector: "serviceaccount.name!=default"
+
+  # If you are not using global.acls.manageSystemACLs and instead manually setting up an
+  # auth method for Connect inject, set this to the name of your auth method.
+  overrideAuthMethodName: ""
+
+  # aclInjectToken refers to a Kubernetes secret that you have created that contains
+  # an ACL token for your Consul cluster which allows the Connect injector the correct
+  # permissions. This is only needed if Consul namespaces [Enterprise Only] and ACLs
+  # are enabled on the Consul cluster and you are not setting
+  # `global.acls.manageSystemACLs` to `true`.
+  # This token needs to have `operator = "write"` privileges to be able to
+  # create Consul namespaces.
+  aclInjectToken:
+    secretName: null
+    secretKey: null
+
+  # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
+  centralConfig:
+    # enabled controls whether central config is enabled on all servers and clients.
+    # See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+    # If changing this after installation, servers and clients must be restarted
+    # for the change to take effect.
+    enabled: true
+
+    # defaultProtocol allows you to specify a convenience default protocol if
+    # most of your services are of the same protocol type. The individual annotation
+    # on any given pod will override this value.
+    # Valid values are "http", "http2", "grpc" and "tcp".
+    # @type: string
+    defaultProtocol: null
+
+    # proxyDefaults is a raw json string that will be written as the value of
+    # the "config" key of the global proxy-defaults config entry.
+    # See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
+    # NOTE: Changes to this value after the chart is first installed have *no*
+    # effect. In order to change the proxy-defaults config after installation,
+    # you must use the Consul API.
+    proxyDefaults: |
+      {}
+
+  sidecarProxy:
+    # Set default resources for sidecar proxy. If null, that resource won't
+    # be set.
+    # These settings can be overridden on a per-pod basis via these annotations:
+    # - `consul.hashicorp.com/sidecar-proxy-cpu-limit`
+    # - `consul.hashicorp.com/sidecar-proxy-cpu-request`
+    # - `consul.hashicorp.com/sidecar-proxy-memory-limit`
+    # - `consul.hashicorp.com/sidecar-proxy-memory-request`
+    resources:
+      requests:
+        # Recommended default: 100Mi
+        # @type: string
+        memory: null
+        # Recommended default: 100m
+        # @type: string
+        cpu: null
+      limits:
+        # Recommended default: 100Mi
+        # @type: string
+        memory: null
+        # Recommended default: 100m
+        # @type: string
+        cpu: null
+
+  # Resource settings for the Connect injected init container.
+  initContainer:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "50m"
+      limits:
+        memory: "150Mi"
+        cpu: "50m"
+
+# Controller handles config entry custom resources.
+# Requires consul >= 1.8.4.
+# ServiceIntentions require consul 1.9+.
+controller:
+  enabled: false
+  replicas: 1
+
+  # Log verbosity level. One of "debug", "info", "warn", or "error".
+  logLevel: info
+
+  # Resource settings for controller pods.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 50Mi
+    requests:
+      cpu: 100m
+      memory: 50Mi
+
+  # Optional YAML string to specify a nodeSelector config.
+  # @type: string
+  nodeSelector: null
+
+  # Optional YAML string to specify tolerations.
+  # @type: string
+  tolerations: null
+
+  # Affinity Settings
+  # This should be a multi-line string matching the affinity object
+  # @type: string
+  affinity: null
+
+  # Optional priorityClassName.
+  priorityClassName: ""
+
+# Mesh Gateways enable Consul Connect to work across Consul datacenters.
+meshGateway:
+  # If mesh gateways are enabled, a Deployment will be created that runs
+  # gateways and Consul Connect will be configured to use gateways.
+  # See https://www.consul.io/docs/connect/mesh_gateway.html
+  # Requirements: consul 1.6.0+ and consul-k8s 0.15.0+ if using
+  # global.acls.manageSystemACLs.
+  enabled: false
+
+  # Globally configure which mode the gateway should run in.
+  # Can be set to either "remote", "local", "none" or empty string or null.
+  # See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
+  # a description of each mode.
+  # If set to anything other than "" or null, connectInject.centralConfig.enabled
+  # should be set to true so that the global config will actually be used.
+  # If set to the empty string, no global default will be set and the gateway mode
+  # will need to be set individually for each service.
+  globalMode: local
+
+  # Number of replicas for the Deployment.
+  replicas: 2
+
+  # What gets registered as WAN address for the gateway.
+  wanAddress:
+    # source configures where to retrieve the WAN address (and possibly port)
+    # for the mesh gateway from.
+    # Can be set to either: Service, NodeIP, NodeName or Static.
+    #
+    # Service - Determine the address based on the service type.
+    #
+    #   If service.type=LoadBalancer use the external IP or hostname of
+    #   the service. Use the port set by service.port.
+    #
+    #   If service.type=NodePort use the Node IP. The port will be set to
+    #   service.nodePort so service.nodePort cannot be null.
+    #
+    #   If service.type=ClusterIP use the ClusterIP. The port will be set to
+    #   service.port.
+    #
+    #   service.type=ExternalName is not supported.
+    #
+    # NodeIP - The node IP as provided by the Kubernetes downward API.
+    #
+    # NodeName - The name of the node as provided by the Kubernetes downward
+    #   API. This is useful if the node names are DNS entries that
+    #   are routable from other datacenters.
+    #
+    # Static - Use the address hardcoded in meshGateway.wanAddress.static.
+    source: "Service"
+
+    # Port that gets registered for WAN traffic.
+    # If source is set to "Service" then this setting will have no effect.
+    # See the documentation for source as to which port will be used in that
+    # case.
+    port: 443
+
+    # If source is set to "Static" then this value will be used as the WAN
+    # address of the mesh gateways. This is useful if you've configured a
+    # DNS entry to point to your mesh gateways.
+    static: ""
+
+  # The service option configures the Service that fronts the Gateway Deployment.
+  service:
+    # Whether to create a Service or not.
+    enabled: true
+
+    # Type of service, ex. LoadBalancer, ClusterIP.
+    type: LoadBalancer
+
+    # Port that the service will be exposed on.
+    # The targetPort will be set to meshGateway.containerPort.
+    port: 443
+
+    # Optionally hardcode the nodePort of the service if using a NodePort service.
+    # If not set and using a NodePort service, Kubernetes will automatically assign
+    # a port.
+    # @type: integer
+    nodePort: null
+
+    # Annotations to apply to the mesh gateway service.
+    # Example:
+    #
+    # ```yaml
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    # ```
+    # @type: string
+    annotations: null
+
+    # Optional YAML string that will be appended to the Service spec.
+    # @type: string
+    additionalSpec: null
+
+  # If set to true, gateway Pods will run on the host network.
+  hostNetwork: false
+
+  # dnsPolicy to use.
+  # @type: string
+  dnsPolicy: null
+
+  # Consul service name for the mesh gateways.
+  # Cannot be set to anything other than "mesh-gateway" if
+  # global.acls.manageSystemACLs is true since the ACL token
+  # generated is only for the name 'mesh-gateway'.
+  consulServiceName: "mesh-gateway"
+
+  # Port that the gateway will run on inside the container.
+  containerPort: 8443
+
+  # Optional hostPort for the gateway to be exposed on.
+  # This can be used with wanAddress.port and wanAddress.useNodeIP
+  # to expose the gateways directly from the node.
+  # If hostNetwork is true, this must be null or set to the same port as
+  # containerPort.
+  # NOTE: Cannot set to 8500 or 8502 because those are reserved for the Consul
+  # agent.
+  # @type: integer
+  hostPort: null
+
+  # Resource settings for mesh gateway pods.
+  # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
+  # YAML map.
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "100Mi"
+      cpu: "100m"
+
+  # Resource settings for the `copy-consul-bin` init container.
+  initCopyConsulContainer:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "50m"
+      limits:
+        memory: "150Mi"
+        cpu: "50m"
+
+  # By default, we set an anti-affinity so that two gateway pods won't be
+  # on the same node. NOTE: Gateways require that Consul client agents are
+  # also running on the nodes alongside each gateway pod.
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: "{{ .Release.Name }}"
+              component: mesh-gateway
+          topologyKey: kubernetes.io/hostname
+
+  # Optional YAML string to specify tolerations.
+  # @type: string
+  tolerations: null
+
+  # Optional YAML string to specify a nodeSelector config.
+  # @type: string
+  nodeSelector: null
+
+  # Optional priorityClassName.
+  priorityClassName: ""
+
+  # Annotations to apply to the mesh gateway deployment.
+  # Example:
+  #
+  # ```yaml
+  #   annotations: |
+  #     "annotation-key": "annotation-value"
+  # ```
+  # @type: string
+  annotations: null
+
+# Configuration options for ingress gateways. Default values for all
+# ingress gateways are defined in `ingressGateways.defaults`. Any of
+# these values may be overridden in `ingressGateways.gateways` for a
+# specific gateway with the exception of annotations. Annotations will
+# include both the default annotations and any additional ones defined
+# for a specific gateway.
+# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+# global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
+ingressGateways:
+  # Enable ingress gateway deployment. Requires `connectInject.enabled=true`
+  # and `client.enabled=true`.
+  enabled: false
+
+  # Defaults sets default values for all gateway fields. With the exception
+  # of annotations, defining any of these values in the `gateways` list
+  # will override the default values provided here. Annotations will
+  # include both the default annotations and any additional ones defined
+  # for a specific gateway.
+  defaults:
+    # Number of replicas for each ingress gateway defined.
+    replicas: 2
+
+    # The service options configure the Service that fronts the gateway Deployment.
+    service:
+      # Type of service: LoadBalancer, ClusterIP or NodePort. If using NodePort service
+      # type, you must set the desired nodePorts in the `ports` setting below.
+      type: ClusterIP
+
+      # Ports that will be exposed on the service and gateway container. Any
+      # ports defined as ingress listeners on the gateway's Consul configuration
+      # entry should be included here. The first port will be used as part of
+      # the Consul service registration for the gateway and be listed in its
+      # SRV record. If using a NodePort service type, you must specify the
+      # desired nodePort for each exposed port.
+      # @type: array<map>
+      # @default: [{port: 8080, port: 8443}]
+      # @recurse: false
+      ports:
+        - port: 8080
+          nodePort: null
+        - port: 8443
+          nodePort: null
+
+      # Annotations to apply to the ingress gateway service. Annotations defined
+      # here will be applied to all ingress gateway services in addition to any
+      # service annotations defined for a specific gateway in `ingressGateways.gateways`.
+      # Example:
+      # ```yaml
+      #   annotations: |
+      #     "annotation-key": "annotation-value"
+      # ````
+      # @type: string
+      annotations: null
+
+      # Optional YAML string that will be appended to the Service spec.
+      # @type: string
+      additionalSpec: null
+
+    # Resource limits for all ingress gateway pods
+    resources:
+      requests:
+        memory: "100Mi"
+        cpu: "100m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
+
+    # Resource settings for the `copy-consul-bin` init container.
+    initCopyConsulContainer:
+      resources:
+        requests:
+          memory: "25Mi"
+          cpu: "50m"
+        limits:
+          memory: "150Mi"
+          cpu: "50m"
+
+    # By default, we set an anti-affinity so that two of the same gateway pods
+    # won't be on the same node. NOTE: Gateways require that Consul client agents are
+    # also running on the nodes alongside each gateway pod.
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "consul.name" . }}
+                release: "{{ .Release.Name }}"
+                component: ingress-gateway
+            topologyKey: kubernetes.io/hostname
+
+    # Optional YAML string to specify tolerations.
+    # @type: string
+    tolerations: null
+
+    # Optional YAML string to specify a nodeSelector config.
+    # @type: string
+    nodeSelector: null
+
+    # Optional priorityClassName.
+    priorityClassName: ""
+
+    # Annotations to apply to the ingress gateway deployment. Annotations defined
+    # here will be applied to all ingress gateway deployments in addition to any
+    # annotations defined for a specific gateway in `ingressGateways.gateways`.
+    # Example:
+    # ```yaml
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    # ```
+    # @type: string
+    annotations: null
+
+    # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
+    # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+    # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+    # Note: The Consul namespace MUST exist before the gateway is deployed.
+    consulNamespace: "default"
+
+  # Gateways is a list of gateway objects. The only required field for
+  # each is `name`, though they can also contain any of the fields in
+  # `defaults`. Values defined here override the defaults except in the
+  # case of annotations where both will be applied.
+  # @type: array<map>
+  gateways:
+    - name: ingress-gateway
+
+# Configuration options for terminating gateways. Default values for all
+# terminating gateways are defined in `terminatingGateways.defaults`. Any of
+# these values may be overridden in `terminatingGateways.gateways` for a
+# specific gateway with the exception of annotations. Annotations will
+# include both the default annotations and any additional ones defined
+# for a specific gateway.
+# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
+# global.acls.manageSystemACLs and consul-k8s  >= 0.10.0 if not.
+terminatingGateways:
+  # Enable terminating gateway deployment. Requires `connectInject.enabled=true`
+  # and `client.enabled=true`.
+  enabled: false
+
+  # Defaults sets default values for all gateway fields. With the exception
+  # of annotations, defining any of these values in the `gateways` list
+  # will override the default values provided here. Annotations will
+  # include both the default annotations and any additional ones defined
+  # for a specific gateway.
+  defaults:
+    # Number of replicas for each terminating gateway defined.
+    replicas: 2
+
+    # A list of extra volumes to mount. These will be exposed to Consul in the path `/consul/userconfig/<name>/`.
+    #
+    # Example:
+    # ```yaml
+    # extraVolumes:
+    # - type: 'secret'
+    #   name: 'my-secret'
+    #   items: # optional items array
+    #     - key: key
+    #       path: path # secret will now mount to /consul/userconfig/my-secret/path
+    # ```
+    # @type: array<map>
+    extraVolumes: []
+
+    # Resource limits for all terminating gateway pods
+    resources:
+      requests:
+        memory: "100Mi"
+        cpu: "100m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
+
+    # Resource settings for the `copy-consul-bin` init container.
+    initCopyConsulContainer:
+      resources:
+        requests:
+          memory: "25Mi"
+          cpu: "50m"
+        limits:
+          memory: "150Mi"
+          cpu: "50m"
+
+    # By default, we set an anti-affinity so that two of the same gateway pods
+    # won't be on the same node. NOTE: Gateways require that Consul client agents are
+    # also running on the nodes alongside each gateway pod.
+    affinity: |
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "consul.name" . }}
+                release: "{{ .Release.Name }}"
+                component: terminating-gateway
+            topologyKey: kubernetes.io/hostname
+
+    # Optional YAML string to specify tolerations.
+    # @type: string
+    tolerations: null
+
+    # Optional YAML string to specify a nodeSelector config.
+    # @type: string
+    nodeSelector: null
+
+    # Optional priorityClassName.
+    # @type: string
+    priorityClassName: ""
+
+    # Annotations to apply to the terminating gateway deployment. Annotations defined
+    # here will be applied to all terminating gateway deployments in addition to any
+    # annotations defined for a specific gateway in `terminatingGateways.gateways`.
+    # Example:
+    # ```yaml
+    #   annotations: |
+    #     "annotation-key": "annotation-value"
+    # ```
+    # @type: string
+    annotations: null
+
+    # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
+    # the gateway into.  Requires `global.enableConsulNamespaces` to be true and
+    # Consul Enterprise v1.7+ with a valid Consul Enterprise license.
+    # Note: The Consul namespace MUST exist before the gateway is deployed.
+    consulNamespace: "default"
+
+  # Gateways is a list of gateway objects. The only required field for
+  # each is `name`, though they can also contain any of the fields in
+  # `defaults`. Values defined here override the defaults except in the
+  # case of annotations where both will be applied.
+  # @type: array<map>
+  gateways:
+    - name: terminating-gateway
+
+# Control whether a test Pod manifest is generated when running helm template.
+# When using helm install, the test Pod is not submitted to the cluster so this
+# is only useful when running helm template.
+tests:
+  enabled: true

--- a/hack/helm-reference-gen/go.mod
+++ b/hack/helm-reference-gen/go.mod
@@ -1,0 +1,8 @@
+module github.com/hashicorp/consul-helm/hack/helm-reference-gen
+
+go 1.15
+
+require (
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+)

--- a/hack/helm-reference-gen/go.sum
+++ b/hack/helm-reference-gen/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -1,0 +1,389 @@
+package main
+
+// This script generates markdown documentation out of the values.yaml file
+// for use on consul.io.
+//
+// Usage: make gen-docs [consul-repo-path] [-validate]
+//        Where [consul-repo-path] is the location of the hashicorp/consul repo. Defaults to ../../../consul.
+//        If -validate is set, the generated docs won't be output anywhere.
+//        This is useful in CI to ensure the generation will succeed.
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	// typeAnnotation matches the @type annotation. It captures the value of @type.
+	typeAnnotation = regexp.MustCompile(`(?m).*@type: (.*)$`)
+
+	// defaultAnnotation matches the @default annotation. It captures the value of @default.
+	defaultAnnotation = regexp.MustCompile(`(?m).*@default: (.*)$`)
+
+	// recurseAnnotation matches the @recurse annotation. It captures the value of @recurse.
+	recurseAnnotation = regexp.MustCompile(`(?m).*@recurse: (.*)$`)
+
+	// commentPrefix matches on the YAML comment prefix, e.g.
+	// ```
+	// # comment here
+	//   # comment with indent
+	// ```
+	// Will match on "comment here" and "comment with indent".
+	//
+	// It also properly handles YAML comments inside code fences, e.g.
+	// ```
+	// # Example:
+	// # ```yaml
+	// # # yaml comment
+	// # ````
+	// ```
+	// And will not match the "# yaml comment" incorrectly.
+	commentPrefix = regexp.MustCompile(`(?m)^[^\S\n]*#[^\S\n]?`)
+
+	// docNodeTmpl is the go template used to print a DocNode node.
+	// We use $ instead of ` in the template so we can use the golang raw string
+	// format. We then do the replace from $ => `.
+	docNodeTmpl = template.Must(
+		template.New("").Parse(
+			strings.Replace(
+				`{{ .LeadingIndent }}- ${{ .Key }}$ ((#v{{ .HTMLAnchor }})){{ if ne .Kind "map" }} (${{ .Kind }}{{ if .FormattedDefault }}: {{ .FormattedDefault }}{{ end }}$){{ end }}{{ if .FormattedDocumentation}} - {{ .FormattedDocumentation }}{{ end }}`,
+				"$", "`", -1)),
+	)
+)
+
+func main() {
+	validateFlag := flag.Bool("validate", false, "only validate that the markdown can be generated, don't actually generate anything")
+	consulRepoPath := "../../../consul"
+	flag.Parse()
+
+	if len(os.Args) > 3 {
+		fmt.Println("Error: extra arguments")
+		os.Exit(1)
+	}
+
+	if !*validateFlag {
+		// Only argument is path to Consul repo. If not set then we default.
+		if len(os.Args) < 2 {
+			abs, _ := filepath.Abs(consulRepoPath)
+			fmt.Printf("Defaulting to Consul repo path: %s\n", abs)
+		} else {
+			// Support absolute and relative paths to the Consul repo.
+			if filepath.IsAbs(os.Args[1]) {
+				consulRepoPath = os.Args[1]
+			} else {
+				consulRepoPath = filepath.Join("../..", os.Args[1])
+			}
+			abs, _ := filepath.Abs(consulRepoPath)
+			fmt.Printf("Using Consul repo path: %s\n", abs)
+		}
+	}
+
+	// Parse the values.yaml file.
+	inputBytes, err := ioutil.ReadFile("../../values.yaml")
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	out, err := GenerateDocs(string(inputBytes))
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	// If we're just validating that generation will succeed then we're done.
+	if *validateFlag {
+		fmt.Println("Validation successful")
+		os.Exit(0)
+	}
+
+	// Otherwise we'll go on to write the changes to the helm docs.
+	helmReferenceFile := filepath.Join(consulRepoPath, "website/content/docs/k8s/helm.mdx")
+	helmReferenceBytes, err := ioutil.ReadFile(helmReferenceFile)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	helmReferenceContents := string(helmReferenceBytes)
+
+	// Swap out the contents between the codegen markers.
+	startStr := "<!-- codegen: start -->\n"
+	endStr := "\n  <!-- codegen: end -->"
+	start := strings.Index(helmReferenceContents, startStr)
+	if start == -1 {
+		fmt.Printf("%q not found in %q\n", startStr, helmReferenceFile)
+		os.Exit(1)
+	}
+	end := strings.Index(helmReferenceContents, endStr)
+	if end == -1 {
+		fmt.Printf("%q not found in %q\n", endStr, helmReferenceFile)
+		os.Exit(1)
+	}
+
+	newMdx := helmReferenceContents[0:start+len(startStr)] + out + helmReferenceContents[end:]
+	err = ioutil.WriteFile(helmReferenceFile, []byte(newMdx), 0644)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	abs, _ := filepath.Abs(helmReferenceFile)
+	fmt.Printf("Updated with generated docs: %s\n", abs)
+}
+
+func GenerateDocs(yamlStr string) (string, error) {
+	node, err := Parse(yamlStr)
+	if err != nil {
+		return "", err
+	}
+
+	children, err := generateDocsFromNode(docNodeTmpl, node)
+	return strings.ReplaceAll(strings.Join(children, "\n\n"), "[Enterprise Only]", "<EnterpriseAlert inline />"), err
+}
+
+// Parse parses yamlStr into a tree of DocNode's.
+func Parse(yamlStr string) (DocNode, error) {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlStr), &node)
+	if err != nil {
+		return DocNode{}, err
+	}
+
+	// Due to how the YAML is parsed this is the first real node.
+	rootNode := node.Content[0].Content
+	children, err := parseNodeContent(rootNode, "", false)
+	if err != nil {
+		return DocNode{}, err
+	}
+	return DocNode{
+		Column:   0,
+		Children: children,
+	}, nil
+}
+
+// parseNodeContent recursively parses the yaml nodes and outputs a DocNode
+// tree.
+func parseNodeContent(nodeContent []*yaml.Node, parentBreadcrumb string, parentWasMap bool) ([]DocNode, error) {
+	var docNodes []DocNode
+
+	// This is a special type of node where it's an array of maps.
+	// e.g.
+	// ````
+	// ingressGateways:
+	// - name: name
+	// ````
+	//
+	// In this case we show the docs as:
+	// - ingress-gateway: ingress gateway descrip
+	//   - name: name descrip.
+	//
+	// To do that, we actually need to skip the map node.
+	if len(nodeContent) == 1 {
+		return parseNodeContent(nodeContent[0].Content, parentBreadcrumb, true)
+	}
+
+	// skipNext is true if we should skip the next node. Due to how the YAML is
+	// parsed, a key: value pair results in two YAML nodes but we only need
+	// doc node out of that so in the loop we look ahead to the next node
+	// and use it to construct our DocNode. Then we can skip it on the next
+	// iteration.
+	skipNext := false
+	for i, child := range nodeContent {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+
+		docNode, err := buildDocNode(i, child, nodeContent, parentBreadcrumb, parentWasMap)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := docNode.Validate(); err != nil {
+			return nil, &ParseError{
+				FullAnchor: docNode.HTMLAnchor(),
+				Err:        err.Error(),
+			}
+		}
+
+		docNodes = append(docNodes, docNode)
+		skipNext = true
+		continue
+	}
+	return docNodes, nil
+}
+
+func generateDocsFromNode(tm *template.Template, node DocNode) ([]string, error) {
+	var out []string
+	for _, child := range node.Children {
+		var nodeOut bytes.Buffer
+		err := tm.Execute(&nodeOut, child)
+		if err != nil {
+			return nil, err
+		}
+		childOut, err := generateDocsFromNode(tm, child)
+		if err != nil {
+			return nil, err
+		}
+		out = append(append(out, nodeOut.String()), childOut...)
+	}
+	return out, nil
+}
+
+// allScalars returns true if content contains only scalar nodes
+// with no chidren.
+func allScalars(content []*yaml.Node) bool {
+	for _, n := range content {
+		if n.Kind != yaml.ScalarNode || len(n.Content) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// toInlineYaml will return the yaml string representation for content
+// using the inline representation, i.e. `["a", "b"]`
+// instead of:
+// ```
+// - "a"
+// - "b"
+// ```
+func toInlineYaml(content []*yaml.Node) (string, error) {
+	// We have to use this struct so we can set the struct tag "flow" so the
+	// generated yaml uses the inline format.
+	type intermediary struct {
+		Arr []*yaml.Node `yaml:"arr,flow"`
+	}
+	i := intermediary{
+		Arr: content,
+	}
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	// Hack: because we had to use our struct, it has the key "arr: " which
+	// we need to trim. Before trimming it will look like:
+	// `arr: ["a","b"]`.
+	return strings.TrimPrefix(string(out), "arr: "), nil
+}
+
+func buildDocNode(nodeContentIdx int, currNode *yaml.Node, nodeContent []*yaml.Node, parentBreadcrumb string, parentWasMap bool) (DocNode, error) {
+	// Check for the @recurse: false annotation.
+	// In this case we construct our node and then don't recurse further.
+	if match := recurseAnnotation.FindStringSubmatch(currNode.HeadComment); len(match) > 0 && match[1] == "false" {
+		return DocNode{
+			Column:           currNode.Column,
+			ParentBreadcrumb: parentBreadcrumb,
+			ParentWasMap:     false,
+			Key:              currNode.Value,
+			Comment:          currNode.HeadComment,
+		}, nil
+	}
+
+	// Nodes should come in pairs.
+	if len(nodeContent) < nodeContentIdx+1 {
+		return DocNode{}, &ParseError{
+			ParentAnchor: parentBreadcrumb,
+			CurrAnchor:   currNode.Value,
+			Err:          fmt.Sprintf("content length incorrect, expected %d got %d", nodeContentIdx+1, len(nodeContent)),
+		}
+	}
+
+	next := nodeContent[nodeContentIdx+1]
+
+	switch next.Kind {
+
+	// If it's a scalar then this is a simple key: value node.
+	case yaml.ScalarNode:
+		return DocNode{
+			ParentBreadcrumb: parentBreadcrumb,
+			ParentWasMap:     parentWasMap,
+			Column:           currNode.Column,
+			Key:              currNode.Value,
+			Comment:          currNode.HeadComment,
+			KindTag:          next.Tag,
+			Default:          next.Value,
+		}, nil
+
+	// If it's a map then we will need to recurse into it.
+	case yaml.MappingNode:
+		docNode := DocNode{
+			ParentBreadcrumb: parentBreadcrumb,
+			ParentWasMap:     parentWasMap,
+			Column:           currNode.Column,
+			Key:              currNode.Value,
+			Comment:          currNode.HeadComment,
+			KindTag:          next.Tag,
+		}
+		var err error
+		docNode.Children, err = parseNodeContent(next.Content, docNode.HTMLAnchor(), false)
+		if err != nil {
+			return DocNode{}, err
+		}
+		return docNode, nil
+
+	// If it's a sequence, i.e. array, then we have to handle it differently
+	// depending on its contents.
+	case yaml.SequenceNode:
+		// If it's empty then its just a key with a default of empty array.
+		if len(next.Content) == 0 {
+			return DocNode{
+				ParentBreadcrumb: parentBreadcrumb,
+				ParentWasMap:     parentWasMap,
+				Column:           currNode.Column,
+				Key:              currNode.Value,
+				// Default is empty array.
+				Default: "[]",
+				Comment: currNode.HeadComment,
+				KindTag: next.Tag,
+			}, nil
+
+			// If it's full of scalars, e.g. key: [a, b] then we can stop recursing
+			// and use the value as the default.
+		} else if allScalars(next.Content) {
+			inlineYaml, err := toInlineYaml(next.Content)
+			if err != nil {
+				return DocNode{}, &ParseError{
+					ParentAnchor: parentBreadcrumb,
+					CurrAnchor:   currNode.Value,
+					Err:          err.Error(),
+				}
+			}
+			return DocNode{
+				ParentBreadcrumb: parentBreadcrumb,
+				ParentWasMap:     parentWasMap,
+				Column:           currNode.Column,
+				Key:              currNode.Value,
+				// Default will be the yaml value.
+				Default: inlineYaml,
+				Comment: currNode.HeadComment,
+				KindTag: next.Tag,
+			}, nil
+		} else {
+
+			// Otherwise we need to recurse into each element of the array.
+			docNode := DocNode{
+				ParentBreadcrumb: parentBreadcrumb,
+				ParentWasMap:     parentWasMap,
+				Column:           currNode.Column,
+				Key:              currNode.Value,
+				Comment:          currNode.HeadComment,
+				KindTag:          next.Tag,
+			}
+			var err error
+			docNode.Children, err = parseNodeContent(next.Content, docNode.HTMLAnchor(), false)
+			if err != nil {
+				return DocNode{}, err
+			}
+			return docNode, nil
+		}
+	}
+	return DocNode{}, fmt.Errorf("fell through cases unexpectedly at breadcrumb: %s", parentBreadcrumb)
+}

--- a/hack/helm-reference-gen/main_test.go
+++ b/hack/helm-reference-gen/main_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test various smaller cases and special cases.
+func Test(t *testing.T) {
+	cases := map[string]struct {
+		Input string
+		Exp   string
+	}{
+		"string value": {
+			Input: `---
+# Line 1
+# Line 2
+key: value`,
+			Exp: `- $key$ ((#v-key)) ($string: value$) - Line 1\n  Line 2`,
+		},
+		"integer value": {
+			Input: `---
+# Line 1
+# Line 2
+replicas: 3`,
+			Exp: `- $replicas$ ((#v-replicas)) ($integer: 3$) - Line 1\n  Line 2`,
+		},
+		"boolean value": {
+			Input: `---
+# Line 1
+# Line 2
+enabled: true`,
+			Exp: `- $enabled$ ((#v-enabled)) ($boolean: true$) - Line 1\n  Line 2`,
+		},
+		"map": {
+			Input: `---
+# Map line 1
+# Map line 2
+map:
+  # Key line 1
+  # Key line 2
+  key: value`,
+			Exp: `- $map$ ((#v-map)) - Map line 1\n  Map line 2
+
+  - $key$ ((#v-map-key)) ($string: value$) - Key line 1\n    Key line 2`,
+		},
+		"map with multiple keys": {
+			Input: `---
+# Map line 1
+# Map line 2
+map:
+  # Key line 1
+  # Key line 2
+  key: value
+  # Int docs
+  int: 1
+  # Bool docs
+  bool: true`,
+			Exp: `- $map$ ((#v-map)) - Map line 1\n  Map line 2
+
+  - $key$ ((#v-map-key)) ($string: value$) - Key line 1
+    Key line 2
+
+  - $int$ ((#v-map-int)) ($integer: 1$) - Int docs
+
+  - $bool$ ((#v-map-bool)) ($boolean: true$) - Bool docs`,
+		},
+		"null value": {
+			Input: `---
+# key docs
+# @type: string
+key: null`,
+			Exp: `- $key$ ((#v-key)) ($string: null$) - key docs`,
+		},
+		"description with empty line": {
+			Input: `---
+# line 1
+#
+# line 2
+key: value`,
+			Exp: `- $key$ ((#v-key)) ($string: value$) - line 1\n\n  line 2`,
+		},
+		"array of strings": {
+			Input: `---
+# line 1
+# @type: array<string>
+serverAdditionalDNSSANs: []
+`,
+			Exp: `- $serverAdditionalDNSSANs$ ((#v-serveradditionaldnssans)) ($array<string>: []$) - line 1`,
+		},
+		"map with empty string values": {
+			Input: `---
+# gossipEncryption
+gossipEncryption:
+  # secretName
+  secretName: ""
+  # secretKey
+  secretKey: ""
+`,
+			Exp: `- $gossipEncryption$ ((#v-gossipencryption)) - gossipEncryption
+
+  - $secretName$ ((#v-gossipencryption-secretname)) ($string: ""$) - secretName
+
+  - $secretKey$ ((#v-gossipencryption-secretkey)) ($string: ""$) - secretKey`,
+		},
+		"map with null string values": {
+			Input: `---
+bootstrapToken:
+  # @type: string
+  secretName: null
+  # @type: string
+  secretKey: null
+`,
+			Exp: `- $bootstrapToken$ ((#v-bootstraptoken))
+
+  - $secretName$ ((#v-bootstraptoken-secretname)) ($string: null$)
+
+  - $secretKey$ ((#v-bootstraptoken-secretkey)) ($string: null$)`,
+		},
+		"resource settings": {
+			Input: `---
+# lifecycle
+lifecycleSidecarContainer:
+  # The resource requests and limits (CPU, memory, etc.)
+  # for each of the lifecycle sidecar containers. This should be a YAML map of a Kubernetes
+  # [ResourceRequirements](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) object.
+  #
+  # Example:
+  # $$$yaml
+  # resources:
+  #   requests:
+  #     memory: "25Mi"
+  #     cpu: "20m"
+  #   limits:
+  #     memory: "50Mi"
+  #     cpu: "20m"
+  # $$$
+  resources:
+    requests:
+      memory: "25Mi"
+      cpu: "20m"
+    limits:
+      memory: "50Mi"
+      cpu: "20m"
+`,
+			Exp: `- $lifecycleSidecarContainer$ ((#v-lifecyclesidecarcontainer)) - lifecycle
+
+  - $resources$ ((#v-lifecyclesidecarcontainer-resources)) - The resource requests and limits (CPU, memory, etc.)
+    for each of the lifecycle sidecar containers. This should be a YAML map of a Kubernetes
+    [ResourceRequirements](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) object.
+
+    Example:
+    $$$yaml
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "20m"
+      limits:
+        memory: "50Mi"
+        cpu: "20m"
+    $$$
+
+    - $requests$ ((#v-lifecyclesidecarcontainer-resources-requests))
+
+      - $memory$ ((#v-lifecyclesidecarcontainer-resources-requests-memory)) ($string: 25Mi$)
+
+      - $cpu$ ((#v-lifecyclesidecarcontainer-resources-requests-cpu)) ($string: 20m$)
+
+    - $limits$ ((#v-lifecyclesidecarcontainer-resources-limits))
+
+      - $memory$ ((#v-lifecyclesidecarcontainer-resources-limits-memory)) ($string: 50Mi$)
+
+      - $cpu$ ((#v-lifecyclesidecarcontainer-resources-limits-cpu)) ($string: 20m$)`,
+		},
+		"default as dash": {
+			Input: `---
+server:
+  # If true, the chart will install all the resources necessary for a
+  # Consul server cluster. If you're running Consul externally and want agents
+  # within Kubernetes to join that cluster, this should probably be false.
+  # @default: global.enabled
+  # @type: boolean
+  enabled: "-"
+`,
+			Exp: `- $server$ ((#v-server))
+
+  - $enabled$ ((#v-server-enabled)) ($boolean: global.enabled$) - If true, the chart will install all the resources necessary for a
+    Consul server cluster. If you're running Consul externally and want agents
+    within Kubernetes to join that cluster, this should probably be false.`,
+		},
+		"extraConfig {}": {
+			Input: `---
+extraConfig: |
+  {}
+`,
+			Exp: `- $extraConfig$ ((#v-extraconfig)) ($string: {}$)`,
+		},
+		"affinity": {
+			Input: `---
+# Affinity Settings
+affinity: |
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: {{ template "consul.name" . }}
+            release: "{{ .Release.Name }}"
+            component: server
+        topologyKey: kubernetes.io/hostname
+`,
+			Exp: `- $affinity$ ((#v-affinity)) ($string$) - Affinity Settings`,
+		},
+		"k8sAllowNamespaces": {
+			Input: `---
+# @type: array<string>
+k8sAllowNamespaces: ["*"]`,
+			Exp: `- $k8sAllowNamespaces$ ((#v-k8sallownamespaces)) ($array<string>: ["*"]$)`,
+		},
+		"k8sDenyNamespaces": {
+			Input: `---
+# @type: array<string>
+k8sDenyNamespaces: ["kube-system", "kube-public"]`,
+			Exp: `- $k8sDenyNamespaces$ ((#v-k8sdenynamespaces)) ($array<string>: ["kube-system", "kube-public"]$)`,
+		},
+		"gateways": {
+			Input: `---
+# @type: array<map>
+gateways:
+  - name: ingress-gateway`,
+			Exp: `- $gateways$ ((#v-gateways)) ($array<map>$)
+
+  - $name$ ((#v-gateways-name)) ($string: ingress-gateway$)`,
+		},
+		"enterprise alert": {
+			Input: `---
+# [Enterprise Only] line 1
+# line 2
+key: value
+`,
+			Exp: `- $key$ ((#v-key)) ($string: value$) - <EnterpriseAlert inline /> line 1\n  line 2`,
+		},
+		"yaml comments in examples": {
+			Input: `---
+# Examples:
+#
+# $$$yaml
+# # Consul 1.5.0
+# image: "consul:1.5.0"
+# # Consul Enterprise 1.5.0
+# image: "hashicorp/consul-enterprise:1.5.0-ent"
+# $$$
+key: value
+`,
+			Exp: `- $key$ ((#v-key)) ($string: value$) - Examples:
+
+  $$$yaml
+  # Consul 1.5.0
+  image: "consul:1.5.0"
+  # Consul Enterprise 1.5.0
+  image: "hashicorp/consul-enterprise:1.5.0-ent"
+  $$$`,
+		},
+		"type override uses last match": {
+			Input: `---
+# @type: override-1
+# @type: override-2
+key: value
+`,
+			Exp: `- $key$ ((#v-key)) ($override-2: value$)`,
+		},
+		"recurse false": {
+			Input: `---
+key: value
+# port docs
+# @type: array<map>
+# @recurse: false
+ports:
+- port: 8080
+  nodePort: null
+- port: 8443
+  nodePort: null
+`,
+			Exp: `- $key$ ((#v-key)) ($string: value$)
+
+- $ports$ ((#v-ports)) ($array<map>$) - port docs`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Swap $ for `.
+			input := strings.Replace(c.Input, "$", "`", -1)
+
+			out, err := GenerateDocs(input)
+			require.NoError(t, err)
+
+			// Swap $ for `.
+			exp := strings.Replace(c.Exp, "$", "`", -1)
+
+			// Swap \n for real \n.
+			exp = strings.Replace(exp, "\\n", "\n", -1)
+
+			require.Equal(t, exp, out)
+		})
+	}
+}
+
+// Test against a full values file and compare against a golden file.
+func TestFullValues(t *testing.T) {
+	inputBytes, err := ioutil.ReadFile(filepath.Join("fixtures", "full-values.yaml"))
+	require.NoError(t, err)
+	expBytes, err := ioutil.ReadFile(filepath.Join("fixtures", "full-values.golden"))
+	require.NoError(t, err)
+
+	actual, err := GenerateDocs(string(inputBytes))
+	require.NoError(t, err)
+	if actual != string(expBytes) {
+		require.NoError(t, ioutil.WriteFile(filepath.Join("fixtures", "full-values.actual"), []byte(actual), 0644))
+		require.FailNow(t, "output not equal, actual output to full-values.actual")
+	}
+}

--- a/hack/helm-reference-gen/parse_error.go
+++ b/hack/helm-reference-gen/parse_error.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+// ParseError is an error that occurs during parsing.
+// It's used to include information about which node failed to parse.
+type ParseError struct {
+	ParentAnchor string
+	CurrAnchor   string
+	FullAnchor   string
+	Err          string
+}
+
+func (p *ParseError) Error() string {
+	anchor := p.FullAnchor
+	if anchor == "" {
+		anchor = fmt.Sprintf("%s-%s", p.ParentAnchor, p.CurrAnchor)
+	}
+	return fmt.Sprintf("%s: %s", anchor, p.Err)
+}


### PR DESCRIPTION
Add script to `hack/helm-reference-gen` to generate our helm configuration docs (https://www.consul.io/docs/k8s/helm) automatically.

The workflow would be:
1. Make change to `values.yaml`
1. Run `make gen-docs` that generates the docs into your hashicorp/consul repo you've checked out
1. Commit the changes to helm and consul

This PR:
* Add CI/CD steps to run the script tests and validate that any changes to our values.yaml don't break the code generation
* Add make target for running the generation `make gen-docs <path-to-consul-repo>`
* Changes our `values.yaml` to match the docs on our website and ensures the generation succeeds
* Adds a section to contributing describing how to use the generator

Companion to https://github.com/hashicorp/consul/pull/9324 which is the newly generated docs.