### PR TITLE
Connect Service Metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:4adf933
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -94,6 +94,15 @@ spec:
                 -health-checks-reconcile-period={{ .Values.connectInject.healthChecks.reconcilePeriod }} \
                 {{- end }}
                 -cleanup-controller-reconcile-period={{ .Values.connectInject.cleanupController.reconcilePeriod }} \
+                {{- if (or (and (ne (.Values.connectInject.metrics.defaultEnabled | toString) "-") .Values.connectInject.metrics.defaultEnabled) (and (eq (.Values.connectInject.metrics.defaultEnabled | toString) "-") .Values.global.metrics.enabled)) }}
+                -default-enable-metrics=true \
+                {{- else }}
+                -default-enable-metrics=false \
+                {{- end }}
+                -default-enable-metrics-merging={{ .Values.connectInject.metrics.defaultEnableMerging }}  \
+                -default-merged-metrics-port={{ .Values.connectInject.metrics.defaultMergedMetricsPort }} \
+                -default-prometheus-scrape-port={{ .Values.connectInject.metrics.defaultPrometheusScrapePort }} \
+                -default-prometheus-scrape-path="{{ .Values.connectInject.metrics.defaultPrometheusScrapePath }}" \
                 {{- if .Values.connectInject.envoyExtraArgs }}
                 -envoy-extra-args="{{ .Values.connectInject.envoyExtraArgs }}" \
                 {{- end }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -244,6 +244,148 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# metrics
+
+@test "connectInject/Deployment: default connect-inject metrics flags" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics-merging=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-merged-metrics-port=20100"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-prometheus-scrape-port=20200"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-prometheus-scrape-path=\"/metrics\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: adds flag default-enable-metrics=true when global.metrics.enabled=true" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: adds flag default-enable-metrics=true when metrics.defaultEnabled=true and global.metrics.enabled=false" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.metrics.defaultEnabled=true' \
+      --set 'global.metrics.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: adds flag default-enable-metrics=false when metrics.defaultEnabled=false and global.metrics.enabled=true" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=true' \
+      --set 'connectInject.metrics.defaultEnabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: adds flag default-enable-metrics=false when global.metrics.enabled=false" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: metrics.defaultEnableMerging can be configured" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.metrics.defaultEnableMerging=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-enable-metrics-merging=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: metrics.defaultMergedMetricsPort can be configured" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.metrics.defaultMergedMetricsPort=12345' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-merged-metrics-port=12345"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: metrics.defaultPrometheusScrapePort can be configured" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.metrics.defaultPrometheusScrapePort=12345' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-prometheus-scrape-port=12345"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: metrics.defaultPrometheusScrapePath can be configured" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.metrics.defaultPrometheusScrapePath=/some-path' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-default-prometheus-scrape-path=\"/some-path\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # consul and envoy images
 
 @test "connectInject/Deployment: container image is global default" {

--- a/values.yaml
+++ b/values.yaml
@@ -1271,6 +1271,43 @@ connectInject:
     # reconcile is done after the initial reconcile at startup is completed.
     reconcilePeriod: "1m"
 
+  # Configures metrics for Consul Connect services. All values are overridable
+  # via annotations on a per-pod basis.
+  metrics:
+    # If true, the connect-injector will automatically
+    # add prometheus annotations to connect-injected pods. It will also
+    # add a listener on the Envoy sidecar to expose metrics. The exposed
+    # metrics will depend on whether metrics merging is enabled:
+    #   - If metrics merging is enabled:
+    #     the Consul sidecar will run a merged metrics server
+    #     combining Envoy sidecar and Connect service metrics,
+    #     i.e. if your service exposes its own Prometheus metrics.
+    #   - If metrics merging is disabled:
+    #     the listener will just expose Envoy sidecar metrics.
+    # This will inherit from `global.metrics.enabled`.
+    defaultEnabled: "-"
+    # Configures the Consul sidecar to run a merged metrics server
+    # to combine and serve both Envoy and Connect service metrics.
+    defaultEnableMerging: false
+    # Configures the port at which the Consul sidecar will listen on to return
+    # combined metrics. This port only needs to be changed if it conflicts with
+    # the application's ports.
+    defaultMergedMetricsPort: 20100
+    # Configures the port Prometheus will scrape metrics from, by configuring
+    # the Pod annotation `prometheus.io/port` and the corresponding listener in
+    # the Envoy sidecar.
+    # NOTE: This is *not* the port that your application exposes metrics on.
+    # That can be configured with the
+    # `consul.hashicorp.com/service-metrics-port` annotation.
+    defaultPrometheusScrapePort: 20200
+    # Configures the path Prometheus will scrape metrics from, by configuring the pod
+    # annotation prometheus.io/path and the corresponding handler in the Envoy
+    # sidecar.
+    # NOTE: This is *not* the path that your application exposes metrics on.
+    # That can be configured with the
+    # `consul.hashicorp.com/service-metrics-path` annotation.
+    defaultPrometheusScrapePath: "/metrics"
+
   # Cleanup controller cleans up Consul service instances that remain registered
   # despite their pods no longer running. This could happen if the pod's `preStop`
   # hook failed to execute for some reason.


### PR DESCRIPTION
Changes proposed in this PR:
- Adds connect service metrics flags to configure metrics merging and Prometheus annotations on Connect-injected Pods.

How I've tested this PR:
1. Deploy with the following values: 
```
global:
  domain: consul
  datacenter: dc1
  imageK8S: gcr.io/nitya-293720/consul-k8s-dev:metrics30
  image: gcr.io/nitya-293720/consul-dev:metrics10

server:
  replicas: 1
  bootstrapExpect: 1

client:
  enabled: true
  grpc: true

ui:
  enabled: true
prometheus:
  enabled: true

connectInject:
  enabled: true
  metrics:
    defaultEnabled: true
    defaultEnableMerging: true
    defaultMergedMetricsPort: 12345
    defaultPrometheusScrapePort: 22345
    defaultPrometheusScrapePath: "/metrics"

controller:
  enabled: true
```
2. Apply this app
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: prometheus-example-app
  name: prometheus-example-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: prometheus-example-app
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'true'
        'consul.hashicorp.com/connect-service-upstreams': 'static-server:1234'
      labels:
        app.kubernetes.io/name: prometheus-example-app
    spec:
      containers:
      - name: prometheus-example-app
        image: quay.io/brancz/prometheus-example-app:v0.3.0
        ports:
        - name: web
          containerPort: 8080
```
3. Port forward to prometheus server
4. Navigate to prometheus dashboard "graph" tab and try to graph the "version" metric

How I expect reviewers to test this PR:
Follow steps above, code review

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

