### PR TITLE
Add acceptance test for metrics merging

### DIFF
--- a/test/acceptance/tests/fixtures/bases/static-metrics-app/deployment.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-metrics-app/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: static-metrics-app
+  name: static-metrics-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-metrics-app
+  template:
+    metadata:
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+        'consul.hashicorp.com/connect-service': 'server'
+      labels:
+        app: static-metrics-app
+    spec:
+      containers:
+      - name: static-metrics-app
+        image: ishustava/fake-service:0.7.0
+        env:
+        - name: METRICS_ENABLE_PROMETHEUS
+          value: "true"
+        ports:
+        - containerPort: 9090


### PR DESCRIPTION
Changes proposed in this PR (by Nitya):
- Add an acceptance test to verify metrics merging works for service metrics that support the same

How I've tested this PR: Run the acceptance test and things looked phenomenal (much like Nitya's code)

How I expect reviewers to test this PR: However Nitya deems fit. Probably watch the pipelines go green and Code Review the rest.


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

