### PR TITLE
Add missing newline to code generation

### DIFF
--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -115,7 +115,7 @@ func main() {
 	helmReferenceContents := string(helmReferenceBytes)
 
 	// Swap out the contents between the codegen markers.
-	startStr := "<!-- codegen: start -->\n"
+	startStr := "<!-- codegen: start -->\n\n"
 	endStr := "\n  <!-- codegen: end -->"
 	start := strings.Index(helmReferenceContents, startStr)
 	if start == -1 {


### PR DESCRIPTION
We need to have a newline between the codegen comment and the start of
the generated docs because the markdown formatter will add it later.

Previously we'd generate the docs like:
```
<!-- codegen: start -->
- `global` ((#v-global)) - Holds values that affect multiple components of the chart.
```

But when the automatic markdown formatter ran on commit, it would add a newline:
```
<!-- codegen: start -->

- `global` ((#v-global)) - Holds values that affect multiple components of the chart.
```

This change ensure we generate the docs with that newline so when the markdown formatter runs it makes no changes. Otherwise when you ran the gen-docs make target it would always make a modification to `helm.mdx` and remove that newline.