### PR TITLE
add several hostPort customizations

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -157,7 +157,7 @@ spec:
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://localhost:8501
+              value: https://localhost:{{ .Values.client.ports.https.port }}
             {{- if .Values.global.tls.enableAutoEncrypt }}
             - name: CONSUL_HTTP_SSL_VERIFY
               value: "false"
@@ -181,6 +181,7 @@ spec:
                 -node-meta=pod-name:${HOSTNAME} \
                 -hcl='leave_on_terminate = true' \
                 -disable-host-node-id=false \
+                -hcl='ports { http = {{ .Values.client.ports.http.port }} }' \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
                 {{- if .Values.global.tls.enableAutoEncrypt }}
@@ -197,13 +198,13 @@ spec:
                 -hcl='verify_server_hostname = true' \
                 {{- end }}
                 {{- end }}
-                -hcl='ports { https = 8501 }' \
+                -hcl='ports { https = {{ .Values.client.ports.https.port }} }' \
                 {{- if .Values.global.tls.httpsOnly }}
                 -hcl='ports { http = -1 }' \
                 {{- end }}
                 {{- end }}
                 {{- if .Values.client.grpc }}
-                -hcl='ports { grpc = 8502 }' \
+                -hcl='ports { grpc = {{ .Values.client.ports.grpc.port }} }' \
                 {{- end }}
                 -config-dir=/consul/config \
                 {{- if .Values.global.acls.manageSystemACLs }}
@@ -261,27 +262,29 @@ spec:
             {{- end }}
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
-            - containerPort: 8500
-              hostPort: 8500
+            - containerPort: {{ .Values.client.ports.http.port }}
+              hostPort: {{ .Values.client.ports.http.port }}
               name: http
             {{- end }}
             {{- if .Values.global.tls.enabled }}
-            - containerPort: 8501
-              hostPort: 8501
+            - containerPort: {{ .Values.client.ports.https.port }}
+              hostPort: {{ .Values.client.ports.https.port }}
               name: https
             {{- end }}
-            - containerPort: 8502
-              hostPort: 8502
+            {{- if .Values.client.grpc }}
+            - containerPort: {{ .Values.client.ports.grpc.port }}
+              hostPort: {{ .Values.client.ports.grpc.port }}
               name: grpc
-            - containerPort: 8301
+            {{- end }}
+            - containerPort: {{ .Values.client.ports.gossip.port }}
               {{- if .Values.client.exposeGossipPorts }}
-              hostPort: 8301
+              hostPort: {{ .Values.client.ports.gossip.port }}
               {{- end }}
               protocol: "TCP"
               name: serflan-tcp
-            - containerPort: 8301
+            - containerPort: {{ .Values.client.ports.gossip.port }}
               {{- if .Values.client.exposeGossipPorts }}
-              hostPort: 8301
+              hostPort: {{ .Values.client.ports.gossip.port }}
               {{- end }}
               protocol: "UDP"
               name: serflan-udp
@@ -302,9 +305,9 @@ spec:
                   {{- if .Values.global.tls.enabled }}
                   curl \
                     -k \
-                    https://127.0.0.1:8501/v1/status/leader \
+                    https://127.0.0.1:{{ .Values.client.ports.https.port }}/v1/status/leader \
                   {{- else }}
