### PR TITLE
Log services in mesh_gateway_test

### DIFF
--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -107,6 +107,17 @@ func TestMeshGatewayDefault(t *testing.T) {
 	logger.Log(t, "verifying federation was successful")
 	verifyFederation(t, primaryClient, secondaryClient, releaseName, false)
 
+	// Log services in DC2 that DC1 is aware of before exiting this test
+	// TODO: remove this code once issue has been debugged
+	defer func() {
+		svcs, _, err := primaryClient.Catalog().Services(&api.QueryOptions{Datacenter: "dc2"})
+		if err != nil {
+			logger.Logf(t, "error calling primary on /v1/catalog/services?dc=dc2: %s\n", err.Error())
+			return
+		}
+		logger.Logf(t, "primary on /v1/catalog/services?dc=dc2: %+v\n", svcs)
+	}()
+
 	// Check that we can connect services over the mesh gateways
 	logger.Log(t, "creating static-server in dc2")
 	k8s.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")


### PR DESCRIPTION
This will help debug errors in connections between static-client and
static-server after federation has been set up. This will provide
information about whether DC1 (static-client) is aware of the
static-server deployment in DC2.

Changes proposed in this PR:
- Log the output of DC1's /v1/catalog/services?dc=dc2 endpoint

How I've tested this PR:
- on [this build](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2170/workflows/c1902e34-687d-4ac6-b5b7-5705c9b810cf/jobs/6303) cmd + F for "primary on" and you'll see the log

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Undo circle ci changes and see tests pass before merging
