### PR TITLE
Acceptance: wait for previous installation to exit

### DIFF
--- a/test/acceptance/tests/fixtures/bases/static-client/deployment.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/deployment.yaml
@@ -19,3 +19,4 @@ spec:
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
       serviceAccountName: static-client
+      terminationGracePeriodSeconds: 0 # so deletion is quick

--- a/test/acceptance/tests/fixtures/bases/static-server/deployment.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-server/deployment.yaml
@@ -23,3 +23,4 @@ spec:
             - containerPort: 8080
               name: http
       serviceAccountName: static-server
+      terminationGracePeriodSeconds: 0 # so deletion is quick


### PR DESCRIPTION
In some cases the previous installation is listed as uninstalled by Helm
but its pods are still terminating. This can cause issues for the newly
running tests when they query Kubernetes to get information about the
new installation, e.g. getting the server pod IPs might return the IPs
from the old installation as well.

This was the cause of the failure of https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2413/workflows/1fb2bed2-96cd-4779-90c3-fbe5c3f84c7a/jobs/8057/steps


I logged which IPs it was getting and you can see that it was getting two IPs, one of which was from a terminating pod.
```
    consul_dns_test.go:44: 2021-02-09T17:58:19Z Waiting for pods to be ready.
    consul_dns_test.go:61: is ready: true, ip=10.244.0.90
    consul_dns_test.go:61: is ready: false, ip=10.244.0.83

```
