### PR TITLE
feat: Customizable command-line option "node-meta" to the agent

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -198,8 +198,9 @@ spec:
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
-                -node-meta=pod-name:${HOSTNAME} \
-                -node-meta=host-ip:${HOST_IP} \
+                {{- range $k, $v := .Values.client.nodeMeta }}
+                -node-meta={{ $k }}:{{ $v }} \
+                {{- end }}
                 -hcl='leave_on_terminate = true' \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -163,6 +163,47 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# nodeMeta
+
+@test "client/DaemonSet: meta-data pod-name:\${HOSTNAME} by default at nodeMeta" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-node-meta=pod-name:${HOSTNAME}"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: meta-data host-ip: \${HOST_IP} by default at nodeMeta" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-node-meta=host-ip:${HOST_IP}"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: pod-name can be configured at nodeMeta" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.nodeMeta.pod-name=foobar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-node-meta=pod-name:foobar"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: additional meta-data at nodeMeta" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.nodeMeta.cluster-name=cluster01' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-node-meta=cluster-name:cluster01"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # resources
 
 @test "client/DaemonSet: resources defined by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -695,6 +695,12 @@ client:
   # required for Connect.
   grpc: true
 
+  # nodeMeta specifies an arbitrary metadata key/value pair to associate with the node 
+  # (see https://www.consul.io/docs/agent/options.html#_node_meta)
+  nodeMeta:
+    pod-name: ${HOSTNAME}
+    host-ip: ${HOST_IP}
+
   # If true, the Helm chart will expose the clients' gossip ports as hostPorts.
   # This is only necessary if pod IPs in the k8s cluster are not directly routable
   # and the Consul servers are outside of the k8s cluster.


### PR DESCRIPTION
Allow receive map to customize the Metadata section of the Node (consul agent).