### PR TITLE
Add ingress option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
+* Add support for Ingress resource for Consul UI [[GH-774](https://github.com/hashicorp/consul-helm/pull/721)]
 
 ## 0.28.0 (Dec 21, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 * Use `consul-k8s` subcommand to perform `tls-init` job. This allows for server certificates to get rotated on subsequent runs.
   Consul servers have to be restarted in order for them to update their server certificates [[GH-749](https://github.com/hashicorp/consul-helm/pull/721)]
-* Add support for Ingress resource for Consul UI [[GH-774](https://github.com/hashicorp/consul-helm/pull/721)]
+* Add support for Ingress resource for Consul UI [[GH-774](https://github.com/hashicorp/consul-helm/pull/774)]
 
 ## 0.28.0 (Dec 21, 2020)
 

--- a/hack/helm-reference-gen/go.sum
+++ b/hack/helm-reference-gen/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=

--- a/templates/ui-ingress.yaml
+++ b/templates/ui-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if (and (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.enabled | toString) "-") .Values.ui.enabled) (and (eq (.Values.ui.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.ingress.enabled | toString) "-") .Values.ui.ingress.enabled) (and (eq (.Values.ui.ingress.enabled | toString) "-") .Values.global.enabled))) }}
+{{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "consul.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.ui.ingress.annotations }}
+  annotations:
+    {{ tpl (toYaml .Values.ui.ingress.annotations) . | nindent 4 | trim }}
+  {{- end}}
+spec:
+  rules:
+  {{- range .Values.ui.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $serviceName }}
+              servicePort: 80
+  {{- end -}}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+    {{ tpl (toYaml .Values.ui.ingress.tls) . | nindent 4 | trim }}
+  {{- end }}
+{{- end }}

--- a/templates/ui-ingress.yaml
+++ b/templates/ui-ingress.yaml
@@ -1,7 +1,7 @@
 {{- if (and (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.enabled | toString) "-") .Values.ui.enabled) (and (eq (.Values.ui.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.service.enabled | toString) "-") .Values.ui.service.enabled) (and (eq (.Values.ui.service.enabled | toString) "-") .Values.global.enabled))) }}
 {{- if (and (ne (.Values.ui.ingress.enabled | toString) "-") .Values.ui.ingress.enabled) }}
 {{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   name: {{ template "consul.fullname" . }}-ingress
@@ -23,16 +23,14 @@ spec:
   - host: {{ .host | quote }}
     http:
       paths:
-      {{- if (or (not $global.tls.enabled) (not $global.tls.httpsOnly)) }}
       {{- range (.paths | default (list "/")) }}
+      {{- if (or (not $global.tls.enabled) (not $global.tls.httpsOnly)) }}
       - backend:
           serviceName: {{ $serviceName }}
           servicePort: 80
         path: {{ . }}
       {{- end }}
-      {{- end }}
       {{- if $global.tls.enabled }}
-      {{- range (.paths | default (list "/")) }}
       - backend:
           serviceName: {{ $serviceName }}
           servicePort: 443
@@ -42,13 +40,7 @@ spec:
   {{- end -}}
   {{- if .Values.ui.ingress.tls }}
   tls:
-  {{- range .Values.ui.ingress.tls }}
-  - hosts:
-    {{- range .hosts }}
-    - {{ . | quote }}
-    {{- end }}
-    secretName: {{ .secretName }}
-  {{- end }}
+  {{- toYaml .Values.ui.ingress.tls | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/ui-ingress.yaml
+++ b/templates/ui-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if (and (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.enabled | toString) "-") .Values.ui.enabled) (and (eq (.Values.ui.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.ingress.enabled | toString) "-") .Values.ui.ingress.enabled) (and (eq (.Values.ui.ingress.enabled | toString) "-") .Values.global.enabled))) }}
+{{- if (and (ne (.Values.ui.ingress.enabled | toString) "-") .Values.ui.ingress.enabled) }}
 {{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -12,20 +12,26 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.ui.ingress.annotations }}
   annotations:
-    {{ tpl (toYaml .Values.ui.ingress.annotations) . | nindent 4 | trim }}
+    {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end}}
 spec:
   rules:
