### PR TITLE
Re-enable OpenShift tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=hashicorpdev/consul-k8s:latest
+                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1
@@ -602,12 +602,10 @@ workflows:
               only:
                 - master
     jobs:
-      # OpenShift temporarily disabled until we get a new mirror.
-      # - acceptance-openshift
+      - acceptance-openshift
       - acceptance-gke-1-16
       - acceptance-eks-1-17
-      # AKS temporarily disabled until we get a new mirror.
-      # - acceptance-aks-1-19
+#      - acceptance-aks-1-19
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/test/acceptance/tests/fixtures/bases/static-client/deployment.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: static-client
-          image: tutum/curl:latest
+          image: docker.mirror.hashicorp.services/curlimages/curl:latest
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
       serviceAccountName: static-client

--- a/test/acceptance/tests/fixtures/bases/static-server/deployment.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-server/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: static-server
-          image: hashicorp/http-echo:latest
+          image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
           args:
             - -text="hello world"
             - -listen=:8080

--- a/test/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
+++ b/test/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: static-server
-          image: kschoche/http-echo:latest
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
           args:
             - -text="hello world"
             - -listen=:8080


### PR DESCRIPTION
Using new mirror

NOTE: AKS tests are still failing, need to debug further.