### PR TITLE
Cleanup controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+                    -consul-k8s-image=ghcr.io/lkysow/consul-k8s-dev:feb09
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=ghcr.io/lkysow/consul-k8s-dev:feb09
+                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ IMPROVEMENTS:
 * CRDs: add value `controller.aclToken` to support manually passing in an ACL token to the CRD controller if independently managing ACLs. [[GH-783](https://github.com/hashicorp/consul-helm/pull/783)]
 * TLS: Consul client certificates now include their pod IPs in the IP SANs. This applies to auto-encrypt enabled and disabled. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
 * Consul client nodes have a new meta key called "host-ip" set to the IP of the Kubernetes node they're running on. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
-* Connect: the latest version of consul-k8s cleans up Consul service instances whose pods are no longer running.
+* Connect: the latest version of consul-k8s cleans up Consul connect service mesh instances whose pods are no longer running.
   This could happen if the pod's `preStop` hook failed to execute for some reason. [[GH-806](https://github.com/hashicorp/consul-helm/pull/806)]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ IMPROVEMENTS:
 * CRDs: add value `controller.aclToken` to support manually passing in an ACL token to the CRD controller if independently managing ACLs. [[GH-783](https://github.com/hashicorp/consul-helm/pull/783)]
 * TLS: Consul client certificates now include their pod IPs in the IP SANs. This applies to auto-encrypt enabled and disabled. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
 * Consul client nodes have a new meta key called "host-ip" set to the IP of the Kubernetes node they're running on. [[GH-805](https://github.com/hashicorp/consul-helm/pull/805)]
+* Connect: the latest version of consul-k8s cleans up Consul service instances whose pods are no longer running.
+  This could happen if the pod's `preStop` hook failed to execute for some reason. [[GH-806](https://github.com/hashicorp/consul-helm/pull/806)]
 
 BUG FIXES:
 * Use `rbac.authorization.k8s.io/v1` instead of `rbac.authorization.k8s.io/v1beta1` API version for the `roles` and `rolebindings` used by the `tls-init`

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -17,14 +17,12 @@ rules:
     - "list"
     - "watch"
     - "patch"
-{{- if .Values.connectInject.healthChecks.enabled }}
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs:
     - "get"
     - "list"
     - "watch"
-{{- end}}
 {{- if .Values.global.enablePodSecurityPolicies }}
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]
@@ -33,7 +31,7 @@ rules:
   verbs:
   - use
 {{- end }}
-{{- if and .Values.global.acls.manageSystemACLs (or .Values.global.enableConsulNamespaces .Values.connectInject.healthChecks.enabled) }}
+{{- if .Values.global.acls.manageSystemACLs }}
 - apiGroups: [""]
   resources:
     - secrets

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -51,9 +51,6 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
-            {{- /* A Consul client and ACL token is necessary for the connect injector if namespaces are enabled
-              or if healthChecks enabled */}}
-            {{- if (or .Values.global.enableConsulNamespaces .Values.connectInject.healthChecks.enabled) }}
             - name: HOST_IP
               valueFrom:
                 fieldRef:
@@ -77,7 +74,6 @@ spec:
               {{- else }}
               value: http://$(HOST_IP):8500
               {{- end }}
-            {{- end }}
           command:
             - "/bin/sh"
             - "-ec"
@@ -97,6 +93,7 @@ spec:
                 -enable-health-checks-controller=true \
                 -health-checks-reconcile-period={{ .Values.connectInject.healthChecks.reconcilePeriod }} \
                 {{- end }}
+                -cleanup-controller-reconcile-period={{ .Values.connectInject.cleanupController.reconcilePeriod }} \
                 {{- if .Values.connectInject.envoyExtraArgs }}
                 -envoy-extra-args="{{ .Values.connectInject.envoyExtraArgs }}" \
                 {{- end }}
@@ -247,9 +244,9 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if or (and .Values.global.acls.manageSystemACLs (or .Values.global.enableConsulNamespaces .Values.connectInject.healthChecks.enabled)) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or (and .Values.global.acls.manageSystemACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
-      {{- if (and .Values.global.acls.manageSystemACLs (or .Values.global.enableConsulNamespaces .Values.connectInject.healthChecks.enabled)) }}
+      {{- if .Values.global.acls.manageSystemACLs }}
       - name: injector-acl-init
         image: {{ .Values.global.imageK8S }}
         command:

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -44,7 +44,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 
 		var notReadyPods []string
 		for _, pod := range pods.Items {
-			if !isReady(pod) {
+			if !IsReady(pod) {
 				notReadyPods = append(notReadyPods, pod.Name)
 			}
 		}
@@ -126,8 +126,8 @@ func KubernetesContextFromOptions(t *testing.T, options *terratestk8s.KubectlOpt
 	return rawConfig.CurrentContext
 }
 
-// isReady returns true if pod is ready.
-func isReady(pod corev1.Pod) bool {
+// IsReady returns true if pod is ready.
+func IsReady(pod corev1.Pod) bool {
 	if len(pod.Status.ContainerStatuses) == 0 {
 		return false
 	}

--- a/test/acceptance/tests/connect/connect_inject_test.go
+++ b/test/acceptance/tests/connect/connect_inject_test.go
@@ -1,8 +1,10 @@
 package connect
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/consul"
@@ -10,7 +12,9 @@ import (
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/logger"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const staticClientName = "static-client"
@@ -85,6 +89,91 @@ func TestConnectInject(t *testing.T) {
 				staticClientName,
 				[]string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"},
 				"http://localhost:1234")
+		})
+	}
+}
+
+// Test the cleanup controller that cleans up force-killed pods.
+func TestConnectInject_CleanupController(t *testing.T) {
+	cases := []struct {
+		secure      bool
+		autoEncrypt bool
+	}{
+		{false, false},
+		{true, false},
+		{true, true},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("secure: %t; auto-encrypt: %t", c.secure, c.autoEncrypt)
+		t.Run(name, func(t *testing.T) {
+			cfg := suite.Config()
+			ctx := suite.Environment().DefaultContext(t)
+
+			helmValues := map[string]string{
+				"connectInject.enabled":        "true",
+				"global.tls.enabled":           strconv.FormatBool(c.secure),
+				"global.tls.enableAutoEncrypt": strconv.FormatBool(c.autoEncrypt),
+				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
+			}
+
+			releaseName := helpers.RandomName()
+			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
+
+			consulCluster.Create(t)
+
+			logger.Log(t, "creating static-client deployment")
+			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
+
+			logger.Log(t, "waiting for static-client to be registered with Consul")
+			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			retry.Run(t, func(r *retry.R) {
+				for _, name := range []string{"static-client", "static-client-sidecar-proxy"} {
+					instances, _, err := consulClient.Catalog().Service(name, "", nil)
+					r.Check(err)
+
+					if len(instances) != 1 {
+						r.Errorf("expected 1 instance of %s", name)
+					}
+				}
+			})
+
+			ns := ctx.KubectlOptions(t).Namespace
+			pods, err := ctx.KubernetesClient(t).CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: "app=static-client"})
+			require.NoError(t, err)
+
+			// There should only be one pod because we set replicas to 1 but
+			// in some cases, the previous test's static-client pod is still
+			// terminating so we filter by ready pods.
+			var podName string
+			for _, pod := range pods.Items {
+				if helpers.IsReady(pod) {
+					podName = pod.Name
+					break
+				}
+			}
+			if podName == "" {
+				t.Errorf("no ready static-client pods: pods=%#v", pods)
+			}
+
+			logger.Logf(t, "force killing the static-client pod %q", podName)
+			var gracePeriod int64 = 0
+			err = ctx.KubernetesClient(t).CoreV1().Pods(ns).Delete(context.Background(), podName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+			require.NoError(t, err)
+
+			logger.Log(t, "ensuring pod is deregistered")
+			retry.Run(t, func(r *retry.R) {
+				for _, name := range []string{"static-client", "static-client-sidecar-proxy"} {
+					instances, _, err := consulClient.Catalog().Service(name, "", nil)
+					r.Check(err)
+
+					for _, instance := range instances {
+						if strings.Contains(instance.ServiceID, podName) {
+							r.Errorf("%s is still registered", instance.ServiceID)
+						}
+					}
+				}
+			})
 		})
 	}
 }

--- a/test/unit/connect-inject-clusterrole.bats
+++ b/test/unit/connect-inject-clusterrole.bats
@@ -74,21 +74,9 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.acls.manageSystemACLs for namespaces
+# global.acls.manageSystemACLs
 
-@test "connectInject/ClusterRole: does not allow secret access with global.bootsrapACLs=true and healthChecks.enabled=false" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=false' \
-      --set 'global.acls.manageSystemACLs=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
-}
-
-@test "connectInject/ClusterRole: secret access with global.bootsrapACLs=true and healthChecks enabled by default" {
+@test "connectInject/ClusterRole: secret access with global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/connect-inject-clusterrole.yaml  \
@@ -97,87 +85,4 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: allow secret access with global.bootsrapACLs=true and global.enableConsulNamespaces=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.enableConsulNamespaces=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: allows secret access with bootsrapACLs, enablePodSecurityPolicies and enableConsulNamespaces all true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.enablePodSecurityPolicies=true' \
-      --set 'global.enableConsulNamespaces=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: pod resource permission set when health checks are enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "pods")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: no pod resource permission set when health checks are disabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=false' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "pods")) | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
-}
-
-@test "connectInject/ClusterRole: allows secret access with healthChecks and manageSystemACLs, no consulNamespaces" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: allows secret access with healthChecks, ACLs and consulNamespaces" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.enableConsulNamespaces=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "connectInject/ClusterRole: no secret access with healthChecks, and no ACLs" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.healthChecks.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resources[0] == "secrets")) | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1227,6 +1227,17 @@ connectInject:
     # reconcile is done after the initial reconcile at startup is completed.
     reconcilePeriod: "1m"
 
+  # Cleanup controller cleans up Consul service instances that remain registered
+  # despite their pods no longer running. This could happen if the pod's `preStop`
+  # hook failed to execute for some reason.
+  cleanupController:
+    # How often to do a full reconcile where the controller looks at all pods
+    # and service instances and ensure the state is correct.
+    # The controller reacts to each delete event immediately but if it misses
+    # an event due to being down or a network issue, the reconcile loop will
+    # handle cleaning up any missed deleted pods.
+    reconcilePeriod: "5m"
+
   # Used to pass arguments to the injected envoy sidecar.
   # Valid arguments to pass to envoy can be found here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli
   # e.g "--log-level debug --disable-hot-restart"


### PR DESCRIPTION
Support cleanup controller that cleans up Consul service instances from
deleted pods.

Part of https://github.com/hashicorp/consul-k8s/pull/433

How I've tested this PR: Acceptance tests

How I expect reviewers to test this PR:
* Force delete pod, see that the service instance is removed
* To test reconcile, can register a service via API directly and ensure it's removed

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

