### PR TITLE
Use consul-k8s subcommand to perform TLS-init job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ FEATURES:
 IMPROVEMENTS:
 * Make `server.bootstrapExpect` optional. If not set, will now default to `server.replicas`.
   If you're currently setting `server.replicas`, there is no effect. [[GH-721](https://github.com/hashicorp/consul-helm/pull/721)]
+* Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
+  Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
 
 BUG FIXES:
 * Fix pod security policy when running mesh gateways in `hostNetwork` mode. [[GH-605](https://github.com/hashicorp/consul-helm/issues/605)]

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -46,42 +46,25 @@ spec:
       {{- end }}
       containers:
         - name: tls-init
-          image: "{{ .Values.global.image }}"
+          image: "{{ .Values.global.imageK8S }}"
           env:
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          # We're using POST requests below to create secrets via Kubernetes API.
-          # Note that in the subsequent runs of the job, POST requests will
-          # return a 409 because these secrets would already exist;
-          # we are ignoring these response codes.
           workingDir: /tmp
           command:
             - "/bin/sh"
             - "-ec"
             - |
-              {{- if (not (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName)) }}
-              consul tls ca create \
-                -domain={{ .Values.global.domain }}
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
-                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
-                -H "Content-Type: application/json" \
-                -H "Accept: application/json" \
-                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.domain }}-agent-ca.pem | base64 | tr -d '\n' )\" }}" > /dev/null
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
-                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
-                -H "Content-Type: application/json" \
-                -H "Accept: application/json" \
-                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-ca-key\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": { \"tls.key\": \"$( cat {{ .Values.global.domain }}-agent-ca-key.pem | base64 | tr -d '\n' )\" }}" > /dev/null
-              {{- end }}
               # Suppress globbing so we can interpolate the $NAMESPACE environment variable
               # and use * at the start of the dns name when setting -additional-dnsname.
               set -o noglob
-              consul tls cert create -server \
+              consul-k8s tls-init \
+                -domain={{ .Values.global.domain }} \
                 -days=730 \
+                -name-prefix={{ template "consul.fullname" . }} \
+                -k8s-namespace=${NAMESPACE} \
                 {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
                 -ca=/consul/tls/ca/cert/tls.crt \
                 -key=/consul/tls/ca/key/tls.key \
@@ -95,17 +78,9 @@ spec:
                 -additional-ipaddress={{ . }} \
                 {{- end }}
                 {{- range .Values.global.tls.serverAdditionalDNSSANs }}
-                 -additional-dnsname={{ . }} \
-                 {{- end }}
-                -dc={{ .Values.global.datacenter }} \
-                -domain={{ .Values.global.domain }}
-              set +o noglob
-              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
-                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
-                -H "Content-Type: application/json" \
-                -H "Accept: application/json" \
-                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"{{ template "consul.fullname" . }}-server-cert\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"kubernetes.io/tls\", \"data\": { \"tls.crt\": \"$( cat {{ .Values.global.datacenter }}-server-{{ .Values.global.domain }}-0.pem | base64 | tr -d '\n' )\", \"tls.key\": \"$( cat {{ .Values.global.datacenter }}-server-{{ .Values.global.domain }}-0-key.pem | base64 | tr -d '\n' )\" } }" > /dev/null
+                -additional-dnsname={{ . }} \
+                {{- end }}
+                -dc={{ .Values.global.datacenter }}
           {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
           volumeMounts:
             - name: consul-ca-cert

--- a/templates/tls-init-role.yaml
+++ b/templates/tls-init-role.yaml
@@ -19,6 +19,9 @@ rules:
     - secrets
   verbs:
     - create
+    - update
+    - get
+    - list
 {{- if .Values.global.enablePodSecurityPolicies }}
 - apiGroups: ["policy"]
   resources:


### PR DESCRIPTION
Changes proposed in this PR:
- Use `tls-init` subcommand from `consul-k8s` https://github.com/hashicorp/consul-k8s/pull/410 to perform the creation of TLS server certificates.

How I've tested this PR:
- Perform a helm install/upgrade whilst running the new tls-init job. It creates the desired server certificates and rotates them when run subsequently. Consul servers need to be restarted in order for them to use the new certificates. It does not update the CA certs once they are created for the first time or provided ensuring the server certificates are always signed by the same CA.

How I expect reviewers to test this PR:
- Perform a helm install. Update the values file to add `additionalDNSSans` and perform a helm upgrade.
`openssl s_client -connect localhost:8501` when performed from with a server pod should initially return a certificate that does not have the provided additional DNS sans. When you restart the server, the servers should continue to be able to talk to each other and and the above `s_client` operation should return an updated certificate which has the new DNS SANS.

- The above operation can be retried but with a BYO CA and key.

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
- [x] PR submitted to update [consul.io Helm docs](https://www.consul.io/docs/k8s/helm) (see [Generating Helm Reference Docs](https://github.com/hashicorp/consul-helm/blob/master/CONTRIBUTING.md#generating-helm-reference-docs))
  - Link to PR: https://github.com/hashicorp/consul/pull/9439
