### PR TITLE
[skip ci] remove artifacthub config file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,3 +1,0 @@
-owners:
-  - name: hashicorp
-    email: rel-eng+artifacthub@hashicorp.com


### PR DESCRIPTION
This PR removes the file that was added in #819. That file should exist on the repo index (helm.releases.hashicorp.com) and not the consul package level. 