### PR TITLE
Increase client init resources 25Mi => 50Mi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+BREAKING CHANGES:
+
+FEATURES:
+
+IMPROVEMENTS:
+
+BUG FIXES:
+* Increase Consul client daemonset's memory from `25Mi` to `50Mi` for its `client-tls-init`
+  init container that runs when TLS is enabled and auto-encrypt is disabled. [[GH-832](https://github.com/hashicorp/consul-helm/pull/832)]
+
 ## 0.30.0 (Feb 16, 2021)
 
 BREAKING CHANGES:

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -381,10 +381,10 @@ spec:
             readOnly: true
         resources:
           requests:
-            memory: "25Mi"
+            memory: "50Mi"
             cpu: "50m"
           limits:
-            memory: "25Mi"
+            memory: "50Mi"
             cpu: "50m"
       {{- end }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -314,7 +314,7 @@ server:
     # enable `server.exposeGossipAndRPCPorts` and `client.exposeGossipPorts`,
     # that will configure the LAN gossip ports on the servers and clients to be
     # hostPorts, so if you are running clients and servers on the same node the
-    # ports will conflict if they are both 8301.  When you enable
+    # ports will conflict if they are both 8301. When you enable
     # `server.exposeGossipAndRPCPorts` and `client.exposeGossipPorts`, you must
     # change this from the default to an unused port on the host, e.g. 9301. By
     # default the LAN gossip port is 8301 and configured as a containerPort on


### PR DESCRIPTION
Increase the memory for the client daemonset's tls-init
container. We saw an out of memory error when running on OpenShift.

https://circleci.com/gh/hashicorp/consul-helm/8609 saw an OOMKilled error

Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

