### PR TITLE
Delete unused ports on client-daemonset

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -275,10 +275,6 @@ spec:
               {{- end }}
               protocol: "UDP"
               name: serflan-udp
-            - containerPort: 8302
-              name: serfwan
-            - containerPort: 8300
-              name: server
             - containerPort: 8600
               name: dns-tcp
               protocol: "TCP"


### PR DESCRIPTION
The client does not need to expose a server-RPC port or a serfwan port
since it doesn't participate in wan gossip or serve server RPCs.