-  {{- range .Values.ui.ingress.hosts }}
+    {{- range .Values.ui.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: 80
-  {{- end -}}
+    {{- end -}}
   {{- if .Values.ui.ingress.tls }}
   tls:
-    {{ tpl (toYaml .Values.ui.ingress.tls) . | nindent 4 | trim }}
+    {{- range $value := .Values.ui.ingress.tls }}
+    - hosts:
+      {{- range $value.hosts }}
+      - {{ . }}
+      {{- end }}
+      secretName: {{ $value.secretName }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/ui-ingress.yaml
+++ b/templates/ui-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if (and (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.enabled | toString) "-") .Values.ui.enabled) (and (eq (.Values.ui.enabled | toString) "-") .Values.global.enabled)) (or (and (ne (.Values.ui.service.enabled | toString) "-") .Values.ui.service.enabled) (and (eq (.Values.ui.service.enabled | toString) "-") .Values.global.enabled))) }}
 {{- if (and (ne (.Values.ui.ingress.enabled | toString) "-") .Values.ui.ingress.enabled) }}
 {{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
 apiVersion: extensions/v1beta1
@@ -10,28 +11,44 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: ui
   {{- if .Values.ui.ingress.annotations }}
   annotations:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end}}
 spec:
   rules:
-    {{- range .Values.ui.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 80
-    {{- end -}}
+  {{ $global := .Values.global }}
+  {{- range .Values.ui.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- if (or (not $global.tls.enabled) (not $global.tls.httpsOnly)) }}
+      {{- range (.paths | default (list "/")) }}
+      - backend:
+          serviceName: {{ $serviceName }}
+          servicePort: 80
+        path: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if $global.tls.enabled }}
+      {{- range (.paths | default (list "/")) }}
+      - backend:
+          serviceName: {{ $serviceName }}
+          servicePort: 443
+        path: {{ . }}
+      {{- end }}
+      {{- end }}
+  {{- end -}}
   {{- if .Values.ui.ingress.tls }}
   tls:
-    {{- range $value := .Values.ui.ingress.tls }}
-    - hosts:
-      {{- range $value.hosts }}
-      - {{ . }}
-      {{- end }}
-      secretName: {{ $value.secretName }}
+  {{- range .Values.ui.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+    - {{ . | quote }}
     {{- end }}
+    secretName: {{ .secretName }}
   {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "ui/Ingress: disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ui/Ingress: enable with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.enabled=true' \
+      --set 'ui.enabled=true' \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ui/Ingress: disable with server.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'server.enabled=false' \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ui/Ingress: disable with ui.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.enabled=false' \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ui/Ingress: disable with ui.ingress.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ui/Ingress: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'global.enabled=false' \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ui/Ingress: disable with global.enabled and server.enabled on" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.enabled=true' \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# hosts
+
+@test "ui/Ingress: no hosts by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ui/Ingress: hosts can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'ui.ingress.hosts[0]=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].host' | tee /dev/stderr)
+  [ "${actual}" = "foo.com" ]
+}
+
+#--------------------------------------------------------------------
+# tls
+
+@test "ui/Ingress: no tls by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.tls' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ui/Ingress: tls can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'ui.ingress.tls[0].hosts[0]=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.tls[0].hosts[0]' | tee /dev/stderr)
+  [ "${actual}" = "foo.com" ]
+}
+
+@test "ui/Ingress: tls with secret name can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'ui.ingress.tls[0].hosts[0]=foo.com' \
+      --set 'ui.ingress.tls[0].secretName=testsecret-tls' \
+      . | tee /dev/stderr |
+      yq -r '.spec.tls[0].secretName' | tee /dev/stderr)
+  [ "${actual}" = "testsecret-tls" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "ui/Ingress: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ui/Ingress: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'ui.ingress.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -11,39 +11,14 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ui/Ingress: enable with global.enabled false" {
+@test "ui/Ingress: enable with ui.ingress.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ui-ingress.yaml  \
-      --set 'global.enabled=false' \
-      --set 'server.enabled=true' \
-      --set 'ui.enabled=true' \
       --set 'ui.ingress.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
-}
-
-@test "ui/Ingress: disable with server.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
-      --set 'server.enabled=false' \
-      --set 'ui.ingress.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "ui/Ingress: disable with ui.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
-      --set 'ui.enabled=false' \
-      --set 'ui.ingress.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
 }
 
 @test "ui/Ingress: disable with ui.ingress.enabled" {
@@ -56,24 +31,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ui/Ingress: disable with global.enabled" {
+@test "ui/Ingress: disable with ui.ingress.enabled dash string" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ui-ingress.yaml  \
-      --set 'global.enabled=false' \
-      --set 'ui.ingress.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "ui/Ingress: disable with global.enabled and server.enabled on" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-service.yaml  \
-      --set 'global.enabled=false' \
-      --set 'server.enabled=true' \
-      --set 'ui.ingress.enabled=true' \
+      --set 'ui.ingress.enabled=-' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -132,7 +94,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
-      --set 'ui.ingress.tls[0].hosts[0]=foo.com' \
+      --set 'ui.ingress.tls[0].hosts[0]=sslexample.foo.com' \
       --set 'ui.ingress.tls[0].secretName=testsecret-tls' \
       . | tee /dev/stderr |
       yq -r '.spec.tls[0].secretName' | tee /dev/stderr)
