### PR TITLE
Acceptance tests fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
           command: |
             terraform init
 
-            terraform apply -var cluster_count=2 -var tags={"build_url": "$CIRCLE_BUILD_URL"} -auto-approve
+            terraform apply -var cluster_count=2 -var tags="{\"build_url\": \"$CIRCLE_BUILD_URL\"}" -auto-approve
 
       # Restore go module cache if there is one
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,15 +214,15 @@ jobs:
             KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
 
             gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
-                  -enable-enterprise \
-                  -enterprise-license-secret-name=ent-license \
-                  -enterprise-license-secret-key=key \
-                  -enable-pod-security-policies \
-                  -enable-multi-cluster \
-                  -kubeconfig="$primary_kubeconfig" \
-                  -secondary-kubeconfig="$secondary_kubeconfig" \
-                  -debug-directory="$TEST_RESULTS/debug" \
-                  -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -enable-enterprise \
+              -enterprise-license-secret-name=ent-license \
+              -enterprise-license-secret-key=key \
+              -enable-pod-security-policies \
+              -enable-multi-cluster \
+              -kubeconfig="$primary_kubeconfig" \
+              -secondary-kubeconfig="$secondary_kubeconfig" \
+              -debug-directory="$TEST_RESULTS/debug" \
+              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -279,12 +279,12 @@ jobs:
             export secondary_kubeconfig=$(terraform output -state ../../terraform/aks/terraform.tfstate -json | jq -r .kubeconfigs.value[1])
 
             gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
-                -enable-enterprise \
-                -enable-multi-cluster \
-                -kubeconfig="$primary_kubeconfig" \
-                -secondary-kubeconfig="$secondary_kubeconfig" \
-                -debug-directory="$TEST_RESULTS/debug" \
-                -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -enable-enterprise \
+              -enable-multi-cluster \
+              -kubeconfig="$primary_kubeconfig" \
+              -secondary-kubeconfig="$secondary_kubeconfig" \
+              -debug-directory="$TEST_RESULTS/debug" \
+              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -352,12 +352,12 @@ jobs:
             chmod 600 "$secondary_kubeconfig"
 
             gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
-                -enable-enterprise \
-                -enable-multi-cluster \
-                -kubeconfig="$primary_kubeconfig" \
-                -secondary-kubeconfig="$secondary_kubeconfig" \
-                -debug-directory="$TEST_RESULTS/debug" \
-                -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -enable-enterprise \
+              -enable-multi-cluster \
+              -kubeconfig="$primary_kubeconfig" \
+              -secondary-kubeconfig="$secondary_kubeconfig" \
+              -debug-directory="$TEST_RESULTS/debug" \
+              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,9 +387,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
             # The license expires 15-Oct-2025.
             KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
 
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \ \
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
                   -enable-enterprise \
                   -enterprise-license-secret-name=ent-license \
                   -enterprise-license-secret-key=key \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
           command: |
             terraform init
 
-            terraform apply -var cluster_count=2 -auto-approve
+            terraform apply -var cluster_count=2 -var tags={"build_url": "$CIRCLE_BUILD_URL"} -auto-approve
 
       # Restore go module cache if there is one
       - restore_cache:
@@ -367,27 +367,13 @@ jobs:
             chmod 600 "$primary_kubeconfig"
             chmod 600 "$secondary_kubeconfig"
 
-            # We have to run the tests for each package separately so that we can
-            # exit early if any test fails (-failfast only works within a single
-            # package).
-            exit_code=0
-            for pkg in $(go list ./...)
-            do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
-                    -enable-enterprise \
-                    -enable-multi-cluster \
-                    -kubeconfig="$primary_kubeconfig" \
-                    -secondary-kubeconfig="$secondary_kubeconfig" \
-                    -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
-              then
-                echo "Tests in ${pkg} failed, aborting early"
-                exit_code=1
-                break
-              fi
-            done
-            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
-            exit $exit_code
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast
+                -enable-enterprise \
+                -enable-multi-cluster \
+                -kubeconfig="$primary_kubeconfig" \
+                -secondary-kubeconfig="$secondary_kubeconfig" \
+                -debug-directory="$TEST_RESULTS/debug" \
+                -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -646,7 +632,7 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance:
+      - acceptance-eks-1-17:
           requires:
             - unit-helm
             - unit-acceptance-framework

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,11 +184,13 @@ jobs:
             terraform init
             echo "${GOOGLE_CREDENTIALS}" | gcloud auth activate-service-account --key-file=-
 
