### PR TITLE
Increase mesh gateway mem limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMPROVEMENTS:
 BUG FIXES:
 * Increase Consul client daemonset's memory from `25Mi` to `50Mi` for its `client-tls-init`
   init container that runs when TLS is enabled and auto-encrypt is disabled. [[GH-832](https://github.com/hashicorp/consul-helm/pull/832)]
+* Increase mesh gateway's memory limit from `25Mi` to `150Mi` for its `service-init`
+  init container. [[GH-837](https://github.com/hashicorp/consul-helm/pull/837)]
 
 ## 0.30.0 (Feb 16, 2021)
 

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -220,7 +220,7 @@ spec:
               memory: "25Mi"
               cpu: "50m"
             limits:
-              memory: "25Mi"
+              memory: "150Mi"
               cpu: "50m"
       containers:
         - name: mesh-gateway


### PR DESCRIPTION
Was OOM'ing in acceptance tests. Set it to the same value as our
connect services init containers.

Failing build: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2498/workflows/d51931fa-17c6-4af3-89fc-7de248bc2f5b/jobs/8644/artifacts

consul-k8s setting: https://github.com/hashicorp/consul-k8s/blob/master/subcommand/inject-connect/command.go#L166

Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