@@ -157,7 +119,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
-      --set 'ui.ingress.annotations.foo=bar' \
+      --set 'ui.ingress.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -4,17 +4,15 @@ load _helpers
 
 @test "ui/Ingress: disabled by default" {
   cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  assert_empty helm template \
+      -s templates/ui-ingress.yaml  \
+      .
 }
 
 @test "ui/Ingress: enable with ui.ingress.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -23,22 +21,18 @@ load _helpers
 
 @test "ui/Ingress: disable with ui.ingress.enabled" {
   cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+  assert_empty helm template \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      .
 }
 
 @test "ui/Ingress: disable with ui.ingress.enabled dash string" {
   cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+  assert_empty helm template \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=-' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+      .
 }
 
 #--------------------------------------------------------------------
@@ -47,7 +41,7 @@ load _helpers
 @test "ui/Ingress: no hosts by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.rules' | tee /dev/stderr)
@@ -57,12 +51,58 @@ load _helpers
 @test "ui/Ingress: hosts can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
-      --set 'ui.ingress.hosts[0]=foo.com' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].host' | tee /dev/stderr)
   [ "${actual}" = "foo.com" ]
+}
+
+@test "ui/Ingress: port 80 when global.tls.enabled=false enables http port" {
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}
+
+@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=true enables https port" {
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=false enables http port" {
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}
+
+@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=false enables https port" {
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
 }
 
 #--------------------------------------------------------------------
@@ -71,7 +111,7 @@ load _helpers
 @test "ui/Ingress: no tls by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.tls' | tee /dev/stderr)
@@ -81,7 +121,7 @@ load _helpers
 @test "ui/Ingress: tls can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       --set 'ui.ingress.tls[0].hosts[0]=foo.com' \
       . | tee /dev/stderr |
@@ -92,7 +132,7 @@ load _helpers
 @test "ui/Ingress: tls with secret name can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       --set 'ui.ingress.tls[0].hosts[0]=sslexample.foo.com' \
       --set 'ui.ingress.tls[0].secretName=testsecret-tls' \
@@ -107,7 +147,7 @@ load _helpers
 @test "ui/Ingress: no annotations by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations' | tee /dev/stderr)
@@ -117,7 +157,7 @@ load _helpers
 @test "ui/Ingress: annotations can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/ui-ingress.yaml  \
+      -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       --set 'ui.ingress.annotations=foo: bar' \
       . | tee /dev/stderr |

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -59,7 +59,7 @@ load _helpers
   [ "${actual}" = "foo.com" ]
 }
 
-@test "ui/Ingress: port 80 when global.tls.enabled=false enables http port" {
+@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false" {
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -70,7 +70,7 @@ load _helpers
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=true enables https port" {
+@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true" {
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -81,7 +81,7 @@ load _helpers
   [ "${actual}" = "443" ]
 }
 
-@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=false enables http port" {
+@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false" {
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -93,7 +93,7 @@ load _helpers
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: port 80 when global.tls.enabled=true and global.tls.httpsOnly=false enables https port" {
+@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false" {
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \

--- a/values.yaml
+++ b/values.yaml
@@ -941,30 +941,50 @@ ui:
     # @type: string
     additionalSpec: null
 
-  ## True if you want to create an Ingress for the Consul UI.
+  # Configure Ingress for the Consul UI.
   ingress:
+    # This will create an Ingress resource for the Consul UI.
+    # @type: boolean
     enabled: false
 
     # hosts is a list of host name to create Ingress rules.
     # The value below is an array of objects, examples are shown below.
+    #
+    # ```yaml
+    # hosts:
+    #   - host: foo.bar
+    #     paths:
+    #       - /example
+    #       - /test
+    # ```
+    #
+    # @type: array<map>
     hosts: []
-    # - sslexample.foo.com
 
     # tls is a list of hosts and secret name in an Ingress
     # which tells the Ingress controller to secure the channel.
     # The value below is an array of objects, examples are shown below.
+    #
+    # ```yaml
+    # tls:
+    #   - hosts:
+    #     - host: chart-example.local
+    #       paths: []
+    #     secretName: testsecret-tls
+    # ```
+    # @type: array<map>
     tls: []
-      # - hosts:
-      #   - host: chart-example.local
-      #     paths: []
-      #   secretName: testsecret-tls
 
