### PR TITLE
Fix: coalesce.go warning while overriding the client affinity with a string value

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -768,7 +768,7 @@ client:
   #           operator: DoesNotExist
   # ```
   # @type: string
-  affinity: {}
+  affinity: null
 
   # This value references an existing
   # Kubernetes `priorityClassName` (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#pod-priority)


### PR DESCRIPTION
Create a local-values.yaml like the example shown in the values.yaml in the docs above client affinity:

    client:
      affinity: |
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: node-role.kubernetes.io/master
                operator: DoesNotExist

If you run `helm template -f ./local-values.yaml consul-test . | head`, it will print a warning like so:

    coalesce.go:196: warning: cannot overwrite table with non table for affinity (map[])

The end result is fine, but the warning is annoying. My understanding is when it's "coalescing" your local-values.yaml with the values.yaml it doesn't like it when a string is replacing an object.

Changes proposed in this PR:
- Default client affinity to null instead of an empty map prevents the coalesce.go warning from being printed

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

