### PR TITLE
Disable nightly OpenShift acc. tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,7 @@ workflows:
               only:
                 - master
     jobs:
-      - acceptance-openshift
+    # - acceptance-openshift >> disabled because OpenShift 4.4 was too flaky. Can possibly re-enable when latest OpenShift version is released.
       - acceptance-gke-1-16
       - acceptance-eks-1-17
       - acceptance-aks-1-18


### PR DESCRIPTION
OpenShift 4.4 seems to have a lot of issues with flakiness due to pod
scheduling occasionally failing. Disabling these tests until we can use
a more up-to-date version that hopefully fixes the issues.

