### PR TITLE
Rename lifecycle-sidecar to consul-sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ BREAKING CHANGES:
 
   See [Upgrade to CRDs](https://www.consul.io/docs/k8s/crds/upgrade-to-crds)
   for more information on how to upgrade.
+* The lifecycle-sidecar command and container has been renamed to
+  consul-sidecar. The Helm value `global.lifecycleSidecarContainer` has been
+  renamed to `global.consulSidecarContainer`.
+  `global.lifecycleSidecarContainer` is no longer supported and will cause
+  errors on `helm upgrade`. Please use `global.consulSidecarContainer` instead.
+  [[GH-810](https://github.com/hashicorp/consul-helm/pull/810)]
 
 IMPROVEMENTS:
 * Add ability to set extra labels on Consul client pods. [[GH-612](https://github.com/hashicorp/consul-helm/pull/612)]

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -6,6 +6,7 @@
 {{- if .Values.connectInject.centralConfig }}{{- if .Values.connectInject.centralConfig.defaultProtocol }}{{ fail "connectInject.centralConfig.defaultProtocol is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" }}{{ end }}{{ end -}}
 {{- if .Values.connectInject.centralConfig }}{{ if .Values.connectInject.centralConfig.proxyDefaults }}{{- if ne (trim .Values.connectInject.centralConfig.proxyDefaults) `{}` }}{{ fail "connectInject.centralConfig.proxyDefaults is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" }}{{ end }}{{ end }}{{ end -}}
 {{- if .Values.connectInject.imageEnvoy }}{{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" }}{{ end }}
+{{- if .Values.global.lifecycleSidecarContainer }}{{ fail "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." }}{{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment
@@ -163,19 +164,19 @@ spec:
                 {{- end }}
                 {{- end }}
 
-                {{- if .Values.global.lifecycleSidecarContainer }}
-                {{- $lifecycleResources := .Values.global.lifecycleSidecarContainer.resources }}
-                {{- if not (kindIs "invalid" $lifecycleResources.limits.memory) }}
-                -lifecycle-sidecar-memory-limit={{ $lifecycleResources.limits.memory }} \
+                {{- if .Values.global.consulSidecarContainer }}
+                {{- $consulSidecarResources := .Values.global.consulSidecarContainer.resources }}
+                {{- if not (kindIs "invalid" $consulSidecarResources.limits.memory) }}
+                -consul-sidecar-memory-limit={{ $consulSidecarResources.limits.memory }} \
                 {{- end }}
-                {{- if not (kindIs "invalid" $lifecycleResources.requests.memory) }}
-                -lifecycle-sidecar-memory-request={{ $lifecycleResources.requests.memory }} \
+                {{- if not (kindIs "invalid" $consulSidecarResources.requests.memory) }}
+                -consul-sidecar-memory-request={{ $consulSidecarResources.requests.memory }} \
                 {{- end }}
-                {{- if not (kindIs "invalid" $lifecycleResources.limits.cpu) }}
-                -lifecycle-sidecar-cpu-limit={{ $lifecycleResources.limits.cpu }} \
+                {{- if not (kindIs "invalid" $consulSidecarResources.limits.cpu) }}
+                -consul-sidecar-cpu-limit={{ $consulSidecarResources.limits.cpu }} \
                 {{- end }}
-                {{- if not (kindIs "invalid" $lifecycleResources.requests.cpu) }}
-                -lifecycle-sidecar-cpu-request={{ $lifecycleResources.requests.cpu }} \
+                {{- if not (kindIs "invalid" $consulSidecarResources.requests.cpu) }}
+                -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
           livenessProbe:

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -2,6 +2,7 @@
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
+{{- if .Values.global.lifecycleSidecarContainer }}{{ fail "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." }}{{ end }}
 
 {{- $root := . }}
 {{- $defaults := .Values.ingressGateways.defaults }}
@@ -366,9 +367,9 @@ spec:
                       {{- end }}
                       -id="${POD_NAME}"
 
-        # lifecycle-sidecar ensures the ingress gateway is always registered with
+        # consul-sidecar ensures the ingress gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
-        - name: lifecycle-sidecar
+        - name: consul-sidecar
           image: {{ $root.Values.global.imageK8S }}
           volumeMounts:
             - name: consul-service
@@ -385,9 +386,9 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-          {{- if  $root.Values.global.lifecycleSidecarContainer }}
-          {{- if $root.Values.global.lifecycleSidecarContainer.resources }}
-          resources: {{ toYaml $root.Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
+          {{- if  $root.Values.global.consulSidecarContainer }}
+          {{- if $root.Values.global.consulSidecarContainer.resources }}
+          resources: {{ toYaml $root.Values.global.consulSidecarContainer.resources | nindent 12 }}
           {{- end }}
           {{- end }}
           env:
@@ -410,7 +411,7 @@ spec:
             {{- end }}
           command:
             - consul-k8s
-            - lifecycle-sidecar
+            - consul-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
             {{- if $root.Values.global.acls.manageSystemACLs }}

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -4,6 +4,7 @@
 {{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
 {{- if .Values.meshGateway.imageEnvoy }}{{ fail "meshGateway.imageEnvoy must be specified in global.imageEnvoy" }}{{ end -}}
 {{- if .Values.meshGateway.globalMode }}{{ fail "meshGateway.globalMode is no longer supported; instead, you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" }}{{ end -}}
+{{- if .Values.global.lifecycleSidecarContainer }}{{ fail "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." }}{{ end }}
 {{- /* The below test checks if clients are disabled (and if so, fails). We use the conditional from other client files and prepend 'not' */ -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
 apiVersion: apps/v1
@@ -311,9 +312,9 @@ spec:
               exec:
                 command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .Values.meshGateway.consulServiceName }}\""]
 
-        # lifecycle-sidecar ensures the mesh gateway is always registered with
+        # consul-sidecar ensures the mesh gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
-        - name: lifecycle-sidecar
+        - name: consul-sidecar
           image: {{ .Values.global.imageK8S }}
           volumeMounts:
             - name: consul-service
@@ -330,9 +331,9 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-          {{- if .Values.global.lifecycleSidecarContainer }}
-          {{- if .Values.global.lifecycleSidecarContainer.resources }}
-          resources: {{ toYaml .Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
+          {{- if .Values.global.consulSidecarContainer }}
+          {{- if .Values.global.consulSidecarContainer.resources }}
+          resources: {{ toYaml .Values.global.consulSidecarContainer.resources | nindent 12 }}
           {{- end }}
           {{- end }}
           env:
@@ -355,7 +356,7 @@ spec:
             {{- end }}
           command:
             - consul-k8s
-            - lifecycle-sidecar
+            - consul-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
             {{- if .Values.global.acls.manageSystemACLs }}

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -2,6 +2,7 @@
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true" }}{{ end -}}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled" }}{{ end -}}
+{{- if .Values.global.lifecycleSidecarContainer }}{{ fail "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." }}{{ end }}
 
 {{- $root := . }}
 {{- $defaults := .Values.terminatingGateways.defaults }}
@@ -313,9 +314,9 @@ spec:
                       {{- end }}
                       -id="${POD_NAME}"
 
-        # lifecycle-sidecar ensures the terminating gateway is always registered with
+        # consul-sidecar ensures the terminating gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
-        - name: lifecycle-sidecar
+        - name: consul-sidecar
           image: {{ $root.Values.global.imageK8S }}
           volumeMounts:
             - name: consul-service
@@ -332,9 +333,9 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-          {{- if  $root.Values.global.lifecycleSidecarContainer }}
-          {{- if $root.Values.global.lifecycleSidecarContainer.resources }}
-          resources: {{ toYaml $root.Values.global.lifecycleSidecarContainer.resources | nindent 12 }}
+          {{- if  $root.Values.global.consulSidecarContainer }}
+          {{- if $root.Values.global.consulSidecarContainer.resources }}
+          resources: {{ toYaml $root.Values.global.consulSidecarContainer.resources | nindent 12 }}
           {{- end }}
           {{- end }}
           env:
@@ -357,7 +358,7 @@ spec:
             {{- end }}
           command:
             - consul-k8s
-            - lifecycle-sidecar
+            - consul-sidecar
             - -service-config=/consul/service/service.hcl
             - -consul-binary=/consul-bin/consul
             {{- if $root.Values.global.acls.manageSystemACLs }}

--- a/test/acceptance/framework/k8s/debug.go
+++ b/test/acceptance/framework/k8s/debug.go
@@ -58,12 +58,12 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 		for _, mpod := range meshGatewayPods.Items {
 			// Get configdump from mesh gateway, passing the discard logger since we only need these logs written to the file (below).
-			configDump, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "exec", mpod.Name, "-c", "lifecycle-sidecar", "--", "curl", "-s", "localhost:19000/config_dump?format=json")
+			configDump, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "exec", mpod.Name, "-c", "consul-sidecar", "--", "curl", "-s", "localhost:19000/config_dump?format=json")
 			if err != nil {
 				configDump = fmt.Sprintf("Error getting config_dump: %s: %s", err, configDump)
 			}
 			// Get cluster config from mesh gateway, passing the discard logger since we only need these logs written to the file (below).
-			clusters, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "exec", mpod.Name, "-c", "lifecycle-sidecar", "--", "curl", "-s", "localhost:19000/clusters?format=json")
+			clusters, err := RunKubectlAndGetOutputWithLoggerE(t, kubectlOptions, terratestLogger.Discard, "exec", mpod.Name, "-c", "consul-sidecar", "--", "curl", "-s", "localhost:19000/clusters?format=json")
 			if err != nil {
 				clusters = fmt.Sprintf("Error getting clusters: %s: %s", err, clusters)
 			}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -1230,9 +1230,9 @@ EOF
 }
 
 #--------------------------------------------------------------------
-# lifecycle sidecar resources
+# consul sidecar resources
 
-@test "connectInject/Deployment: default lifecycle sidecar container resources" {
+@test "connectInject/Deployment: default consul sidecar container resources" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
@@ -1241,133 +1241,143 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-request=25Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-request=25Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-request=20m"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-request=20m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-limit=50Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-limit=50Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-limit=20m"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-limit=20m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: lifecycle sidecar container resources can be set" {
+@test "connectInject/Deployment: consul sidecar container resources can be set" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.memory=100Mi' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.cpu=100m' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.memory=200Mi' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.cpu=200m' \
+      --set 'global.consulSidecarContainer.resources.requests.memory=100Mi' \
+      --set 'global.consulSidecarContainer.resources.requests.cpu=100m' \
+      --set 'global.consulSidecarContainer.resources.limits.memory=200Mi' \
+      --set 'global.consulSidecarContainer.resources.limits.cpu=200m' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-request=100Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-request=100Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-request=100m"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-request=100m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-limit=200Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-limit=200Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-limit=200m"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-limit=200m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: lifecycle sidecar container resources can be set explicitly to 0" {
+@test "connectInject/Deployment: consul sidecar container resources can be set explicitly to 0" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.memory=0' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.cpu=0' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.memory=0' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.cpu=0' \
+      --set 'global.consulSidecarContainer.resources.requests.memory=0' \
+      --set 'global.consulSidecarContainer.resources.requests.cpu=0' \
+      --set 'global.consulSidecarContainer.resources.limits.memory=0' \
+      --set 'global.consulSidecarContainer.resources.limits.cpu=0' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-request=0"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-request=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-request=0"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-request=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-limit=0"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-limit=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-limit=0"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-limit=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: lifecycle sidecar container resources can be individually set to null" {
+@test "connectInject/Deployment: consul sidecar container resources can be individually set to null" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.memory=null' \
-      --set 'global.lifecycleSidecarContainer.resources.requests.cpu=null' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.memory=null' \
-      --set 'global.lifecycleSidecarContainer.resources.limits.cpu=null' \
+      --set 'global.consulSidecarContainer.resources.requests.memory=null' \
+      --set 'global.consulSidecarContainer.resources.requests.cpu=null' \
+      --set 'global.consulSidecarContainer.resources.limits.memory=null' \
+      --set 'global.consulSidecarContainer.resources.limits.cpu=null' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-request"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-request"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: lifecycle sidecar container resources can be set to null" {
+@test "connectInject/Deployment: consul sidecar container resources can be set to null" {
   cd `chart_dir`
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'global.lifecycleSidecarContainer.resources=null' \
+      --set 'global.consulSidecarContainer.resources=null' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-request"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-request"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-memory-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-memory-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-lifecycle-sidecar-cpu-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: fails if global.lifecycleSidecarContainer is set" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.lifecycleSidecarContainer.resources.requests.memory=100Mi' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." ]]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -228,12 +228,12 @@ global:
     # `<helm-release-name>-consul-federation`. Requires consul-k8s 0.15.0+.
     createFederationSecret: false
 
-  # The lifecycle sidecar ensures the Consul services
+  # The consul sidecar ensures the Consul services
   # are always registered with their local Consul clients and is used by the
   # ingress/terminating/mesh gateways as well as with every Connect-injected service.
   # @recurse: false
   # @type: map
-  lifecycleSidecarContainer:
+  consulSidecarContainer:
     resources:
       requests:
         memory: "25Mi"


### PR DESCRIPTION
Changes proposed in this PR:
- deprecates helm value lifecycleSidecarContainer and replaces it with
consulSidecarContainer. 
- replaces all uses of lifecycle sidecar
with consul sidecar, including container names, commands, and flags.

This is to enable future functionality within the consul-sidecar
container, since it may no longer be only responsible for managing
lifecycle.

How I've tested this PR:
acceptance tests against consul-k8s rename-sidecar branch

How I expect reviewers to test this PR:
code review


Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

