### PR TITLE
Provide a deterministic host-based node ID for the Consul clients.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ BUG FIXES:
 * Use `rbac.authorization.k8s.io/v1` instead of `rbac.authorization.k8s.io/v1beta1` API version for the `roles` and `rolebindings` used by the `tls-init`
   and `tls-init-cleanup` jobs. [[GH-789](https://github.com/hashicorp/consul-helm/issues/789)]
 * Fix API version of Ingress resource for Consul UI. [[GH-786](https://github.com/hashicorp/consul-helm/pull/786)]
+* Provide a deterministic host-based node ID for the Consul clients to fix an error when a client is terminated without a graceful shutdown.
+  [[GH-791](https://github.com/hashicorp/consul-helm/pull/791)]
 
 ## 0.29.0 (Jan 22, 2021)
 

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -177,6 +177,7 @@ spec:
                 -client=0.0.0.0 \
                 -node-meta=pod-name:${HOSTNAME} \
                 -hcl='leave_on_terminate = true' \
+                -disable-host-node-id=false \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
                 {{- if .Values.global.tls.enableAutoEncrypt }}


### PR DESCRIPTION
Currently, Consul clients will generate a random UUID every time they start.
This works in most situations because typically Consul clients will leave
the cluster gracefully. However, if the haven't left gracefully, for example,
when Kubernetes force kills the pod due to OOM errors, then this leaves
the cluster in an unhealthy state, with other members showing conflicting
node ID errors.

This proposed change will ensure that a client restarting on the same kube worker
will always have the same node-id.

How I've tested this PR:
- Install the current version of the helm chart (i.e w/o this change)
- Force deleted a client pod and saw errors in consul servers saying:
  ```
      2021-01-27T00:12:51.732Z [WARN]  agent.fsm: EnsureRegistration failed: error="failed inserting node: Error while renaming Node ID: "afa5d55b-ea34-cd37-176f-b24447c850b5": Node name gke-shustava-default-pool-bad0f39a-f890 is reserved by node 7df16f21-b493-a066-f0cb-261a81cba524 with name gke-shustava-default-pool-bad0f39a-f890 (10.24.2.32)"
  ```
- Upgraded to this version, repeated the step above and did not see the same errors appear in the logs.

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