-                  curl http://127.0.0.1:8500/v1/status/leader \
+                  curl http://127.0.0.1:{{ .Values.client.ports.http.port }}/v1/status/leader \
                   {{- end }}
                   2>/dev/null | grep -E '".+"'
           {{- if .Values.client.resources }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -56,8 +56,8 @@ spec:
       port: 8302
       targetPort: 8302
     - name: server
-      port: 8300
-      targetPort: 8300
+      port: {{ .Values.server.ports.gossipAndRPC.port }}
+      targetPort: {{ .Values.server.ports.gossipAndRPC.port }}
     - name: dns-tcp
       protocol: "TCP"
       port: 8600

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -41,20 +41,20 @@ spec:
     {{- end }}
     - name: serflan-tcp
       protocol: "TCP"
-      port: 8301
-      targetPort: 8301
+      port: {{ .Values.server.ports.serflan.port }}
+      targetPort: {{ .Values.server.ports.serflan.port }}
     - name: serflan-udp
       protocol: "UDP"
-      port: 8301
-      targetPort: 8301
+      port: {{ .Values.server.ports.serflan.port }}
+      targetPort: {{ .Values.server.ports.serflan.port }}
     - name: serfwan-tcp
       protocol: "TCP"
-      port: 8302
-      targetPort: 8302
+      port: {{ .Values.server.ports.serfwan.port }}
+      targetPort: {{ .Values.server.ports.serfwan.port }}
     - name: serfwan-udp
       protocol: "UDP"
-      port: 8302
-      targetPort: 8302
+      port: {{ .Values.server.ports.serfwan.port }}
+      targetPort: {{ .Values.server.ports.serfwan.port }}
     - name: server
       port: {{ .Values.server.ports.gossipAndRPC.port }}
       targetPort: {{ .Values.server.ports.gossipAndRPC.port }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -207,6 +207,7 @@ spec:
                 -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:{{ $serverSerfLANPort }}" \
                 {{- end }}
                 -serf-lan-port={{ .Values.server.ports.serflan.port }} \
+                -serf-wan-port={{ .Values.server.ports.serfwan.port }} \
                 -server \
                 -server-port={{ .Values.server.ports.gossipAndRPC.port }}
           volumeMounts:
@@ -248,8 +249,11 @@ spec:
               {{- end }}
               protocol: "UDP"
               name: serflan-udp
-            - containerPort: 8302
+            - containerPort: {{ .Values.server.ports.serfwan.port }}
               name: serfwan
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: {{ .Values.server.ports.serfwan.port }}
+              {{- end }}
             - containerPort: {{ .Values.server.ports.gossipAndRPC.port }}
               {{- if .Values.server.exposeGossipAndRPCPorts }}
               hostPort: {{ .Values.server.ports.gossipAndRPC.port }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -207,7 +207,8 @@ spec:
                 -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:{{ $serverSerfLANPort }}" \
                 {{- end }}
                 -serf-lan-port={{ .Values.server.ports.serflan.port }} \
-                -server
+                -server \
+                -server-port={{ .Values.server.ports.gossipAndRPC.port }}
           volumeMounts:
             - name: data-{{ .Release.Namespace }}
               mountPath: /consul/data
@@ -249,9 +250,9 @@ spec:
               name: serflan-udp
             - containerPort: 8302
               name: serfwan
-            - containerPort: 8300
+            - containerPort: {{ .Values.server.ports.gossipAndRPC.port }}
               {{- if .Values.server.exposeGossipAndRPCPorts }}
-              hostPort: 8300
+              hostPort: {{ .Values.server.ports.gossipAndRPC.port }}
               {{- end }}
               name: server
             - containerPort: 8600

--- a/values.yaml
+++ b/values.yaml
@@ -320,6 +320,9 @@ server:
     serflan:
       port: 8301
 
+    serfwan:
+      port: 8302
+
     gossipAndRPC:
       port: 8300
 

--- a/values.yaml
+++ b/values.yaml
@@ -173,7 +173,6 @@ global:
 
   # Configure ACLs.
   acls:
-
     # If true, the Helm chart will automatically manage ACL tokens and policies
     # for all Consul and consul-k8s components.
     # This requires Consul >= 1.4 and consul-k8s >= 0.14.0.
@@ -259,7 +258,6 @@ global:
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.
 server:
-
   # If true, the chart will install all the resources necessary for a
   # Consul server cluster. If you're running Consul externally and want agents
   # within Kubernetes to join that cluster, this should probably be false.
@@ -321,6 +319,9 @@ server:
     # the consul server Pods.
     serflan:
       port: 8301
+
+    gossipAndRPC:
+      port: 8300
 
   # This defines the disk size for configuring the
   # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
@@ -881,6 +882,16 @@ client:
     # ```
     # @type: string
     caCert: null
+
+  ports:
+    http:
+      port: 8500
+    https:
+      port: 8501
+    gossip:
+      port: 8301
+    grpc:
+      port: 8302
 
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)


### PR DESCRIPTION
I'm not sure yet which of these should be fully-customizable and which should just be customizable by hostPort, you know?

While I'm here, should I just make every port customizable across the board?

Changes proposed in this PR:
- Add the ability to customize several ports, enabling the ability to 
- Fixes https://github.com/hashicorp/consul-helm/issues/803

How I've tested this PR:

* Used it to install multiple Consuls on the same cluster

How I expect reviewers to test this PR:

* Use it to install multiple Consuls on the same cluster

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

