### PR TITLE
Server wan ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ IMPROVEMENTS:
 BUG FIXES:
 * Increase Consul client daemonset's memory from `25Mi` to `50Mi` for its `client-tls-init`
   init container that runs when TLS is enabled and auto-encrypt is disabled. [[GH-832](https://github.com/hashicorp/consul-helm/pull/832)]
+* Add UDP port specification for server's serf WAN. Previously there was only one
+  port specification that defaulted to TCP. However in some cases (like when exposing as a host port)
+  UDP traffic would not be routed properly.
+
+  In addition, if `server.exposeGossipAndRPCPorts` is true, expose the WAN port
+  (`8302`) as a host port. [[GH-839](https://github.com/hashicorp/consul-helm/pull/839)]
 
 ## 0.30.0 (Feb 16, 2021)
 

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -228,37 +228,37 @@ spec:
             {{- end }}
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
-            - containerPort: 8500
-              name: http
+            - name: http
+              containerPort: 8500
             {{- end }}
             {{- if .Values.global.tls.enabled }}
-            - containerPort: 8501
-              name: https
+            - name: https
+              containerPort: 8501
             {{- end }}
-            - containerPort: {{ .Values.server.ports.serflan.port }}
+            - name: serflan-tcp
+              containerPort: {{ .Values.server.ports.serflan.port }}
               {{- if .Values.server.exposeGossipAndRPCPorts }}
               hostPort: {{ .Values.server.ports.serflan.port }}
               {{- end }}
               protocol: "TCP"
-              name: serflan-tcp
-            - containerPort: {{ .Values.server.ports.serflan.port }}
+            - name: serflan-udp
+              containerPort: {{ .Values.server.ports.serflan.port }}
               {{- if .Values.server.exposeGossipAndRPCPorts }}
               hostPort: {{ .Values.server.ports.serflan.port }}
               {{- end }}
               protocol: "UDP"
-              name: serflan-udp
-            - containerPort: 8302
-              name: serfwan
-            - containerPort: 8300
+            - name: serfwan
+              containerPort: 8302
+            - name: server
+              containerPort: 8300
               {{- if .Values.server.exposeGossipAndRPCPorts }}
               hostPort: 8300
               {{- end }}
-              name: server
-            - containerPort: 8600
-              name: dns-tcp
+            - name: dns-tcp
+              containerPort: 8600
               protocol: "TCP"
-            - containerPort: 8600
-              name: dns-udp
+            - name: dns-udp
+              containerPort: 8600
               protocol: "UDP"
           readinessProbe:
             # NOTE(mitchellh): when our HTTP status endpoints support the

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -247,8 +247,12 @@ spec:
               hostPort: {{ .Values.server.ports.serflan.port }}
               {{- end }}
               protocol: "UDP"
-            - name: serfwan
+            - name: serfwan-tcp
               containerPort: 8302
+              protocol: "TCP"
+            - name: serfwan-udp
+              containerPort: 8302
+              protocol: "UDP"
             - name: server
               containerPort: 8300
               {{- if .Values.server.exposeGossipAndRPCPorts }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -249,9 +249,15 @@ spec:
               protocol: "UDP"
             - name: serfwan-tcp
               containerPort: 8302
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: 8302
+              {{- end }}
               protocol: "TCP"
             - name: serfwan-udp
               containerPort: 8302
+              {{- if .Values.server.exposeGossipAndRPCPorts }}
+              hostPort: 8302
+              {{- end }}
               protocol: "UDP"
             - name: server
               containerPort: 8300

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -178,6 +178,14 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serflan-udp")' | yq -r '.hostPort' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serfwan-tcp")' | yq -r '.hostPort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serfwan-udp")' | yq -r '.hostPort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
   # Test that hostPort is not set for rpc ports
   local actual=$(echo "$object" |
       yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "server")' | yq -r '.hostPort' | tee /dev/stderr)
@@ -204,6 +212,14 @@ load _helpers
   local actual=$(echo "$object" |
       yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serflan-udp")' | yq -r '.hostPort' | tee /dev/stderr)
   [ "${actual}" = "8301" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serfwan-tcp")' | yq -r '.hostPort' | tee /dev/stderr)
+  [ "${actual}" = "8302" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "serfwan-udp")' | yq -r '.hostPort' | tee /dev/stderr)
+  [ "${actual}" = "8302" ]
 
   # Test that hostPort is set for rpc ports
   local actual=$(echo "$object" |


### PR DESCRIPTION
It turns out that we *do* need to expose the server wan port as a host port when the advertise IP is the node IP in order for the `/operator/keyring` to work. There may be other reasons as well but we know this doesn't work without it.

Changes proposed in this PR:
- refactor YAML for ports so the name of the port is at the top so it's easier to parse
- split out `serfwan` into `serfwan-tcp` and `serfwan-udp` (similar to `serflan-tcp/udp`) because when exposed as a `hostPort` if the UDP protocol port doesn't exist then the `/operator/keyring` API fails
- expose `serfwan` as a host port when `server.exposeGossipAndRPCPorts` is `true`

FIxes https://github.com/hashicorp/consul-helm/issues/838, re-opens and concludes https://github.com/hashicorp/consul-helm/pull/762.

How I've tested this PR:
* `kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)`
* Use values.yaml

  ```yaml
  global:
    name: consul
    enabled: false
    gossipEncryption:
      secretName: consul-gossip-encryption-key
      secretKey: key
  server:
    enabled: true
    exposeGossipAndRPCPorts: true
    replicas: 1
  ```
* Install with latest helm chart
* Run `kubectl exec consul-server-0 -- curl -sS localhost:8500/v1/operator/keyring`
  * You'll get an error
* Uninstall
* Install with this branch
* Run `kubectl exec consul-server-0 -- curl -sS localhost:8500/v1/operator/keyring`
  * It will succeed


How I expect reviewers to test this PR:
* See above


Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