+            # On GKE, we're setting the build number instead of build URL because label values
+            # cannot contain dashes.
             terraform apply \
               -var project=${CLOUDSDK_CORE_PROJECT} \
               -var init_cli=true \
               -var cluster_count=2 \
-              -var labels="{\"build_url\": \"$CIRCLE_BUILD_URL\"}" \
+              -var labels="{\"build_number\": \"CIRCLE_BUILD_NUM\"}" \
               -auto-approve
 
       # Restore go module cache if there is one

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,12 @@ jobs:
             terraform init
             echo "${GOOGLE_CREDENTIALS}" | gcloud auth activate-service-account --key-file=-
 
-            terraform apply -var project=${CLOUDSDK_CORE_PROJECT} -var init_cli=true -var cluster_count=2 -auto-approve
+            terraform apply \
+              -var project=${CLOUDSDK_CORE_PROJECT} \
+              -var init_cli=true \
+              -var cluster_count=2 \
+              -var labels="{\"build_url\": \"$CIRCLE_BUILD_URL\"}" \
+              -auto-approve
 
       # Restore go module cache if there is one
       - restore_cache:
@@ -206,30 +211,16 @@ jobs:
             # The license expires 15-Oct-2025.
             KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
 
-            # We have to run the tests for each package separately so that we can
-            # exit early if any test fails (-failfast only works within a single
-            # package).
-            exit_code=0
-            for pkg in $(go list ./...)
-            do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 30m -failfast \
-                    -enable-enterprise \
-                    -enterprise-license-secret-name=ent-license \
-                    -enterprise-license-secret-key=key \
-                    -enable-pod-security-policies \
-                    -enable-multi-cluster \
-                    -kubeconfig="$primary_kubeconfig" \
-                    -secondary-kubeconfig="$secondary_kubeconfig" \
-                    -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
-              then
-                echo "Tests in ${pkg} failed, aborting early"
-                exit_code=1
-                break
-              fi
-            done
-            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
-            exit $exit_code
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \ \
+                  -enable-enterprise \
+                  -enterprise-license-secret-name=ent-license \
+                  -enterprise-license-secret-key=key \
+                  -enable-pod-security-policies \
+                  -enable-multi-cluster \
+                  -kubeconfig="$primary_kubeconfig" \
+                  -secondary-kubeconfig="$secondary_kubeconfig" \
+                  -debug-directory="$TEST_RESULTS/debug" \
+                  -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -263,7 +254,12 @@ jobs:
           command: |
             terraform init
 
-            terraform apply -var client_id="$ARM_CLIENT_ID" -var client_secret="$ARM_CLIENT_SECRET" -var cluster_count=2 -auto-approve
+            terraform apply \
+              -var client_id="$ARM_CLIENT_ID" \
+              -var client_secret="$ARM_CLIENT_SECRET" \
+              -var cluster_count=2 \
+              -var tags="{\"build_url\": \"$CIRCLE_BUILD_URL\"}" \
+              -auto-approve
 
       # Restore go module cache if there is one
       - restore_cache:
@@ -280,27 +276,13 @@ jobs:
             export primary_kubeconfig=$(terraform output -state ../../terraform/aks/terraform.tfstate -json | jq -r .kubeconfigs.value[0])
             export secondary_kubeconfig=$(terraform output -state ../../terraform/aks/terraform.tfstate -json | jq -r .kubeconfigs.value[1])
 
