### PR TITLE
Run acceptance tests against kind v1.19.4; add a nightly run for kind v1.20.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ jobs:
       - run:
           name: Create kind clusters
           command: |
-            kind create cluster --name dc1 --image kindest/node:v1.18.4
-            kind create cluster --name dc2 --image kindest/node:v1.18.4
+            kind create cluster --name dc1 --image kindest/node:v1.19.4
+            kind create cluster --name dc2 --image kindest/node:v1.19.4
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
@@ -467,6 +467,84 @@ jobs:
           fail_only: true
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
+  acceptance-kind-1-20:
+    environment:
+      - TEST_RESULTS: /tmp/test-results
+    machine:
+      image: ubuntu-2004:202010-01
+    parallelism: 6
+    steps:
+      - checkout
+      - run:
+          name: Install gotestsum, kind, kubectl, and helm
+          command: |
+            go get gotest.tools/gotestsum
+
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin/kind
+
+            curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x ./kubectl
+            sudo mv ./kubectl /usr/local/bin/kubectl
+
+            curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+            sudo apt-get install apt-transport-https --yes
+            echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+            sudo apt-get update
+            sudo apt-get install helm
+      - run:
+          name: Create kind clusters
+          command: |
+            kind create cluster --name dc1 --image kindest/node:v1.20.2
+            kind create cluster --name dc2 --image kindest/node:v1.20.2
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+      - run:
+          name: go mod download
+          working_directory: test/acceptance
+          command: go mod download
+      - save_cache:
+          key: consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+          paths:
+            - ~/.go_workspace/pkg/mod
+      - run: mkdir -p $TEST_RESULTS
+      - run:
+          name: Run acceptance tests
+          working_directory: test/acceptance/tests
+          no_output_timeout: 1h
+          command: |
+            # We have to run the tests for each package separately so that we can
+            # exit early if any test fails (-failfast only works within a single
+            # package).
+            exit_code=0
+            pkgs=$(go list ./... | circleci tests split)
+            echo "Running $pkgs"
+            for pkg in $pkgs
+            do
+              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 30m -failfast \
+                    -use-kind \
+                    -enable-multi-cluster \
+                    -enable-enterprise \
+                    -kubecontext="kind-dc1" \
+                    -secondary-kubecontext="kind-dc2" \
+                    -debug-directory="$TEST_RESULTS/debug" \
+                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              then
+                echo "Tests in ${pkg} failed, aborting early"
+                exit_code=1
+                break
+              fi
+            done
+            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
+            exit $exit_code
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
   go-fmt-and-vet-helm-gen:
     executor: go
     steps:
@@ -593,6 +671,7 @@ workflows:
             - unit-helm2
             - unit-helm3
             - unit-acceptance-framework
+      - acceptance-kind-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,6 +546,9 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
+      - slack/status:
+          fail_only: true
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   go-fmt-and-vet-helm-gen:
     executor: go
@@ -673,7 +676,6 @@ workflows:
             - unit-helm2
             - unit-helm3
             - unit-acceptance-framework
-      - acceptance-kind-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:
@@ -687,6 +689,7 @@ workflows:
       - acceptance-gke-1-16
       - acceptance-eks-1-17
       - acceptance-aks-1-18
+      - acceptance-kind-1-20
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     machine:
       image: ubuntu-2004:202010-01
+    resource_class: xlarge
     parallelism: 6
     steps:
       - checkout
@@ -472,6 +473,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     machine:
       image: ubuntu-2004:202010-01
+    resource_class: xlarge
     parallelism: 6
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,30 +517,14 @@ jobs:
           working_directory: test/acceptance/tests
           no_output_timeout: 1h
           command: |
-            # We have to run the tests for each package separately so that we can
-            # exit early if any test fails (-failfast only works within a single
-            # package).
-            exit_code=0
-            pkgs=$(go list ./... | circleci tests split)
-            echo "Running $pkgs"
-            for pkg in $pkgs
-            do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 30m -failfast \
-                    -use-kind \
-                    -enable-multi-cluster \
-                    -enable-enterprise \
-                    -kubecontext="kind-dc1" \
-                    -secondary-kubecontext="kind-dc2" \
-                    -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
-              then
-                echo "Tests in ${pkg} failed, aborting early"
-                exit_code=1
-                break
-              fi
-            done
-            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
-            exit $exit_code
+            gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- ./... -p 1 -timeout 30m -failfast \
+              -use-kind \
+              -enable-multi-cluster \
+              -enable-enterprise \
+              -kubecontext="kind-dc1" \
+              -secondary-kubecontext="kind-dc2" \
+              -debug-directory="$TEST_RESULTS/debug" \
+              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results


### PR DESCRIPTION
Since we've switched AKS to run against 1.18, we no longer have tests running with k8s v1.19. 

This PR changes the` acceptance` job to run against kind with k8s image v1.19.4 instead of v1.18.4. It also adds a nightly run for acceptance tests against kind with image v1.20.2

Additionally, change `resource_class` for our machines to be `xlarge` (8 CPUs and 32G of RAM) in an attempt to fix some [flaky](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2253/workflows/07dea919-035a-4fd1-9906-09e35be05c4b/jobs/6982) tests. Previously we were using 2CPU and 4G of RAM.

Passing tests against kind+k8s v1.20 is [here](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2337/workflows/73cdc30e-6a3b-4d76-93d3-50491e2e3219/jobs/7536).
