### PR TITLE
Expose server serfwan port as hostPort when hostIP is advertised.

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -255,6 +255,9 @@ spec:
               protocol: "UDP"
               name: serflan-udp
             - containerPort: 8302
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: 8302
+              {{- end }}
               name: serfwan
             - containerPort: 8300
               {{- if .Values.server.exposeGossipAndRPCPorts }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -210,11 +210,15 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "server")' | yq -r '.hostPort' | tee /dev/stderr)
   [ "${actual}" = "8300" ]
 
+  # Test that hostPort is set for server serfwan port
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serfwan")' | yq -r '.hostPort' | tee /dev/stderr)
+  [ "${actual}" = "8302" ]
+
   # Test that ADVERTISE_IP is being set to hostIP
   local actual=$(echo "$object" |
     yq -r -c '.spec.template.spec.containers[0].env | map(select(.name == "ADVERTISE_IP"))' | tee /dev/stderr)
   [ "${actual}" = '[{"name":"ADVERTISE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}]' ]
-
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
The servers try to talk to each other on the serfwan port, and when the
advertised IP of the server is the host IP, the serfwan port needs to be
exposed so the server doesn't log wan gossip errors.

Changes proposed in this PR:
- When exposeGossipAndRPCPorts is set, the server's serfwan port is also exposed as a hostPort

How I've tested this PR:
- enable exposeGossipAndRPCPorts, and ensure that there are no longer errors being logged.
- EDIT: not sure if this actually worked since I didn't see the error without this change.

How I expect reviewers to test this PR:
- Code review

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

