### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,4 @@ How I expect reviewers to test this PR:
 Checklist:
 - [ ] Bats tests added
 - [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
-- [ ] PR submitted to update [consul.io Helm docs](https://www.consul.io/docs/k8s/helm) (see [Generating Helm Reference Docs](https://github.com/hashicorp/consul-helm/blob/master/CONTRIBUTING.md#generating-helm-reference-docs))
-  - Link to PR:
+


### PR DESCRIPTION
No longer require to submit docs PRs on every pull request. It's better if we do it right before a release because we can't merge those PRs until we release anyway.
