### PR TITLE
Run Consul servers and clients as non-root and make it configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ BREAKING CHANGES:
 * Setting `server.bootstrapExpect` to a value less than `server.replicas` will now
   give an error. This was a misconfiguration as the servers wouldn't wait
   until the proper number have started before electing a leader. [[GH-721](https://github.com/hashicorp/consul-helm/pull/721)]
+* Clients and servers now run as non root. Users can also configure `server.securityContext` and `client.securityContext`
+  if they wish to overwrite this behavior. Please see [Helm reference](https://www.consul.io/docs/k8s/helm) for more information.
+  [[GH-748](https://github.com/hashicorp/consul-helm/pull/748)]
 
 FEATURES:
 * CRDs: add new CRD `IngressGateway` for configuring Consul's [ingress-gateway](https://www.consul.io/docs/agent/config-entries/ingress-gateway) config entry. [[GH-714](https://github.com/hashicorp/consul-helm/pull/714)]

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -48,6 +48,11 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "consul.fullname" . }}-client
 
+      {{- if not .Values.global.openshift.enabled }}
+      securityContext:
+        {{- toYaml .Values.client.securityContext | nindent 8 -}}
+      {{- end }}
+
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -60,9 +60,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "consul.fullname" . }}-server
-      {{- if not .Values.global.openshift.enabled}}
+      {{- if not .Values.global.openshift.enabled }}
       securityContext:
-        fsGroup: 1000
+        {{- toYaml .Values.server.securityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: config

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -1036,3 +1036,55 @@ rollingUpdate:
       yq -c '.spec.updateStrategy == {"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":5}}' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.openshift.enabled & client.securityContext
+
+@test "client/DaemonSet: securityContext is not set when global.openshift.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+#--------------------------------------------------------------------
+# client.securityContext
+
+@test "client/DaemonSet: sets default security context settings" {
+  cd `chart_dir`
+  local security_context=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $security_context | jq -r .fsGroup)
+  [ "${actual}" = "1000" ]
+
+  local actual=$(echo $security_context | jq -r .runAsUser)
+  [ "${actual}" = "100" ]
+
+  local actual=$(echo $security_context | jq -r .runAsGroup)
+  [ "${actual}" = "1000" ]
+}
+
+@test "client/DaemonSet: can overwrite security context settings" {
+  cd `chart_dir`
+  local security_context=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.securityContext.runAsNonRoot=false' \
+      --set 'client.securityContext.privileged=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $security_context | jq -r .privileged)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -468,7 +468,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.openshift.enabled
+# global.openshift.enabled & server.securityContext
 
 @test "server/StatefulSet: setting server.disableFsGroupSecurityContext fails" {
   cd `chart_dir`
@@ -479,7 +479,7 @@ load _helpers
   [[ "$output" =~ "server.disableFsGroupSecurityContext has been removed. Please use global.openshift.enabled instead." ]]
 }
 
-@test "server/StatefulSet: fsGroup is not set when global.openshift.enabled=true" {
+@test "server/StatefulSet: securityContext is not set when global.openshift.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
@@ -489,13 +489,43 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/StatefulSet: default fsGroup security context settings fsGroup: 1000" {
+#--------------------------------------------------------------------
+# server.securityContext
+
+@test "server/StatefulSet: sets default security context settings" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local security_context=$(helm template \
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $security_context | jq -r .fsGroup)
   [ "${actual}" = "1000" ]
+
+  local actual=$(echo $security_context | jq -r .runAsUser)
+  [ "${actual}" = "100" ]
+
+  local actual=$(echo $security_context | jq -r .runAsGroup)
+  [ "${actual}" = "1000" ]
+}
+
+@test "server/StatefulSet: can overwrite security context settings" {
+  cd `chart_dir`
+  local security_context=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.securityContext.runAsNonRoot=false' \
+      --set 'server.securityContext.privileged=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $security_context | jq -r .privileged)
+  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -342,6 +342,20 @@ server:
       memory: "100Mi"
       cpu: "100m"
 
+  # The security context for the server pods. This should be a YAML map corresponding to a
+  # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
+  # By default, servers will run as non-root, with user ID `100` and group ID `1000`,
+  # which correspond to the consul user and group created by the Consul docker image.
+  # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
+  # by the OpenShift platform.
+  # @type: map
+  # @recurse: false
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+    fsGroup: 1000
+
   # This value is used to carefully
   # control a rolling update of Consul server agents. This value specifies the
   # partition (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions)
@@ -618,6 +632,20 @@ client:
     limits:
       memory: "100Mi"
       cpu: "100m"
+
+  # The security context for the client pods. This should be a YAML map corresponding to a
+  # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
+  # By default, servers will run as non-root, with user ID `100` and group ID `1000`,
+  # which correspond to the consul user and group created by the Consul docker image.
+  # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
+  # by the OpenShift platform.
+  # @type: map
+  # @recurse: false
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+    fsGroup: 1000
 
   # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
   # clients. This will be saved as-is into a ConfigMap that is read by the Consul


### PR DESCRIPTION
Based on work done in #311 

## Changes proposed in this PR

Add new values `server.securityContext` and `client.securityContext` to allow configuring securityContext setting for clients and servers. The map directly to pod's security context in Kubernetes.

We also default these settings to running both servers and clients as non-root and with the `consul` uid and gid, which are created in the Consul docker image.

When openshift is enabled, we don't want these settings to be there since openshift generates random user and group and sets them for each pod.

## Testing

No need for the reviewers to test since passing acceptance tests is enough of a validation

## TODO

- [x] Changelog entry