### PR TITLE
Increase timeout for checking the static server connection.

### DIFF
--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -104,7 +104,7 @@ func CheckStaticServerConnectionMultipleFailureMessages(
 ) {
 	t.Helper()
 
-	retrier := &retry.Timer{Timeout: 20 * time.Second, Wait: 500 * time.Millisecond}
+	retrier := &retry.Timer{Timeout: 80 * time.Second, Wait: 2 * time.Second}
 
 	args := []string{"exec", "deploy/" + deploymentName, "-c", deploymentName, "--", "curl", "-vvvsSf"}
 	args = append(args, curlArgs...)


### PR DESCRIPTION
The mesh gateway tests intermittently fail while checking this
connection with connection reset by peer errors. This could potentially
help.

Changes proposed in this PR:
- Increase timeout for checking static server connection, since it fails sometimes (2x in 14 days)
- For background context: EKS [test investigation](https://docs.google.com/document/d/1j88SdxLz4eLW2iBPsQhf-2CGMvVQCITgQxf3M1ia5m0/edit) leading to this PR


How I've tested this PR:
- running eks tests on this branch

How I expect reviewers to test this PR:
- code review

