### PR TITLE
Re-enable AKS acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-  acceptance-aks-1-19:
+  acceptance-aks-1-18:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -605,7 +605,7 @@ workflows:
       - acceptance-openshift
       - acceptance-gke-1-16
       - acceptance-eks-1-17
-#      - acceptance-aks-1-19
+      - acceptance-aks-1-18
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/test/terraform/aks/main.tf
+++ b/test/terraform/aks/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default[count.index].location
   resource_group_name = azurerm_resource_group.default[count.index].name
   dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.19.3"
+  kubernetes_version  = "1.18.14"
 
   default_node_pool {
     name            = "default"


### PR DESCRIPTION
Use Kube 1.18.14 because 1.19+ is not working (https://github.com/Azure/AKS/issues/2070)

This passes with 1.18.14: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2232/workflows/9a170a09-a841-4201-b433-ea776f10f163/jobs/6742