### PR TITLE
Add controller.aclToken 

### DIFF
--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -83,6 +83,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        {{- if (and .Values.controller.aclToken.secretName .Values.controller.aclToken.secretKey) }}
+        - name: CONSUL_HTTP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.controller.aclToken.secretName }}
+              key: {{ .Values.controller.aclToken.secretKey }}
+        {{- end }}
         {{- if .Values.global.acls.manageSystemACLs }}
         - name: CONSUL_HTTP_TOKEN
           valueFrom:

--- a/test/unit/controller-deployment.bats
+++ b/test/unit/controller-deployment.bats
@@ -444,3 +444,40 @@ load _helpers
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
 }
+
+#--------------------------------------------------------------------
+# aclToken
+
+@test "controller/Deployment: aclToken disabled when secretName is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'controller.aclToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "controller/Deployment: aclToken disabled when secretKey is missing" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'controller.aclToken.secretName=foo' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "controller/Deployment: aclToken enabled when secretName and secretKey is provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'controller.aclToken.secretName=foo' \
+      --set 'controller.aclToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1496,11 +1496,24 @@ controller:
 
   # Refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which grants the controller process the correct
-  # permissions. This is only needed if ACLs are enabled on the Consul cluster.
+  # permissions. This is only needed if you are managing ACLs yourself (i.e. not using
+  # `global.acls.manageSystemACLs`).
+  #
+  # If running Consul OSS, requires permissions:
+  # ```hcl
+  # operator = "write"
+  # service_prefix "" {
+  #   policy = "write"
+  #   intentions = "write"
+  # }
+  # ```
+  # If running Consul Enterprise, talk to your account manager for assistance.
   aclToken:
     # The name of the Kubernetes secret.
+    # @type: string
     secretName: null
     # The key of the Kubernetes secret.
+    # @type: string
     secretKey: null
 
 # Mesh Gateways enable Consul Connect to work across Consul datacenters.

--- a/values.yaml
+++ b/values.yaml
@@ -1494,6 +1494,15 @@ controller:
   # Optional priorityClassName.
   priorityClassName: ""
 
+  # Refers to a Kubernetes secret that you have created that contains
+  # an ACL token for your Consul cluster which grants the controller process the correct
+  # permissions. This is only needed if ACLs are enabled on the Consul cluster.
+  aclToken:
+    # The name of the Kubernetes secret.
+    secretName: null
+    # The key of the Kubernetes secret.
+    secretKey: null
+
 # Mesh Gateways enable Consul Connect to work across Consul datacenters.
 meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs


### PR DESCRIPTION
Adds optional `controller.aclToken`.
Provide a pre-existing kubernetes secret with an ACL token for the controller deployment

Closes #778