-            # We have to run the tests for each package separately so that we can
-            # exit early if any test fails (-failfast only works within a single
-            # package).
-            exit_code=0
-            for pkg in $(go list ./...)
-            do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 40m -failfast \
-                    -enable-enterprise \
-                    -enable-multi-cluster \
-                    -kubeconfig="$primary_kubeconfig" \
-                    -secondary-kubeconfig="$secondary_kubeconfig" \
-                    -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
-              then
-                echo "Tests in ${pkg} failed, aborting early"
-                exit_code=1
-                break
-              fi
-            done
-            gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
-            exit $exit_code
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
+                -enable-enterprise \
+                -enable-multi-cluster \
+                -kubeconfig="$primary_kubeconfig" \
+                -secondary-kubeconfig="$secondary_kubeconfig" \
+                -debug-directory="$TEST_RESULTS/debug" \
+                -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -314,9 +296,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-17:
     environment:
@@ -367,7 +349,7 @@ jobs:
             chmod 600 "$primary_kubeconfig"
             chmod 600 "$secondary_kubeconfig"
 
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 40m -failfast \
                 -enable-enterprise \
                 -enable-multi-cluster \
                 -kubeconfig="$primary_kubeconfig" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
               -var project=${CLOUDSDK_CORE_PROJECT} \
               -var init_cli=true \
               -var cluster_count=2 \
-              -var labels="{\"build_number\": \"CIRCLE_BUILD_NUM\"}" \
+              -var labels="{\"build_number\": \"$CIRCLE_BUILD_NUM\"}" \
               -auto-approve
 
       # Restore go module cache if there is one

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,9 +236,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-18:
     environment:
@@ -298,9 +298,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-17:
     environment:
@@ -371,9 +371,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -620,9 +620,6 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,9 +234,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-18:
     environment:
@@ -614,10 +614,13 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance-eks-1-17:
+      - acceptance:
           requires:
             - unit-helm
             - unit-acceptance-framework
+      - acceptance-gke-1-16
+      - acceptance-eks-1-17
+      - acceptance-aks-1-18
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
             echo "${GOOGLE_CREDENTIALS}" | gcloud auth activate-service-account --key-file=-
 
             # On GKE, we're setting the build number instead of build URL because label values
-            # cannot contain dashes.
+            # cannot contain '/'.
             terraform apply \
               -var project=${CLOUDSDK_CORE_PROJECT} \
               -var init_cli=true \

