### PR TITLE
Add last synced time to CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ BREAKING CHANGES:
 FEATURES:
 
 IMPROVEMENTS:
+* CRDs: add field Last Synced Time to CRD status and add printer column on CRD to display time since when the
+  resource was last successfully synced with Consul. [[GH-849](https://github.com/hashicorp/consul-helm/pull/849)]
 
 BUG FIXES:
 * Increase Consul client daemonset's memory from `25Mi` to `50Mi` for its `client-tls-init`

--- a/templates/crd-ingressgateways.yaml
+++ b/templates/crd-ingressgateways.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -116,6 +120,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -111,6 +115,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-servicedefaults.yaml
+++ b/templates/crd-servicedefaults.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -114,6 +118,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-serviceintentions.yaml
+++ b/templates/crd-serviceintentions.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -158,6 +162,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-serviceresolvers.yaml
+++ b/templates/crd-serviceresolvers.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -190,6 +194,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-servicerouters.yaml
+++ b/templates/crd-servicerouters.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -186,6 +190,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-servicesplitters.yaml
+++ b/templates/crd-servicesplitters.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -94,6 +98,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/templates/crd-terminatinggateways.yaml
+++ b/templates/crd-terminatinggateways.yaml
@@ -19,6 +19,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .status.lastSyncedTime
+    description: The last successful synced time of the resource with Consul
+    name: Last Synced
+    type: date
   - JSONPath: .metadata.creationTimestamp
     description: The age of the resource
     name: Age
@@ -101,6 +105,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the resource successfully synced with Consul.
+              format: date-time
+              type: string
           type: object
       type: object
   version: v1alpha1


### PR DESCRIPTION
Changes proposed in this PR:
- Update CRDs to have printer column for "Last Synced At" which displays time since the last successful sync of a resource with the Consul Server.
Companion PR to https://github.com/hashicorp/consul-k8s/pull/448
How I've tested this PR:
- Deployed consul-helm with the image: `ashwinvenkatesh/consul-k8s@sha256:8f2d59278f4b8deca8eaeb643a3e6143684e4c37a3e03c051781a1c42a8d70d4` for consul-k8s
- Created a resource and `kubectl get resource` now displays a column Last Synced At with time since the successful sync.

![image](https://user-images.githubusercontent.com/26226763/109989840-df87da00-7cd6-11eb-9072-5970ea10d3e3.png)


How I expect reviewers to test this PR:
- Retry the above step. Potentially edit the object to observe the Last Sync time update itself. 
Edit the config with a "failing" spec and save it. The Last Synced time should now not update as the sync will be unsuccessful. 

Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

