### PR TITLE
Expose server gossip and RPC ports as hostPorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ BREAKING CHANGES:
 FEATURES:
 * CRDs: add new CRD `IngressGateway` for configuring Consul's [ingress-gateway](https://www.consul.io/docs/agent/config-entries/ingress-gateway) config entry. [[GH-714](https://github.com/hashicorp/consul-helm/pull/714)]
 * CRDs: add new CRD `TerminatingGateway` for configuring Consul's [terminating-gateway](https://www.consul.io/docs/agent/config-entries/terminating-gateway) config entry. [[GH-715](https://github.com/hashicorp/consul-helm/pull/715)]
+* Enable client agents outside of the K8s cluster to join a consul datacenter
+  without the Pod IPs of the consul servers and clients in K8s needing to be
+  routeable. Adds new helm values `server.exposeGossipAndRPCPorts` and
+  `server.ports.serflan.port`. To enable external client agents, enable
+  `server.exposeGossipAndRPCPorts` and `client.exposeGossipAndPorts`, and set
+  `server.ports.serflan.port` to a port not being used on the host, e.g 9301.
+  The internal IP of the K8s nodes do need to be routeable from the external
+  client agent and the external client agent's IP also needs to be routeable
+  from the K8s nodes.
+  [[GH-740](https://github.com/hashicorp/consul-helm/pull/740)]
 
 IMPROVEMENTS:
 * Make `server.bootstrapExpect` optional. If not set, will now default to `server.replicas`.

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -121,12 +121,12 @@ spec:
             - name: ADVERTISE_IP
               valueFrom:
                 fieldRef:
-                  {{- if not .Values.client.exposeGossipPorts }}
-                  fieldPath: status.podIP
-                  {{- else }}
-                  # Clients will be exposed on their node's hostPort for external-to-k8s communication,
-                  # so they need to advertise their host ip instead of their pod ip.
+                  {{- if .Values.client.exposeGossipPorts }}
+                  {{- /* Clients will be exposed on their node's hostPort for external-to-k8s communication,
+                  so they need to advertise their host ip instead of their pod ip. */}}
                   fieldPath: status.hostIP
+                  {{- else }}
+                  fieldPath: status.podIP
                   {{- end }}
             - name: NAMESPACE
               valueFrom:
@@ -219,8 +219,9 @@ spec:
                 {{- end }}
                 {{- else }}
                 {{- if .Values.server.enabled }}
+                {{- $serverSerfLANPort  := .Values.server.ports.serflan.port -}}
                 {{- range $index := until (.Values.server.replicas | int) }}
-                -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
+                -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:{{ $serverSerfLANPort }}" \
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -106,6 +106,18 @@ spec:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image }}"
           env:
+            - name: ADVERTISE_IP
+              valueFrom:
+                fieldRef:
+                  {{- if .Values.server.exposeGossipAndRPCPorts }}
+                  {{- /* Server gossip and RPC ports will be exposed as a hostPort
+                  on the hostIP, so they need to advertise their host ip
+                  instead of their pod ip. This is to support external client
+                  agents. */}}
+                  fieldPath: status.hostIP
+                  {{- else }}
+                  fieldPath: status.podIP
+                  {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -142,7 +154,7 @@ spec:
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
               exec /bin/consul agent \
-                -advertise="${POD_IP}" \
+                -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }} \
                 {{- if .Values.global.tls.enabled }}
@@ -190,9 +202,11 @@ spec:
                 {{- if .Values.ui.enabled }}
                 -ui \
                 {{- end }}
+                {{- $serverSerfLANPort  := .Values.server.ports.serflan.port -}}
                 {{- range $index := until (.Values.server.replicas | int) }}
-                -retry-join=${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc \
+                -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:{{ $serverSerfLANPort }}" \
                 {{- end }}
+                -serf-lan-port={{ .Values.server.ports.serflan.port }} \
                 -server
           volumeMounts:
             - name: data-{{ .Release.Namespace }}
@@ -228,11 +242,24 @@ spec:
             - containerPort: 8501
               name: https
             {{- end }}
-            - containerPort: 8301
-              name: serflan
+            - containerPort: {{ .Values.server.ports.serflan.port }}
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: {{ .Values.server.ports.serflan.port }}
+              {{- end }}
+              protocol: "TCP"
+              name: serflan-tcp
+            - containerPort: {{ .Values.server.ports.serflan.port }}
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: {{ .Values.server.ports.serflan.port }}
+              {{- end }}
+              protocol: "UDP"
+              name: serflan-udp
             - containerPort: 8302
               name: serfwan
             - containerPort: 8300
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: 8300
+              {{- end }}
               name: server
             - containerPort: 8600
               name: dns-tcp

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -79,13 +79,32 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
-  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8301\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8301\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8301\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: retry join uses the server.ports.serflan port" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'server.replicas=3' \
+      --set 'server.ports.serflan.port=9301' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:9301\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:9301\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-retry-join=\"${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:9301\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/values.yaml
+++ b/values.yaml
@@ -295,6 +295,28 @@ server:
     # The key within the Kubernetes secret that holds the enterprise license.
     secretKey: null
 
+  # Exposes the servers' gossip and RPC ports as hostPorts. To enable a client
+  # agent outside of the k8s cluster to join the datacenter, you would need to
+  # enable `server.exposeGossipAndRPCPorts`, `client.exposeGossipPorts`, and
+  # set `server.ports.serflan.port` to a port not being used on the host. Since
+  # `client.exposeGossipPorts` uses the hostPort 8301,
+  # `server.ports.serflan.port` must be set to something other than 8301.
+  exposeGossipAndRPCPorts: false
+
+  # Configures ports for the consul servers.
+  ports:
+    # Configures the LAN gossip port for the consul servers. If you choose to
+    # enable `server.exposeGossipAndRPCPorts` and `client.exposeGossipPorts`,
+    # that will configure the LAN gossip ports on the servers and clients to be
+    # hostPorts, so if you are running clients and servers on the same node the
+    # ports will conflict if they are both 8301.  When you enable
+    # `server.exposeGossipAndRPCPorts` and `client.exposeGossipPorts`, you must
+    # change this from the default to an unused port on the host, e.g. 9301. By
+    # default the LAN gossip port is 8301 and configured as a containerPort on
+    # the consul server Pods.
+    serflan:
+      port: 8301
+
   # This defines the disk size for configuring the
   # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
   # desired size. For manually defined persistent volumes, this should be set to


### PR DESCRIPTION
**Changes proposed**
* Adds option to expose server gossip and RPC ports as hostPorts
* Adds option to configure the server gossip port with `server.ports.serflan.port`. This would be necessary to configure differently when exposing both server.exposeGossipAndRPCPorts and client.exposeGossipPorts to avoid port conflicts when client and servers are running on the same node.

**Use Case**
To enable a client agent outside of the k8s cluster to join the datacenter, you would need to enable server.exposeGossipAndRPCPorts, client.exposeGossipPorts, and set server.ports.serflan.port to a port not being used on the host. Since client.exposeGossipPorts uses the hostPort 8301, server.ports.serflan.port must be set to something other than 8301, if those client/server pods can be scheduled on the same node.

**How I've tested**
On GCP:
1. Deploy GKE cluster
`gcloud container clusters create external-agent --project nitya-293720 --cluster-version="1.17.12-gke.2502" --zone us-west1-a --machine-type=n1-standard-4 --num-nodes 3`
1. Helm install from this PR branch, using the following values:
<details>
<summary>values.yaml</summary>

```yaml
global:
  domain: consul
  datacenter: dc1
server:
  replicas: 1
  bootstrapExpect: 1
  exposeGossipAndRPCPorts: true
  serflan:
    port: 9301
client:
  enabled: true
  grpc: true
  exposeGossipPorts: true
ui:
  enabled: true
connectInject:
  enabled: true
controller:
  enabled: true
```
</details>

1. On the GCP console, create a new VM. If you are in the same project and use the same zone, the VM will be deployed to the same subnet as your GKE VMs. The VM and GKE VMs need to be routeable on the private network. I created an E2-small with Debian boot disk.
1. Add a network tag to the VM (you should see the option when you edit the VM)
1. Add a firewall rule whose target is the network tag you created above. Allow all ingress on 0.0.0.0/0 on all ports. (I wasn't able to reduce this to just the private network range 10.128.0.0/9 and have it work, and I'm not sure why).
1. When the VM is created, copy the gcloud command to ssh onto the VM.
1. Get consul binary (You'll need to apt install wget and unzip)
`wget https://releases.hashicorp.com/consul/1.9.0/consul_1.9.0_linux_amd64.zip && unzip consul_1.9.0_linux_amd64.zip`
1. Run this script to run a local agent, and replace the `-advertise` ip with the internal ip of your VM. Replace the `-retry-join` with the `status.hostIP` on your consul server pod. If you have multiple consul servers, you will need multiple of these lines with each ip:port of a consul server. Create a folder called `local/consul/config` and `local/consul/data`.

```sh
#! /usr/bin/env bash

./consul agent \
  -advertise="10.138.0.38" \
  -bind=0.0.0.0 \
  -client=0.0.0.0 \
  -hcl='leave_on_terminate = true' \
  -hcl='ports { grpc = 8502 }' \
  -config-dir=local/consul/config \
  -datacenter=dc1 \
  -data-dir=local/consul/data \
  -retry-join="10.138.0.35:9301" \
  -domain=consul
```
1. Another (more recommended way) to join the cluster is by copying the kubeconfig file to target the k8s cluster into the home directory on the VM. Then you can replace the retry-join flag above and use: `-retry-join 'provider=k8s host_network=true label_selector="app=consul,component=server"'` instead rather than hardcoding potentially multiple consul server IPs. 
1. Look at logs on consul-server on k8s and the consul-client on the VM, and ensure no error messages are being printed
1. Register a service on the client on the VM: 
```
curl --request PUT --data @payload.json http://localhost:8500/v1/agent/service/register
```
<details>
<summary>payload.json</summary>

```json
{
  "ID": "redis1",
  "Name": "redis",
  "Tags": [
    "primary",
    "v1"
  ],
  "Address": "127.0.0.1",
  "TaggedAddresses": {
    "lan": {
      "address": "127.0.0.1",
      "port": 8000
    }
  },
  "Port": 8000,
  "Check": {
    "CheckID": "service:redis1",
    "Name": "Redis health check",
    "Notes": "TCP health check",
    "ServiceID": "redis1",
    "TCP": "localhost:8888",
    "Interval": "5s",
    "Timeout": "1s",
    "DeregisterCriticalServiceAfter": "600s"
  }
}
```
</details>

1. On the server, `curl http://127.0.0.1:8500/v1/catalog/services` and verify you see the service.

**How I expect reviewers to test**
If at least one reviewer has the bandwidth to run through the complete steps above it would give some confidence in catching any gotchas we might want to document. 