### PR TITLE
Remove preStop hook that calls consul leave from Consul servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,9 @@
 ## Unreleased
 
-BREAKING CHANGES:
-* Consul servers start with a provided node ID and no longer call "consul leave" command when restarted or deleted. [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
-  If you have an existing Consul cluster with ACLs enabled, please follow the steps below up upgrade.
-  Otherwise, no additional steps are necessary to upgrade.
-  1. Set `leave_on_terminate` on your existing installation, setting `leave_on_terminate` to `true` so that the new node ID can be registered:
-
-     ```bash
-     helm upgrade consul --set server.extraConfig='\"{"leave_on_terminate": true}\"' hashicorp/consul --version <your current version>
-     ```
-
-  2. Upgrade to this version of the Helm chart, removing the `leave_on_terminate` setting:
-
-     ```bash
-     helm repo update
-     helm upgrade consul hashicorp/consul
-     ```
-
 IMPROVEMENTS:
 * Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
+* Consul servers no longer call `consul leave` command when restarted or deleted. [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
 
 ## 0.28.0 (Dec 21, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ IMPROVEMENTS:
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
 
 BUG FIXES:
-* Consul servers no longer call `consul leave` command when restarted or deleted. [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
+* Consul servers no longer call `consul leave` command when restarted or deleted.
+  This is because `consul leave` reduces the quorum size, but we want to maintain the quorum size.
+  For example, for a server with 3 replicas the quorum size should always be 2.
+  [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
 
 ## 0.28.0 (Dec 21, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 IMPROVEMENTS:
 * Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
+
+BUG FIXES:
 * Consul servers no longer call `consul leave` command when restarted or deleted. [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
 
 ## 0.28.0 (Dec 21, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## Unreleased
 
+BREAKING CHANGES:
+* Consul servers start with a provided node ID and no longer call "consul leave" command when restarted or deleted. [[GH-764](https://github.com/hashicorp/consul-helm/pull/764)]
+  If you have an existing Consul cluster with ACLs enabled, please follow the steps below up upgrade.
+  Otherwise, no additional steps are necessary to upgrade.
+  1. Set `leave_on_terminate` on your existing installation, setting `leave_on_terminate` to `true` so that the new node ID can be registered:
+
+     ```bash
+     helm upgrade consul --set server.extraConfig='\"{"leave_on_terminate": true}\"' hashicorp/consul --version <your current version>
+     ```
+
+  2. Upgrade to this version of the Helm chart, removing the `leave_on_terminate` setting:
+
+     ```bash
+     helm repo update
+     helm upgrade consul hashicorp/consul
+     ```
+
 IMPROVEMENTS:
 * Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -153,15 +153,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              # Generate a unique Node ID for each server.
-              # This Node ID is going to last for the whole lifetime of the consul servers
-              # and will persist across restarts.
-              # The Node ID is sha1 hash based on the Hostname and the datacenter.
-              nid_sha1=$(echo $HOSTNAME-{{.Values.global.datacenter}} | sha1sum)
-              nid=${nid_sha1:0:8}-${nid_sha1:8:4}-${nid_sha1:12:4}-${nid_sha1:16:4}-${nid_sha1:20:12}
-
               exec /bin/consul agent \
-                -node-id="${nid}" \
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }} \

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -153,7 +153,15 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
+              # Generate a unique Node ID for each server.
+              # This Node ID is going to last for the whole lifetime of the consul servers
+              # and will persist across restarts.
+              # The Node ID is sha1 hash based on the Hostname and the datacenter.
+              nid_sha1=$(echo $HOSTNAME-{{.Values.global.datacenter}} | sha1sum)
+              nid=${nid_sha1:0:8}-${nid_sha1:8:4}-${nid_sha1:12:4}-${nid_sha1:16:4}-${nid_sha1:20:12}
+
               exec /bin/consul agent \
+                -node-id="${nid}" \
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }} \
@@ -226,13 +234,6 @@ spec:
               readOnly: true
               mountPath: /consul/userconfig/{{ .name }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - /bin/sh
-                - -c
-                - consul leave
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
             - containerPort: 8500


### PR DESCRIPTION
## Background
Currently, when Consul servers are restarted, we call the `consul leave` command in the `preStop` hook that is registered with the servers. This approach has a couple of problems:

1. This command does not work when ACLs are enabled on the cluster because this command requires a valid ACL token with `agent:write` permission. Furthermore, we cannot reasonably make it work because even if the server's ACL token had that permission, we could not retrieve it because it's stored in the Consul's data directory. We could work around this by removing the preStop hook and instead setting `leave_on_terminate` to `true` on the servers, which would accomplish the same behavior. However, this solution is not recommended because of point 2.
2. The voting members of the consul cluster (aka the consul servers) should not gracefully leave the cluster. That is so that the quorum size is not affected during upgrades or downtime. See hashicorp/consul#5947.

## Changes proposed in this PR:
- Remove the preStop hook calling `consul leave` from the consul server pods

## How I've tested this PR:

- Deployed Consul from this helm chart, ran `kubectl rollout restart sts/...`, and checked that servers came up healthy.
- Deployed the current stable version of the helm chart, upgraded to this version and checked that the upgrade goes through without problems

## How I expect reviewers to test this PR:
Code review

## Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
