### PR TITLE
Drop support for Helm 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,27 +9,16 @@ executors:
       - TEST_RESULTS: /tmp/test-results
 
 jobs:
-  unit-helm2:
+  unit-helm:
     docker:
-      # This image is built from test/docker/Test.dockerfile
-      # helm2 must use 0.3.0 version of the image
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.3.0
-
-    steps:
-      - checkout
-      - run:
-          name: Run Unit Tests
-          command: bats ./test/unit
-  unit-helm3:
-    docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.1
 
     steps:
       - checkout
 
       - run:
           name: Run Unit Tests
-          command: bats ./test/unit
+          command: bats --jobs 4 ./test/unit
 
   go-fmt-and-vet-acceptance:
     executor: go
@@ -652,12 +641,10 @@ workflows:
           requires:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
-      - unit-helm2
-      - unit-helm3
+      - unit-helm
       - acceptance:
           requires:
-            - unit-helm2
-            - unit-helm3
+            - unit-helm
             - unit-acceptance-framework
   nightly-acceptance-tests:
     triggers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BREAKING CHANGES:
 * Ingress Gateways: when running on platforms that use hostnames instead of IPs for LoadBalancers (e.g. EKS)
   the hostname will now be used as the address of the ingress gateway. Previously the first IP was
   used, however, the IP could be recycled or go stale whereas the hostname will always work. [[GH-813](https://github.com/hashicorp/consul-helm/pull/813]
+* Helm 2 is no longer supported. It may still work, however the chart is no longer unit tested against Helm 2. [[GH-807](https://github.com/hashicorp/consul-helm/pull/807)]
 
 IMPROVEMENTS:
 * Add ability to set extra labels on Consul client pods. [[GH-612](https://github.com/hashicorp/consul-helm/pull/612)]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
   ```bash
   brew install python-yq
   ```
-* [helm](https://helm.sh)
+* [Helm 3](https://helm.sh) (Helm 2 is not supported)
   ```bash
   brew install kubernetes-helm
   ```
@@ -37,22 +37,6 @@ The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
   ```bash
   brew install golang
   ```
-
-### Helm 2/3
-These tests will work with both Helm 2 and 3 if run through `bats`, e.g. `bats ./test/unit`. If copying the
-test command and running yourself, e.g.
-```sh
-helm template \
-  -s templates/sync-catalog-deployment.yaml  \
-  --set 'syncCatalog.enabled=true' \
-  --set 'syncCatalog.toConsul=false' \
-  .
-```
-It's expected that the version of `helm` in your path is Helm 3.
-
-In our CI/CD the tests are run against both Helm 2 and Helm 3.
-
-**Note:** Acceptance tests require Helm 3.
 
 ### Running The Tests
 
@@ -245,7 +229,7 @@ Here are some examples of common test patterns:
           . 
     }
     ```
-    Here we are using the `assert_empty` helper command that works with both Helm 2 and 3.
+    Here we are using the `assert_empty` helper command.
     
 ### Writing Acceptance Tests
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use Consul with Kubernetes, please see the
 [Consul and Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html).
 
 ## Prerequisites
-  * **Helm 2.10+ or Helm 3.0+**
+  * **Helm 3.0+** (Helm 2 is not supported)
   * **Kubernetes 1.9+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -9,12 +9,7 @@ https://www.consul.io/docs/platform/k8s/index.html
 
 Your release is named {{ .Release.Name }}.
 
-To learn more about the release if you are using Helm 2, run:
-
-  $ helm status {{ .Release.Name }}
-  $ helm get {{ .Release.Name }}
-
-To learn more about the release if you are using Helm 3, run:
+To learn more about the release, run:
 
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -11,7 +11,7 @@ FROM circleci/golang:1.14
 # change the user to root so we can install stuff
 USER root
 
-ENV BATS_VERSION "1.1.0"
+ENV BATS_VERSION "1.2.1"
 ENV TERRAFORM_VERSION "0.13.5"
 
 # base packages

--- a/test/unit/_helpers.bash
+++ b/test/unit/_helpers.bash
@@ -3,40 +3,10 @@ chart_dir() {
     echo ${BATS_TEST_DIRNAME}/../..
 }
 
-# helm is used to intercept the `helm` command in tests and change flags depending
-# on which version is being run.
-# Helm 2 uses the -x flag instead of -s.
-# NOTE: command is used so that this function isn't called recursively.
-helm() {
-  if [[ $(v2) ]]; then
-    command helm template -x "${@:3}"
-  else
-    # The release name in Helm 3 defaults to RELEASE-NAME whereas it's lowercaes
-    # in Helm 3 so we need to set it explictly.
-    command helm template release-name -s "${@:3}"
-  fi
-}
-
 # Usage: assert_empty helm template -s <template> [flags] .
-# assert_empty makes it possible to test that a template is not rendered in
-# both Helm 2 and 3.
+# assert_empty makes it possible to test that a template is not rendered.
 assert_empty() {
-  if [[ $(v2) ]]; then
-      local actual=$(command helm template \
-          -x "${@:4}"  \
-          . | tee /dev/stderr |
-          yq 'length > 0' | tee /dev/stderr)
-    [ "${actual}" = "false" ]
-  else
-      run command helm "${@:2}"
-      [ "$status" -eq 1 ]
-      [[ "$output" =~ "Error: could not find template" ]]
-  fi
-}
-
-# v2 outputs "1" if running Helm 2, otherwise it outputs nothing.
-v2() {
-  if [[ $(command helm version --short -c) =~ "v2" ]]; then
-    echo 1
-  fi
+    run helm "${@:2}"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error: could not find template" ]]
 }

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -433,11 +433,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = 79e3ac58b3bbfec6ef27d39e3e0f25e7dab63b5cc76d15f4935f308c94a5ff11 ]
-  else
-    [ "${actual}" = db1cb14f20d2a2f9fe0b3a1f5a65446a32126faeeadf3813f9fe610ba8ee549b ]
-  fi
+  [ "${actual}" = db1cb14f20d2a2f9fe0b3a1f5a65446a32126faeeadf3813f9fe610ba8ee549b ]
 }
 
 @test "client/DaemonSet: adds config-checksum annotation when extraConfig is provided" {
@@ -447,11 +443,7 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = f3d2e7d13e5ef853ae79b8c528b263022e2e2f7689aa4b490393f14128a389eb ]
-  else
-    [ "${actual}" = 4e3576ef3ecf806b27906771411df25ff9fe5cc30ea20ea02f7890de944ecd32 ]
-  fi
+  [ "${actual}" = 4e3576ef3ecf806b27906771411df25ff9fe5cc30ea20ea02f7890de944ecd32 ]
 }
 
 @test "client/DaemonSet: adds config-checksum annotation when client config is updated" {
@@ -461,11 +453,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = ab9a9f78fc78a0c7509ec21d2f270052c556c28a1eceb26e4b40ef0068a34889 ]
-  else
-    [ "${actual}" = 56e95d32e8bc31f566498a05dc8e1e08b2cb049880ce589d2e9143f45308638c ]
-  fi
+  [ "${actual}" = 56e95d32e8bc31f566498a05dc8e1e08b2cb049880ce589d2e9143f45308638c ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -433,7 +433,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = db1cb14f20d2a2f9fe0b3a1f5a65446a32126faeeadf3813f9fe610ba8ee549b ]
+  [ "${actual}" = 779a0e24c2ed561c727730698a75b1c552f562c100f0c3315ff2cb925f5e296b ]
 }
 
 @test "client/DaemonSet: adds config-checksum annotation when extraConfig is provided" {
@@ -443,7 +443,7 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 4e3576ef3ecf806b27906771411df25ff9fe5cc30ea20ea02f7890de944ecd32 ]
+  [ "${actual}" = ba1ceb79d2d18e136d3cc40a9dfddcf2a252aa19ca1703bee3219ca28f1ee187 ]
 }
 
 @test "client/DaemonSet: adds config-checksum annotation when client config is updated" {
@@ -453,7 +453,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 56e95d32e8bc31f566498a05dc8e1e08b2cb049880ce589d2e9143f45308638c ]
+  [ "${actual}" = 8496f6bcdec460eac8a5c890e7899f5757111e13e54808af533aaf205ef18bd0 ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/client-role.bats
+++ b/test/unit/client-role.bats
@@ -110,7 +110,7 @@ load _helpers
       --set 'global.openshift.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.rules[] | select(.resources==["securitycontextconstraints"]) | .resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-client" ]
+  [ "${actual}" = "RELEASE-NAME-consul-client" ]
 }
 
 @test "client/Role: allows securitycontextconstraints and acl secret access with global.openshift.enabled=true and global.acls.manageSystemACLs=true" {
@@ -124,10 +124,10 @@ load _helpers
       yq -r '.rules[]' | tee /dev/stderr)
 
   local scc_resource=$(echo $rules | jq -r '. | select(.resources==["securitycontextconstraints"]) | .resourceNames[0]')
-  [ "${scc_resource}" = "release-name-consul-client" ]
+  [ "${scc_resource}" = "RELEASE-NAME-consul-client" ]
 
   local secrets_resource=$(echo $rules | jq -r '. | select(.resources==["secrets"]) | .resourceNames[0]')
-  [ "${secrets_resource}" = "release-name-consul-client-acl-token" ]
+  [ "${secrets_resource}" = "RELEASE-NAME-consul-client-acl-token" ]
 }
 
 @test "client/Role: allows securitycontextconstraints and psp access with global.openshift.enabled=true and global.enablePodSecurityPolices=true" {
@@ -141,10 +141,10 @@ load _helpers
       yq -r '.rules[]' | tee /dev/stderr)
 
   local scc_resource=$(echo $rules | jq -r '. | select(.resources==["securitycontextconstraints"]) | .resourceNames[0]')
-  [ "${scc_resource}" = "release-name-consul-client" ]
+  [ "${scc_resource}" = "RELEASE-NAME-consul-client" ]
 
   local psp_resource=$(echo $rules | jq -r '. | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]')
-  [ "${psp_resource}" = "release-name-consul-client" ]
+  [ "${psp_resource}" = "RELEASE-NAME-consul-client" ]
 }
 
 @test "client/Role: allows securitycontextconstraints, acl secret, and psp access when all global.openshift.enabled, global.enablePodSecurityPolices, and global.acls.manageSystemACLs are true " {
@@ -159,11 +159,11 @@ load _helpers
       yq -r '.rules[]' | tee /dev/stderr)
 
   local scc_resource=$(echo $rules | jq -r '. | select(.resources==["securitycontextconstraints"]) | .resourceNames[0]')
-  [ "${scc_resource}" = "release-name-consul-client" ]
+  [ "${scc_resource}" = "RELEASE-NAME-consul-client" ]
 
   local secrets_resource=$(echo $rules | jq -r '. | select(.resources==["secrets"]) | .resourceNames[0]')
-  [ "${secrets_resource}" = "release-name-consul-client-acl-token" ]
+  [ "${secrets_resource}" = "RELEASE-NAME-consul-client-acl-token" ]
 
   local psp_resource=$(echo $rules | jq -r '. | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]')
-  [ "${psp_resource}" = "release-name-consul-client" ]
+  [ "${psp_resource}" = "RELEASE-NAME-consul-client" ]
 }

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -491,7 +491,7 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"release-name-consul-k8s-auth-method\""))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-acl-auth-method=\"RELEASE-NAME-consul-k8s-auth-method\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/test/unit/controller-clusterrole.bats
+++ b/test/unit/controller-clusterrole.bats
@@ -54,6 +54,6 @@ load _helpers
       --set 'controller.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resourceNames[0] == "release-name-consul-controller-acl-token")) | length' | tee /dev/stderr)
+      yq -r '.rules | map(select(.resourceNames[0] == "RELEASE-NAME-consul-controller-acl-token")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }

--- a/test/unit/create-federation-secret-job.bats
+++ b/test/unit/create-federation-secret-job.bats
@@ -76,7 +76,7 @@ load _helpers
   local actual
 
   # test it uses the auto-generated ca secret
-  actual=$(echo $volumes | yq 'map(select(.name=="consul-ca-cert" and .secret.secretName=="release-name-consul-ca-cert")) | length > 0' | tee /dev/stderr)
+  actual=$(echo $volumes | yq 'map(select(.name=="consul-ca-cert" and .secret.secretName=="RELEASE-NAME-consul-ca-cert")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # test it uses the correct secret key for the auto-generated ca secret
@@ -84,7 +84,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   # test it uses the auto-generated ca key secret
-  actual=$(echo $volumes | yq 'map(select(.name=="consul-ca-key" and .secret.secretName=="release-name-consul-ca-key")) | length > 0' | tee /dev/stderr)
+  actual=$(echo $volumes | yq 'map(select(.name=="consul-ca-key" and .secret.secretName=="RELEASE-NAME-consul-ca-key")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   # test it uses the correct secret key for the auto-generated ca key secret

--- a/test/unit/create-federation-secret-role.bats
+++ b/test/unit/create-federation-secret-role.bats
@@ -38,7 +38,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.createReplicationToken=true' \
       . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resourceNames[0] == "release-name-consul-acl-replication-acl-token")) | length' | tee /dev/stderr)
+      yq -r '.rules | map(select(.resourceNames[0] == "RELEASE-NAME-consul-acl-replication-acl-token")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 

--- a/test/unit/enterprise-license-job.bats
+++ b/test/unit/enterprise-license-job.bats
@@ -140,7 +140,7 @@ load _helpers
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
-  [ "${actual}" = "http://release-name-consul-server:8500" ]
+  [ "${actual}" = "http://RELEASE-NAME-consul-server:8500" ]
 }
 
 @test "server/EnterpriseLicense: URL is https when TLS is enabled" {
@@ -152,7 +152,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
-  [ "${actual}" = "https://release-name-consul-server:8501" ]
+  [ "${actual}" = "https://RELEASE-NAME-consul-server:8501" ]
 }
 
 @test "server/EnterpriseLicense: CA certificate is specified when TLS is enabled" {

--- a/test/unit/enterprise-license-role.bats
+++ b/test/unit/enterprise-license-role.bats
@@ -68,7 +68,7 @@ load _helpers
       --set 'server.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.rules | map(select(.resourceNames[0] == "release-name-consul-enterprise-license-acl-token")) | length' | tee /dev/stderr)
+      yq -r '.rules | map(select(.resourceNames[0] == "RELEASE-NAME-consul-enterprise-license-acl-token")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -8,13 +8,13 @@ load _helpers
 # These tests use test-runner.yaml to test the consul.fullname helper
 # since we need an existing template that calls the consul.fullname helper.
 
-@test "helper/consul.fullname: defaults to release-name-consul" {
+@test "helper/consul.fullname: defaults to RELEASE-NAME-consul" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/tests/test-runner.yaml \
       . | tee /dev/stderr |
       yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-test" ]
+  [ "${actual}" = "RELEASE-NAME-consul-test" ]
 }
 
 @test "helper/consul.fullname: fullnameOverride overrides the name" {
@@ -84,7 +84,7 @@ load _helpers
       --set nameOverride=override \
       . | tee /dev/stderr |
       yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-override-test" ]
+  [ "${actual}" = "RELEASE-NAME-override-test" ]
 }
 
 #--------------------------------------------------------------------
@@ -120,7 +120,7 @@ load _helpers
       yq '.spec.initContainers[] | select(.name == "get-auto-encrypt-client-ca").command | join(" ")' | tee /dev/stderr)
 
   # check server address
-  actual=$(echo $command | jq ' . | contains("-server-addr=release-name-consul-server")')
+  actual=$(echo $command | jq ' . | contains("-server-addr=RELEASE-NAME-consul-server")')
   [ "${actual}" = "true" ]
 
   # check server port

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -22,7 +22,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-ingress-gateway" ]
+  [ "${actual}" = "RELEASE-NAME-consul-ingress-gateway" ]
 }
 
 #--------------------------------------------------------------------
@@ -1075,7 +1075,7 @@ key2: value2' \
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-ingress-gateway \
+  -name=RELEASE-NAME-consul-ingress-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT=8080
@@ -1135,13 +1135,13 @@ EOF
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='consul-k8s acl-init \
-  -secret-name="release-name-consul-ingress-gateway-ingress-gateway-acl-token" \
+  -secret-name="RELEASE-NAME-consul-ingress-gateway-ingress-gateway-acl-token" \
   -k8s-namespace=default \
   -token-sink-file=/consul/service/acl-token
 
 consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-ingress-gateway \
+  -name=RELEASE-NAME-consul-ingress-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT=8080
@@ -1317,10 +1317,10 @@ EOF
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/ingress-gateways-podsecuritypolicy.bats
+++ b/test/unit/ingress-gateways-podsecuritypolicy.bats
@@ -43,8 +43,8 @@ load _helpers
   [ "${actual}" = "false" ]
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 }

--- a/test/unit/ingress-gateways-role.bats
+++ b/test/unit/ingress-gateways-role.bats
@@ -46,7 +46,7 @@ load _helpers
   [ "${actual}" = "secrets" ]
 
   local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-ingress-gateway-ingress-gateway-acl-token" ]
+  [ "${actual}" = "RELEASE-NAME-consul-ingress-gateway-ingress-gateway-acl-token" ]
 }
 
 @test "ingressGateways/Role: rules for ingressGateways service" {
@@ -87,10 +87,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
   [ "${actual}" = "3" ]

--- a/test/unit/ingress-gateways-rolebinding.bats
+++ b/test/unit/ingress-gateways-rolebinding.bats
@@ -32,10 +32,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/ingress-gateways-service.bats
+++ b/test/unit/ingress-gateways-service.bats
@@ -333,7 +333,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.selector."ingress-gateway-name"' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-ingress-gateway" ]
+  [ "${actual}" = "RELEASE-NAME-consul-ingress-gateway" ]
 }
 
 #--------------------------------------------------------------------
@@ -351,10 +351,10 @@ key2: value2' \
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -57,10 +57,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo "$object" |
       yq -r '.[2] | length > 0' | tee /dev/stderr)

--- a/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -28,6 +28,6 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-mesh-gateway" ]
+  [ "${actual}" = "RELEASE-NAME-consul-mesh-gateway" ]
 }
 

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -718,7 +718,7 @@ key2: value2' \
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -767,13 +767,13 @@ EOF
       yq -r '.spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='consul-k8s acl-init \
-  -secret-name="release-name-consul-mesh-gateway-acl-token" \
+  -secret-name="RELEASE-NAME-consul-mesh-gateway-acl-token" \
   -k8s-namespace=default \
   -token-sink-file=/consul/service/acl-token
 
 consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -825,7 +825,7 @@ EOF
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1102,7 +1102,7 @@ EOF
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1219,7 +1219,7 @@ EOF
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"
@@ -1269,7 +1269,7 @@ EOF
 
   exp='consul-k8s service-address \
   -k8s-namespace=default \
-  -name=release-name-consul-mesh-gateway \
+  -name=RELEASE-NAME-consul-mesh-gateway \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT="443"

--- a/test/unit/server-acl-init-cleanup-job.bats
+++ b/test/unit/server-acl-init-cleanup-job.bats
@@ -55,7 +55,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -c '.spec.template.spec.containers[0].args' | tee /dev/stderr)
-  [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","release-name-consul-server-acl-init"]' ]
+  [ "${actual}" = '["delete-completed-job","-k8s-namespace=default","RELEASE-NAME-consul-server-acl-init"]' ]
 }
 
 @test "serverACLInitCleanup/Job: enabled with externalServers.enabled=true and global.acls.manageSystemACLs=true, but server.enabled set to false" {

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -93,7 +93,7 @@ load _helpers
 @test "serverACLInit/Job: fails if global.bootstrapACLs is true" {
   cd `chart_dir`
   run helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.bootstrapACLs=true' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" ]]
@@ -268,7 +268,7 @@ load _helpers
 @test "serverACLInit/Job: sync catalog acl option disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-sync-token"))' | tee /dev/stderr)
@@ -315,7 +315,7 @@ load _helpers
 @test "serverACLInit/Job: mesh gateway acl option disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
@@ -341,7 +341,7 @@ load _helpers
 @test "serverACLInit/Job: ingress gateways acl options disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
@@ -352,7 +352,7 @@ load _helpers
 @test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true (single default gateway)" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -364,7 +364,7 @@ load _helpers
 @test "serverACLInit/Job: able to define multiple ingress gateways" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -389,7 +389,7 @@ load _helpers
 @test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true, namespaces enabled, default namespace" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -402,7 +402,7 @@ load _helpers
 @test "serverACLInit/Job: ingress gateways acl option enabled with .ingressGateways.enabled=true, namespaces enabled, no default namespace set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -416,7 +416,7 @@ load _helpers
 @test "serverACLInit/Job: multiple ingress gateways with namespaces enabled provides the correct flag format" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -447,7 +447,7 @@ load _helpers
 @test "serverACLInit/Job: terminating gateways acl options disabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
@@ -458,7 +458,7 @@ load _helpers
 @test "serverACLInit/Job: terminating gateways acl option enabled with .terminatingGateways.enabled=true (single default gateway)" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -470,7 +470,7 @@ load _helpers
 @test "serverACLInit/Job: able to define multiple terminating gateways" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -495,7 +495,7 @@ load _helpers
 @test "serverACLInit/Job: terminating gateways acl option enabled with .terminatingGateways.enabled=true, namespaces enabled, default namespace" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -508,7 +508,7 @@ load _helpers
 @test "serverACLInit/Job: terminating gateways acl option enabled with .terminatingGateways.enabled=true, namespaces enabled, no default namespace set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
@@ -522,7 +522,7 @@ load _helpers
 @test "serverACLInit/Job: multiple terminating gateways with namespaces enabled provides the correct flag format" {
   cd `chart_dir`
   local object=$(helm template \
-      -x templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -532,11 +532,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = 4167c468ed8a709addb845f9ae4e3815a660d2ac63948e79e245e51dcbf42f82 ]
-  else
-    [ "${actual}" = dace10a37eb68bd57cf173422f8c4d567f94cae7270a752ca5bc4b573ec51fc8 ]
-  fi
+  [ "${actual}" = dace10a37eb68bd57cf173422f8c4d567f94cae7270a752ca5bc4b573ec51fc8 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -546,11 +542,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = 4d553d72dfbce63d407c6437bbf627b76d4c17f4238f938f2d21f57a2817e0fb ]
-  else
-    [ "${actual}" = 84bd2eb79ecec0fa8307474ce9e3ffd7f4643aa92fef5103fe4df406f90ee3d4 ]
-  fi
+  [ "${actual}" = 84bd2eb79ecec0fa8307474ce9e3ffd7f4643aa92fef5103fe4df406f90ee3d4 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -560,11 +552,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  if [[ $(v2) ]]; then
-    [ "${actual}" = 7c92326ad718ca8ad680a9d28ae81242beb8749530be468a9f6688e2a6671864 ]
-  else
-    [ "${actual}" = 41b6109630815e481179da6170435b0f996d37c854e1f7f160673ec44157767a ]
-  fi
+  [ "${actual}" = 41b6109630815e481179da6170435b0f996d37c854e1f7f160673ec44157767a ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -532,7 +532,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = dace10a37eb68bd57cf173422f8c4d567f94cae7270a752ca5bc4b573ec51fc8 ]
+  [ "${actual}" = c67246d1e00625e07698939e328524019e0016f828b0d46fb62704a480ba9931 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -542,7 +542,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 84bd2eb79ecec0fa8307474ce9e3ffd7f4643aa92fef5103fe4df406f90ee3d4 ]
+  [ "${actual}" = faad7e9a87aa09fc7106bcfc81397409b036bcf4f4c4449c49484c901fc271a7 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -552,7 +552,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 41b6109630815e481179da6170435b0f996d37c854e1f7f160673ec44157767a ]
+  [ "${actual}" = 7c922d7bf5e1a7e599ac6ec65ce45af6efc3f112749ffd556755748e3c6fb3ec ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -91,7 +91,7 @@ load _helpers
 @test "server/StatefulSet: resources can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-statefulset.yaml  \
+      -s templates/server-statefulset.yaml  \
       --set 'server.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
@@ -102,7 +102,7 @@ load _helpers
 @test "server/StatefulSet: resources can be overridden with string" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/server-statefulset.yaml  \
+      -s templates/server-statefulset.yaml  \
       --set 'server.resources=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -342,7 +342,7 @@ load _helpers
 @test "syncCatalog/Deployment: affinity not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.affinity == null' | tee /dev/stderr)
@@ -352,7 +352,7 @@ load _helpers
 @test "syncCatalog/Deployment: affinity can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.affinity=foobar' \
       . | tee /dev/stderr |
@@ -400,7 +400,7 @@ load _helpers
 @test "syncCatalog/Deployment: tolerations not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.tolerations == null' | tee /dev/stderr)
@@ -410,7 +410,7 @@ load _helpers
 @test "syncCatalog/Deployment: tolerations can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.tolerations=foobar' \
       . | tee /dev/stderr |
@@ -777,7 +777,7 @@ load _helpers
 @test "syncCatalog/Deployment: default resources" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
@@ -787,7 +787,7 @@ load _helpers
 @test "syncCatalog/Deployment: can set resources" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-catalog-deployment.yaml  \
+      -s templates/sync-catalog-deployment.yaml  \
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.resources.requests.memory=100Mi' \
       --set 'syncCatalog.resources.requests.cpu=100m' \

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -845,7 +845,7 @@ load _helpers
 
   local actual
   actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
-  [ "${actual}" = 'http://release-name-consul-server:8500' ]
+  [ "${actual}" = 'http://RELEASE-NAME-consul-server:8500' ]
 }
 
 @test "syncCatalog/Deployment: consul service is used when client.enabled=false and global.tls.enabled=true" {
@@ -860,7 +860,7 @@ load _helpers
 
   local actual
   actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
-  [ "${actual}" = 'https://release-name-consul-server:8501' ]
+  [ "${actual}" = 'https://RELEASE-NAME-consul-server:8501' ]
 
   actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
     [ "${actual}" = "/consul/tls/ca/tls.crt" ]

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -22,7 +22,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-terminating-gateway" ]
+  [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway" ]
 }
 
 #--------------------------------------------------------------------
@@ -953,7 +953,7 @@ EOF
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='consul-k8s acl-init \
-  -secret-name="release-name-consul-terminating-gateway-terminating-gateway-acl-token" \
+  -secret-name="RELEASE-NAME-consul-terminating-gateway-terminating-gateway-acl-token" \
   -k8s-namespace=default \
   -token-sink-file=/consul/service/acl-token
 
@@ -1131,10 +1131,10 @@ EOF
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/terminating-gateways-podsecuritypolicy.bats
+++ b/test/unit/terminating-gateways-podsecuritypolicy.bats
@@ -43,8 +43,8 @@ load _helpers
   [ "${actual}" = "false" ]
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 }

--- a/test/unit/terminating-gateways-role.bats
+++ b/test/unit/terminating-gateways-role.bats
@@ -46,7 +46,7 @@ load _helpers
   [ "${actual}" = "secrets" ]
 
   local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-terminating-gateway-terminating-gateway-acl-token" ]
+  [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway-terminating-gateway-acl-token" ]
 }
 
 @test "terminatingGateways/Role: rules is empty if no ACLs, PSPs" {
@@ -87,10 +87,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
   [ "${actual}" = "2" ]

--- a/test/unit/terminating-gateways-rolebinding.bats
+++ b/test/unit/terminating-gateways-rolebinding.bats
@@ -32,10 +32,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/terminating-gateways-serviceaccount.bats
+++ b/test/unit/terminating-gateways-serviceaccount.bats
@@ -57,10 +57,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
 
   local actual=$(echo "$object" |
       yq -r '.[2] | length > 0' | tee /dev/stderr)

--- a/test/unit/tls-init-cleanup-role.bats
+++ b/test/unit/tls-init-cleanup-role.bats
@@ -57,5 +57,5 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.rules[] | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]' | tee /dev/stderr)
 
-  [ "${actual}" = "release-name-consul-tls-init-cleanup" ]
+  [ "${actual}" = "RELEASE-NAME-consul-tls-init-cleanup" ]
 }

--- a/test/unit/tls-init-role.bats
+++ b/test/unit/tls-init-role.bats
@@ -57,5 +57,5 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.rules[] | select(.resources==["podsecuritypolicies"]) | .resourceNames[0]' | tee /dev/stderr)
 
-  [ "${actual}" = "release-name-consul-tls-init" ]
+  [ "${actual}" = "RELEASE-NAME-consul-tls-init" ]
 }

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -60,16 +60,15 @@ load _helpers
 }
 
 @test "ui/Ingress: exposes single port 80 when global.tls.enabled=false" {
-  if [[ $(v2) ]]; then
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=false' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  else
+# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
+#  local actual=$(helm template \
+#      -s templates/ui-ingress.yaml  \
+#      --set 'ui.ingress.enabled=true' \
+#      --set 'global.tls.enabled=false' \
+#      --set 'ui.ingress.hosts[0].host=foo.com' \
+#      --kube-version "1.18" \
+#      . | tee /dev/stderr |
+#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
   local actual=$(helm template \
      -s templates/ui-ingress.yaml  \
      --set 'ui.ingress.enabled=true' \
@@ -77,21 +76,19 @@ load _helpers
      --set 'ui.ingress.hosts[0].host=foo.com' \
      . | tee /dev/stderr |
      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
-  fi
   [ "${actual}" = "80" ]
 }
 
 @test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true" {
-  if [[ $(v2) ]]; then
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  else
+# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
+#  local actual=$(helm template \
+#      -s templates/ui-ingress.yaml  \
+#      --set 'ui.ingress.enabled=true' \
+#      --set 'global.tls.enabled=true' \
+#      --set 'ui.ingress.hosts[0].host=foo.com' \
+#      --kube-version "1.18" \
+#      . | tee /dev/stderr |
+#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -99,22 +96,20 @@ load _helpers
       --set 'ui.ingress.hosts[0].host=foo.com' \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
-  fi
   [ "${actual}" = "443" ]
 }
 
 @test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false" {
-  if [[ $(v2) ]]; then
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'global.tls.httpsOnly=false' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  else
+# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
+#  local actual=$(helm template \
+#      -s templates/ui-ingress.yaml  \
+#      --set 'ui.ingress.enabled=true' \
+#      --set 'global.tls.enabled=true' \
+#      --set 'global.tls.httpsOnly=false' \
+#      --set 'ui.ingress.hosts[0].host=foo.com' \
+#      --kube-version "1.18" \
+#      . | tee /dev/stderr |
+#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -123,22 +118,20 @@ load _helpers
       --set 'ui.ingress.hosts[0].host=foo.com' \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
-  fi
   [ "${actual}" = "80" ]
 }
 
 @test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false" {
-  if [[ $(v2) ]]; then
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'global.tls.httpsOnly=false' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
-  else
+# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
+#  local actual=$(helm template \
+#      -s templates/ui-ingress.yaml  \
+#      --set 'ui.ingress.enabled=true' \
+#      --set 'global.tls.enabled=true' \
+#      --set 'global.tls.httpsOnly=false' \
+#      --set 'ui.ingress.hosts[0].host=foo.com' \
+#      --kube-version "1.18" \
+#      . | tee /dev/stderr |
+#      yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -147,7 +140,6 @@ load _helpers
       --set 'ui.ingress.hosts[0].host=foo.com' \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[1].backend.service.port.number' | tee /dev/stderr)
-  fi
   [ "${actual}" = "443" ]
 }
 


### PR DESCRIPTION
* Remove unit test cases for Helm 2
* Update docs
* Remove circle ci step
* Use parallelism for Helm 3 tests
* Helm 3's release name is uppercase `RELEASE-NAME` so need to use that

According to https://app.circleci.com/insights/github/hashicorp/consul-helm/workflows/test/jobs?reporting-window=last-90-days the p95 for helm3 is 7m 49s and 9m 2s.

This looks like the helm3 tests are now running in 4m.