--- a/test/acceptance/tests/metrics/metrics_test.go
+++ b/test/acceptance/tests/metrics/metrics_test.go
@@ -94,7 +94,12 @@ func TestAppMetrics(t *testing.T) {
 		"global.metrics.enabled": "true",
 
 		// This image is required till Consul 1.10 is released and the CI config is updated.
+		// Note we need to set ent license to empty explicitly so that if tests have ent license
+		// globally provided this test won't try to apply it because this image is not an enterprise image.
+		// TODO: Remove this setting and ent license settings once Consul alpha is released.
 		"global.image": "docker.mirror.hashicorp.services/hashicorpdev/consul:latest",
+		"server.enterpriseLicense.secretName": "",
+		"server.enterpriseLicense.secretKey": "",
 
 		"connectInject.enabled":                      "true",
 		"connectInject.metrics.defaultEnableMerging": "true",

--- a/test/acceptance/tests/metrics/metrics_test.go
+++ b/test/acceptance/tests/metrics/metrics_test.go
@@ -97,9 +97,9 @@ func TestAppMetrics(t *testing.T) {
 		// Note we need to set ent license to empty explicitly so that if tests have ent license
 		// globally provided this test won't try to apply it because this image is not an enterprise image.
 		// TODO: Remove this setting and ent license settings once Consul alpha is released.
-		"global.image": "docker.mirror.hashicorp.services/hashicorpdev/consul:latest",
+		"global.image":                        "docker.mirror.hashicorp.services/hashicorpdev/consul:latest",
 		"server.enterpriseLicense.secretName": "",
-		"server.enterpriseLicense.secretKey": "",
+		"server.enterpriseLicense.secretKey":  "",
 
 		"connectInject.enabled":                      "true",
 		"connectInject.metrics.defaultEnableMerging": "true",

--- a/test/terraform/aks/main.tf
+++ b/test/terraform/aks/main.tf
@@ -14,6 +14,8 @@ resource "azurerm_resource_group" "default" {
   count    = var.cluster_count
   name     = "consul-k8s-${random_id.suffix[count.index].dec}"
   location = var.location
+
+  tags = var.tags
 }
 
 resource "azurerm_kubernetes_cluster" "default" {
@@ -39,6 +41,8 @@ resource "azurerm_kubernetes_cluster" "default" {
   role_based_access_control {
     enabled = true
   }
+
+  tags = var.tags
 }
 
 resource "local_file" "kubeconfigs" {

--- a/test/terraform/aks/variables.tf
+++ b/test/terraform/aks/variables.tf
@@ -17,3 +17,9 @@ variable "cluster_count" {
   default     = 1
   description = "The number of Kubernetes clusters to create."
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to attach to the created resources."
+}

--- a/test/terraform/eks/main.tf
+++ b/test/terraform/eks/main.tf
@@ -43,6 +43,8 @@ module "vpc" {
     "kubernetes.io/cluster/consul-k8s-${random_id.suffix[count.index].dec}" = "shared"
     "kubernetes.io/role/internal-elb"                                       = "1"
   }
+
+  tags = var.tags
 }
 
 module "eks" {
@@ -70,6 +72,8 @@ module "eks" {
   manage_aws_auth    = false
   write_kubeconfig   = true
   config_output_path = pathexpand("~/.kube/consul-k8s-${random_id.suffix[count.index].dec}")
+
+  tags = var.tags
 }
 
 data "aws_eks_cluster" "cluster" {

--- a/test/terraform/eks/variables.tf
+++ b/test/terraform/eks/variables.tf
@@ -14,7 +14,7 @@ variable "role_arn" {
 }
 
 variable "tags" {
-  type = map()
+  type = map
   default = {}
   description = "Tags to attach to AWS resources created here."
 }

--- a/test/terraform/eks/variables.tf
+++ b/test/terraform/eks/variables.tf
@@ -16,5 +16,5 @@ variable "role_arn" {
 variable "tags" {
   type = map
   default = {}
-  description = "Tags to attach to AWS resources created here."
+  description = "Tags to attach to the created resources."
 }

--- a/test/terraform/eks/variables.tf
+++ b/test/terraform/eks/variables.tf
@@ -12,3 +12,9 @@ variable "role_arn" {
   default     = ""
   description = "AWS role for the AWS provider to assume when running these templates."
 }
+
+variable "tags" {
+  type = map()
+  default = {}
+  description = "Tags to attach to AWS resources created here."
+}

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -28,6 +28,8 @@ resource "google_container_cluster" "cluster" {
   pod_security_policy_config {
     enabled = true
   }
+
+  resource_labels = var.labels
 }
 
 resource "null_resource" "kubectl" {

--- a/test/terraform/gke/variables.tf
+++ b/test/terraform/gke/variables.tf
@@ -20,3 +20,9 @@ variable "cluster_count" {
   default     = 1
   description = "The number of Kubernetes clusters to create."
 }
+
+variable "labels" {
+  type = map
+  default = {}
+  description = "Labels to attach to the created resources."
+}


### PR DESCRIPTION
Sometimes resources created by terraform for tests don't cleaned up properly during terraform destroy. As a result, over time we accumulate resources in AWS and Azure that we then have to delete manually. This PR proposes to add a tag/label containing either this build URL or build number so we can better track why those resources were not removed.

Changes proposed in this PR:
- Pass either build URL or build number to terraform resources for GCP/AWS/Azure. On GKE, we can't pass build URL because `/` is not a valid character in labels
- Remove scripting logic that makes tests fail early (we don't need it in nightly acceptance tests)
- Fix metrics merging test on GKE. We are running tests there with enterprise license enabled, but since we're setting the consul image to OSS one, we should also unset enterprise license values so that we don't try to run the enterprise license commands against OSS binary,  where they don't exist.

How I've tested this PR:
Enabled all tests in this PR (https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2590/workflows/8925e10f-ddb8-4560-ba4b-c99f08a830a7) and checked that created resources have tags or labels.

How I expect reviewers to test this PR:
Code review



