### PR TITLE
Add pod IP to IP SANS of client certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ BREAKING CHANGES:
 IMPROVEMENTS:
 * Add ability to set extra labels on Consul client pods. [[GH-612](https://github.com/hashicorp/consul-helm/pull/612)]
 * CRDs: add value `controller.aclToken` to support manually passing in an ACL token to the CRD controller if independently managing ACLs. [[GH-783](https://github.com/hashicorp/consul-helm/pull/783)]
+* TLS: Consul client certificates now include their pod IPs in the IP SANs. This applies to auto-encrypt enabled and disabled. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
+* Consul client nodes have a new meta key called "host-ip" set to the IP of the Kubernetes node they're running on. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
 
 BUG FIXES:
 * Use `rbac.authorization.k8s.io/v1` instead of `rbac.authorization.k8s.io/v1beta1` API version for the `roles` and `rolebindings` used by the `tls-init`

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -148,6 +148,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
             - name: GOSSIP_KEY
               valueFrom:
@@ -179,13 +183,14 @@ spec:
                 -bind=0.0.0.0 \
                 -client=0.0.0.0 \
                 -node-meta=pod-name:${HOSTNAME} \
+                -node-meta=host-ip:${HOST_IP} \
                 -hcl='leave_on_terminate = true' \
                 -disable-host-node-id=false \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
                 {{- if .Values.global.tls.enableAutoEncrypt }}
                 -hcl='auto_encrypt = {tls = true}' \
-                -hcl="auto_encrypt = {ip_san = [\"$HOST_IP\"]}" \
+                -hcl="auto_encrypt = {ip_san = [\"$HOST_IP\",\"$POD_IP\"]}" \
                 {{- else }}
                 -hcl='cert_file = "/consul/tls/client/tls.crt"' \
                 -hcl='key_file = "/consul/tls/client/tls.key"' \
@@ -347,6 +352,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         command:
           - "/bin/sh"
           - "-ec"
@@ -354,6 +363,7 @@ spec:
             cd /consul/tls/client
             consul tls cert create -client \
               -additional-ipaddress=${HOST_IP} \
+              -additional-ipaddress=${POD_IP} \
               -dc={{ .Values.global.datacenter }} \
               -domain={{ .Values.global.domain }} \
               -ca=/consul/tls/ca/cert/tls.crt \

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -813,7 +813,7 @@ load _helpers
   [ "${actual}" == "true" ]
 
   # sets IP SANs to contain the HOST IP of the client
-  actual=$(echo $command | jq -r '. | contains("auto_encrypt = {ip_san = [\\\"$HOST_IP\\\"]}")' | tee /dev/stderr)
+  actual=$(echo $command | jq -r '. | contains("auto_encrypt = {ip_san = [\\\"$HOST_IP\\\",\\\"$POD_IP\\\"]}")' | tee /dev/stderr)
   [ "${actual}" == "true" ]
 
   # doesn't set verify_incoming_rpc and verify_server_hostname


### PR DESCRIPTION
* So cert is valid if calling client via pod IP rather than host IP.
* Also add the host IP as a meta value to the client agent since this
information is not available through Consul right now.

How I've tested this PR:
* As part of pod deregistration. I got cert errors and then using this branch I did not.

How I expect reviewers to test this PR:
* Can test manually by bringing up consul with/without autoencrypt and using openssl to view the certs or you can trust the config

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

