### PR TITLE
Add more time to verifyFederation and checking static server connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,16 +499,16 @@ workflows:
   test:
     jobs:
       - go-fmt-and-vet
-      - unit-acceptance-framework:
-          requires:
-            - go-fmt-and-vet
-      - unit-helm2
-      - unit-helm3
-      - acceptance:
-          requires:
-            - unit-helm2
-            - unit-helm3
-            - unit-acceptance-framework
+      # - unit-acceptance-framework:
+      #     requires:
+      #       - go-fmt-and-vet
+      # - unit-helm2
+      # - unit-helm3
+      - acceptance-eks-1-17
+          # requires:
+            # - unit-helm2
+            # - unit-helm3
+            # - unit-acceptance-framework
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,12 +378,14 @@ jobs:
             exit_code=0
             for pkg in $(go list ./...)
             do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
+              if ! gotestsum --format standard-verbose --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
                     -enable-enterprise \
                     -enable-multi-cluster \
                     -kubeconfig="$primary_kubeconfig" \
                     -secondary-kubeconfig="$secondary_kubeconfig" \
                     -debug-directory="$TEST_RESULTS/debug" \
+                    -v \
+                    -run TestMeshGateway \
                     -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
               then
                 echo "Tests in ${pkg} failed, aborting early"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,14 +378,12 @@ jobs:
             exit_code=0
             for pkg in $(go list ./...)
             do
-              if ! gotestsum --format standard-verbose --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
+              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
                     -enable-enterprise \
                     -enable-multi-cluster \
                     -kubeconfig="$primary_kubeconfig" \
                     -secondary-kubeconfig="$secondary_kubeconfig" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -v \
-                    -run TestMeshGateway \
                     -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
               then
                 echo "Tests in ${pkg} failed, aborting early"
@@ -501,16 +499,16 @@ workflows:
   test:
     jobs:
       - go-fmt-and-vet
-      # - unit-acceptance-framework:
-      #     requires:
-      #       - go-fmt-and-vet
-      # - unit-helm2
-      # - unit-helm3
-      - acceptance-eks-1-17
-          # requires:
-            # - unit-helm2
-            # - unit-helm3
-            # - unit-acceptance-framework
+      - unit-acceptance-framework:
+          requires:
+            - go-fmt-and-vet
+      - unit-helm2
+      - unit-helm3
+      - acceptance:
+          requires:
+            - unit-helm2
+            - unit-helm3
+            - unit-acceptance-framework
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,3 +378,4 @@ Here are some things to consider before adding a test:
   either Consul itself or consul-k8s? In that case, it should be tested there rather than in the Helm chart.
   For example, we don't expect acceptance tests to include all the permutations of the consul-k8s commands
   and their respective flags. Something like that should be tested in the consul-k8s repository.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,4 +378,3 @@ Here are some things to consider before adding a test:
   either Consul itself or consul-k8s? In that case, it should be tested there rather than in the Helm chart.
   For example, we don't expect acceptance tests to include all the permutations of the consul-k8s commands
   and their respective flags. Something like that should be tested in the consul-k8s repository.
- 

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -134,8 +134,7 @@ func CheckStaticServerConnectionMultipleFailureMessages(
 func CheckStaticServerConnectionSuccessful(t *testing.T, options *k8s.KubectlOptions, deploymentName string, curlArgs ...string) {
 	start := time.Now()
 	CheckStaticServerConnection(t, options, true, deploymentName, "", curlArgs...)
-	timeToVerify := time.Since(start)
-	logger.Logf(t, "Took %+v to check if static server connection was successful", timeToVerify)
+	logger.Logf(t, "Took %s to check if static server connection was successful", time.Since(start))
 }
 
 // CheckStaticServerConnectionSuccessful is just like CheckStaticServerConnection

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
@@ -131,7 +132,10 @@ func CheckStaticServerConnectionMultipleFailureMessages(
 // CheckStaticServerConnectionSuccessful is just like CheckStaticServerConnection
 // but it always expects a successful connection.
 func CheckStaticServerConnectionSuccessful(t *testing.T, options *k8s.KubectlOptions, deploymentName string, curlArgs ...string) {
+	start := time.Now()
 	CheckStaticServerConnection(t, options, true, deploymentName, "", curlArgs...)
+	timeToVerify := time.Since(start)
+	logger.Logf(t, "Took %+v to check if static server connection was successful", timeToVerify)
 }
 
 // CheckStaticServerConnectionSuccessful is just like CheckStaticServerConnection

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -256,7 +256,8 @@ func TestMeshGatewaySecure(t *testing.T) {
 // by first checking members are alive from the perspective of both servers.
 // If secure is true, it will also check that the ACL replication is running on the secondary server.
 func verifyFederation(t *testing.T, primaryClient, secondaryClient *api.Client, releaseName string, secure bool) {
-	retrier := &retry.Timer{Timeout: 2 * time.Minute, Wait: 1 * time.Second}
+	retrier := &retry.Timer{Timeout: 5 * time.Minute, Wait: 1 * time.Second}
+	start := time.Now()
 
 	// Check that server in dc1 is healthy from the perspective of the server in dc2, and vice versa.
 	// We're calling the Consul health API, as opposed to checking serf membership status,
@@ -282,4 +283,7 @@ func verifyFederation(t *testing.T, primaryClient, secondaryClient *api.Client, 
 			require.True(r, replicationStatus.Running)
 		}
 	})
+
+	timeToVerify := time.Since(start)
+	logger.Logf(t, "Took %+v to verify federation", timeToVerify)
 }

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -284,6 +284,5 @@ func verifyFederation(t *testing.T, primaryClient, secondaryClient *api.Client, 
 		}
 	})
 
-	timeToVerify := time.Since(start)
-	logger.Logf(t, "Took %+v to verify federation", timeToVerify)
+	logger.Logf(t, "Took %s to verify federation", time.Since(start))
 }


### PR DESCRIPTION
Adds more time to verifyFederation and checking the static server connection to see if it addresses flakes on EKS. Logs the amount of time it took to do those things. 