### PR TITLE
fix: support v1beta1 MutationWebhookConfiguration

### DIFF
--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -17,10 +17,12 @@ metadata:
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
     failurePolicy: Ignore
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
     sideEffects: None
     admissionReviewVersions:
       - "v1beta1"
       - "v1"
+{{- end }}
     clientConfig:
       service:
         name: {{ template "consul.fullname" . }}-connect-injector-svc

--- a/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/templates/controller-mutatingwebhookconfiguration.yaml
@@ -21,9 +21,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-proxydefaults
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-proxydefaults.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -35,7 +38,6 @@ webhooks:
       - UPDATE
       resources:
       - proxydefaults
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -43,9 +45,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicedefaults
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-servicedefaults.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -57,7 +62,6 @@ webhooks:
       - UPDATE
       resources:
       - servicedefaults
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -65,9 +69,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-serviceresolver
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-serviceresolver.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -79,7 +86,6 @@ webhooks:
       - UPDATE
       resources:
       - serviceresolvers
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -87,9 +93,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicerouter
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-servicerouter.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -101,7 +110,6 @@ webhooks:
       - UPDATE
       resources:
       - servicerouters
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -109,9 +117,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-servicesplitter
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-servicesplitter.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -123,7 +134,6 @@ webhooks:
       - UPDATE
       resources:
       - servicesplitters
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -131,9 +141,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-serviceintentions
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-serviceintentions.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -145,7 +158,6 @@ webhooks:
       - UPDATE
       resources:
       - serviceintentions
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -153,9 +165,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-ingressgateway
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-ingressgateway.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -167,7 +182,6 @@ webhooks:
         - UPDATE
       resources:
         - ingressgateways
-  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -175,9 +189,12 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1alpha1-terminatinggateway
   failurePolicy: Fail
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  sideEffects: None
   admissionReviewVersions:
     - "v1beta1"
     - "v1"
+{{- end }}
   name: mutate-terminatinggateway.consul.hashicorp.com
   rules:
     - apiGroups:
@@ -189,5 +206,4 @@ webhooks:
         - UPDATE
       resources:
         - terminatinggateways
-  sideEffects: None
 {{- end }}


### PR DESCRIPTION
Changes proposed in this PR:
- removed sideEffects and admissionReviewVersions parameters for MutationWebhookConfiguration not v1 version

How I've tested this PR:
```
helm template consul . --set controller.enabled=true --set global.name=consul --set connectInject.enabled=true --show-only templates/connect-inject-mutatingwebhook.yaml --show-only templates/controller-mutatingwebhookconfiguration.yaml --api-versions admissionregistration.k8s.io/v1beta1
```
and it will be cool use option `--kube-version`, but it's still in progress here helm/helm#9040

How I expect reviewers to test this PR:

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