-    # This should be a multi-line string mapping directly to the a map of
-    # the annotations to configure some options depending on the Ingress controller
+    # Annotations to apply to the UI ingress.
+    #
+    # Example:
+    #
+    # ```yaml
+    # annotations: |
+    #   'annotation-key': annotation-value
+    # ```
+    # @type: string
     annotations: null
-    # |
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
 
 # Configure the catalog sync process to sync K8S with Consul
 # services. This can run bidirectional (default) or unidirectionally (Consul

--- a/values.yaml
+++ b/values.yaml
@@ -942,13 +942,16 @@ ui:
     additionalSpec: null
 
   # Configure Ingress for the Consul UI.
+  # If `global.tls.enabled` is set to `true`, the Ingress will expose
+  # the port 443 on the UI service. Please ensure the Ingress Controller
+  # supports SSL pass-through and it is enabled to ensure traffic forwarded
+  # to port 443 has not been TLS terminated.
   ingress:
     # This will create an Ingress resource for the Consul UI.
     # @type: boolean
     enabled: false
 
     # hosts is a list of host name to create Ingress rules.
-    # The value below is an array of objects, examples are shown below.
     #
     # ```yaml
     # hosts:
@@ -963,13 +966,11 @@ ui:
 
     # tls is a list of hosts and secret name in an Ingress
     # which tells the Ingress controller to secure the channel.
-    # The value below is an array of objects, examples are shown below.
     #
     # ```yaml
     # tls:
     #   - hosts:
-    #     - host: chart-example.local
-    #       paths: []
+    #     - chart-example.local
     #     secretName: testsecret-tls
     # ```
     # @type: array<map>

--- a/values.yaml
+++ b/values.yaml
@@ -955,12 +955,16 @@ ui:
     # The value below is an array of objects, examples are shown below.
     tls: []
       # - hosts:
-      #   - sslexample.foo.com
-    #   secretName: testsecret-tls
+      #   - host: chart-example.local
+      #     paths: []
+      #   secretName: testsecret-tls
 
     # This should be a multi-line string mapping directly to the a map of
     # the annotations to configure some options depending on the Ingress controller
     annotations: null
+    # |
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
 
 # Configure the catalog sync process to sync K8S with Consul
 # services. This can run bidirectional (default) or unidirectionally (Consul

--- a/values.yaml
+++ b/values.yaml
@@ -941,6 +941,27 @@ ui:
     # @type: string
     additionalSpec: null
 
+  ## True if you want to create an Ingress for the Consul UI.
+  ingress:
+    enabled: false
+
+    # hosts is a list of host name to create Ingress rules.
+    # The value below is an array of objects, examples are shown below.
+    hosts: []
+    # - sslexample.foo.com
+
+    # tls is a list of hosts and secret name in an Ingress
+    # which tells the Ingress controller to secure the channel.
+    # The value below is an array of objects, examples are shown below.
+    tls: []
+      # - hosts:
+      #   - sslexample.foo.com
+    #   secretName: testsecret-tls
+
+    # This should be a multi-line string mapping directly to the a map of
+    # the annotations to configure some options depending on the Ingress controller
+    annotations: null
+
 # Configure the catalog sync process to sync K8S with Consul
 # services. This can run bidirectional (default) or unidirectionally (Consul
 # to K8S or K8S to Consul only).


### PR DESCRIPTION
Changes proposed in this PR:
- Based on https://github.com/hashicorp/consul-helm/pull/130
- Added support to expose http port when `global.tls.enabled` is true and `global.tls.httpsOnly` is `false`.

The ingress resource always performs TLS termination at the point of ingress and can only communicate with the Consul server over the HTTP port. This can be avoided by certain ingress controllers that have the option of [allowing ssl pass-through](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough). Added a note to ensure that users have an ingress controller that can passthrough SSL and have it enabled if they want to enable TLS on Consul.

How I've tested this PR:
- Deployed an ingress controller on the kubernetes cluster (nginx).
- Performed a helm deploy with ingress enabled for UI. Verified the fields on the ingress resource created for non-TLS and TLS (with HTTP enabled) use cases and was able to access the UI via the created Ingress. (GKE creates a LoadBalancer for ingress)

How I expect reviewers to test this PR:
- Code review.


Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
- [x] PR submitted to update [consul.io Helm docs](https://www.consul.io/docs/k8s/helm) (see [Generating Helm Reference Docs](https://github.com/hashicorp/consul-helm/blob/master/CONTRIBUTING.md#generating-helm-reference-docs))
  - Link to PR: https://github.com/hashicorp/consul/pull/9612
