### PR TITLE
Register IGW service hostname, rather than first IPv4 address.

### DIFF
--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -162,7 +162,6 @@ spec:
                 consul-k8s service-address \
                   -k8s-namespace={{ $root.Release.Namespace }} \
                   -name={{ template "consul.fullname" $root }}-{{ .name }} \
-                  -resolve-hostnames \
                   -output-file=/tmp/address.txt
                 WAN_ADDR="$(cat /tmp/address.txt)"
                 {{- else }}

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -1065,7 +1065,6 @@ key2: value2' \
   exp='consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-ingress-gateway \
-  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT=8080
@@ -1132,7 +1131,6 @@ EOF
 consul-k8s service-address \
   -k8s-namespace=default \
   -name=release-name-consul-ingress-gateway \
-  -resolve-hostnames \
   -output-file=/tmp/address.txt
 WAN_ADDR="$(cat /tmp/address.txt)"
 WAN_PORT=8080


### PR DESCRIPTION
Opening per conversation with @lkysow.

Changes proposed in this PR:
- Remove the `-resolve-hostnames` flag from the Ingress Gateway's service-init container. When using a LoadBalancer service, this causes the DNS hostname to be registered in place of the first IPv4 address, bringing several benefits:
  - Consul will return a CNAME, rather than A record for <service>.ingress.consul DNS queries. In the event there are multiple points of ingress (i.e. AWS ELB attached to multiple subnets), the traffic can be distributed in response to load balancer auto-scaling.
  - For load balancer integrations which scale outside of Kubernetes, the Consul service registration will not go stale as a result of this scaling activity.
  - Currently, in the event the `service-init` container executes before the load balancer resource has finished provisioning, the Consul catalog is updated with an invalid target address for the platform load balancer. Changing this to the LB hostname removes the need to perform a rolling update of the ingress gateway deployment to retrieve the correct address(es).

How I've tested this PR:
- Deployed to an AWS EKS cluster. Used an NLB LoadBalancer k8s service to front Consul ingress gateways, and tested traffic to a destination Vault service. Feel free to ping me on Slack for full environment details.

How I expect reviewers to test this PR:


Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

