### PR TITLE
Fail if autoencrypt true but tls false

### DIFF
--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (and (not .Values.global.tls.enabled) .Values.global.tls.enableAutoEncrypt) }}{{ fail "if global.tls.enableAutoEncrypt is true, global.tls.enabled must also be true" }}{{ end -}}
 {{- if .Values.global.tls.enabled }}
 # tls-init job generate Consul cluster CA and certificates for the Consul servers
 # and creates Kubernetes secrets for them.

--- a/test/unit/tls-init-job.bats
+++ b/test/unit/tls-init-job.bats
@@ -104,3 +104,13 @@ load _helpers
   actual=$(echo $spec | jq -r '.containers[0].command | join(" ") | contains("consul tls ca create")' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "tlsInit/Job: fails if tls.autoEncryptEnabled is true but tls.enabled is false" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=false' \
+      --set 'global.tls.enableAutoEncrypt=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "if global.tls.enableAutoEncrypt is true, global.tls.enabled must also be true" ]]
+}


### PR DESCRIPTION
Give an error if a user enables autoencrypt but forgets to set
tls.enabled to true. This helps them notice a misconfiguration.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
- [ ] PR submitted to update [consul.io Helm docs](https://www.consul.io/docs/k8s/helm) (see [Generating Helm Reference Docs](https://github.com/hashicorp/consul-helm/blob/master/CONTRIBUTING.md#generating-helm-reference-docs))
  - Link to PR:
