### PR TITLE
Refactor Connect Inject Webhook to use webhook-cert-manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+                    -consul-k8s-image=ishustava/consul-k8s-dev:04-06-2021-37a4384 # TODO: change once feature-tproxy consul-k8s branch is merged
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,18 +133,17 @@ jobs:
             # exit early if any test fails (-failfast only works within a single
             # package).
             exit_code=0
-            pkgs=$(go list ./... | circleci tests split)
+            pkgs=$(go list ./... | grep -v -E 'metrics'| circleci tests split)
             echo "Running $pkgs"
             for pkg in $pkgs
             do
               if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 30m -failfast \
                     -use-kind \
                     -enable-multi-cluster \
-                    -enable-enterprise \
                     -kubecontext="kind-dc1" \
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
-                    -consul-k8s-image=ishustava/consul-k8s-dev:04-06-2021-37a4384 # TODO: change once feature-tproxy consul-k8s branch is merged
+                    -consul-k8s-image=ishustava/consul-k8s-dev:04-06-2021-8a9a841 # TODO: change once feature-tproxy consul-k8s branch is merged
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/templates/connect-inject-authmethod-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
 apiVersion: v1
 kind: ServiceAccount

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 # The ClusterRole to enable the Connect injector to get, list, watch and patch MutatingWebhookConfiguration.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -10,19 +10,12 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: 
-    - "get"
-    - "list"
-    - "watch"
-    - "patch"
 - apiGroups: [""]
-  resources: ["pods", "nodes"]
+  resources: ["pods", "nodes", "endpoints"]
   verbs:
-    - "get"
-    - "list"
-    - "watch"
+  - "get"
+  - "list"
+  - "watch"
 {{- if .Values.global.enablePodSecurityPolicies }}
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]
@@ -34,10 +27,10 @@ rules:
 {{- if .Values.global.acls.manageSystemACLs }}
 - apiGroups: [""]
   resources:
-    - secrets
+  - secrets
   resourceNames:
-    - {{ template "consul.fullname" . }}-connect-inject-acl-token
+  - {{ template "consul.fullname" . }}-connect-inject-acl-token
   verbs:
-    - get
+  - get
 {{- end }}
 {{- end }}

--- a/templates/connect-inject-clusterrolebinding.yaml
+++ b/templates/connect-inject-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,7 +13,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "consul.fullname" . }}-connect-injector-webhook
 subjects:
-  - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -181,26 +181,6 @@ spec:
                 -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
-{{/*          livenessProbe:*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /health/ready*/}}
-{{/*              port: 8080*/}}
-{{/*              scheme: HTTPS*/}}
-{{/*            failureThreshold: 2*/}}
-{{/*            initialDelaySeconds: 1*/}}
-{{/*            periodSeconds: 2*/}}
-{{/*            successThreshold: 1*/}}
-{{/*            timeoutSeconds: 5*/}}
-{{/*          readinessProbe:*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /health/ready*/}}
-{{/*              port: 8080*/}}
-{{/*              scheme: HTTPS*/}}
-{{/*            failureThreshold: 2*/}}
-{{/*            initialDelaySeconds: 2*/}}
-{{/*            periodSeconds: 2*/}}
-{{/*            successThreshold: 1*/}}
-{{/*            timeoutSeconds: 5*/}}
           volumeMounts:
           - name: certs
             mountPath: /etc/connect-injector/certs

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -36,12 +36,14 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
     spec:
-  {{- if not .Values.connectInject.certs.secretName }}
       serviceAccountName: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
-  {{- end }}
       containers:
         - name: sidecar-injector
           image: "{{ default .Values.global.imageK8S .Values.connectInject.image }}"
+          ports:
+          - containerPort: 8080
+            name: webhook-server
+            protocol: TCP
           env:
             - name: NAMESPACE
               valueFrom:
@@ -132,13 +134,7 @@ spec:
                 -consul-cross-namespace-acl-policy=cross-namespace-policy \
                 {{- end }}
                 {{- end }}
-                {{- if .Values.connectInject.certs.secretName }}
-                -tls-cert-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.certName }} \
-                -tls-key-file=/etc/connect-injector/certs/{{ .Values.connectInject.certs.keyName }} \
-                {{- else }}
-                -tls-auto=${CONSUL_FULLNAME}-connect-injector-cfg \
-                -tls-auto-hosts=${CONSUL_FULLNAME}-connect-injector-svc,${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE},${CONSUL_FULLNAME}-connect-injector-svc.${NAMESPACE}.svc \
-                {{- end }}
+                -tls-cert-dir=/etc/connect-injector/certs \
                 {{- $resources := .Values.connectInject.sidecarProxy.resources }}
                 {{- /* kindIs is used here to differentiate between null and 0 */}}
                 {{- if not (kindIs "invalid" $resources.limits.memory) }}
@@ -185,81 +181,66 @@ spec:
                 -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTPS
-            failureThreshold: 2
-            initialDelaySeconds: 1
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTPS
-            failureThreshold: 2
-            initialDelaySeconds: 2
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 5
-          startupProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTPS
-            failureThreshold: 15
-            periodSeconds: 2
-            timeoutSeconds: 5
-          {{- if (or .Values.connectInject.certs.secretName .Values.global.tls.enabled) }}
+{{/*          livenessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /health/ready*/}}
+{{/*              port: 8080*/}}
+{{/*              scheme: HTTPS*/}}
+{{/*            failureThreshold: 2*/}}
+{{/*            initialDelaySeconds: 1*/}}
+{{/*            periodSeconds: 2*/}}
+{{/*            successThreshold: 1*/}}
+{{/*            timeoutSeconds: 5*/}}
+{{/*          readinessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /health/ready*/}}
+{{/*              port: 8080*/}}
+{{/*              scheme: HTTPS*/}}
+{{/*            failureThreshold: 2*/}}
+{{/*            initialDelaySeconds: 2*/}}
+{{/*            periodSeconds: 2*/}}
+{{/*            successThreshold: 1*/}}
+{{/*            timeoutSeconds: 5*/}}
           volumeMounts:
-            {{- if .Values.connectInject.certs.secretName }}
-            - name: certs
-              mountPath: /etc/connect-injector/certs
-              readOnly: true
-            {{- end }}
-            {{- if .Values.global.tls.enabled }}
-            {{- if .Values.global.tls.enableAutoEncrypt }}
-            - name: consul-auto-encrypt-ca-cert
-            {{- else }}
-            - name: consul-ca-cert
-            {{- end }}
-              mountPath: /consul/tls/ca
-              readOnly: true
-            {{- end }}
-            {{- end }}
+          - name: certs
+            mountPath: /etc/connect-injector/certs
+            readOnly: true
+          {{- if .Values.global.tls.enabled }}
+          {{- if .Values.global.tls.enableAutoEncrypt }}
+          - name: consul-auto-encrypt-ca-cert
+          {{- else }}
+          - name: consul-ca-cert
+          {{- end }}
+            mountPath: /consul/tls/ca
+            readOnly: true
+          {{- end }}
           {{- with .Values.connectInject.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if (or .Values.connectInject.certs.secretName .Values.global.tls.enabled) }}
       volumes:
-        {{- if .Values.connectInject.certs.secretName }}
-        - name: certs
-          secret:
-            secretName: {{ .Values.connectInject.certs.secretName }}
-        {{- end }}
-        {{- if .Values.global.tls.enabled }}
-        {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
-        - name: consul-ca-cert
-          secret:
-            {{- if .Values.global.tls.caCert.secretName }}
-            secretName: {{ .Values.global.tls.caCert.secretName }}
-            {{- else }}
-            secretName: {{ template "consul.fullname" . }}-ca-cert
-            {{- end }}
-            items:
-            - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
-              path: tls.crt
-        {{- end }}
-        {{- if .Values.global.tls.enableAutoEncrypt }}
-        - name: consul-auto-encrypt-ca-cert
-          emptyDir:
-            medium: "Memory"
-        {{- end }}
-        {{- end }}
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ template "consul.fullname" . }}-connect-inject-webhook-cert
+      {{- if .Values.global.tls.enabled }}
+      {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+      - name: consul-ca-cert
+        secret:
+          {{- if .Values.global.tls.caCert.secretName }}
+          secretName: {{ .Values.global.tls.caCert.secretName }}
+          {{- else }}
+          secretName: {{ template "consul.fullname" . }}-ca-cert
+          {{- end }}
+          items:
+          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+            path: tls.crt
+      {{- end }}
+      {{- if .Values.global.tls.enableAutoEncrypt }}
+      - name: consul-auto-encrypt-ca-cert
+        emptyDir:
+          medium: "Memory"
+      {{- end }}
       {{- end }}
       {{- if or (and .Values.global.acls.manageSystemACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -26,7 +26,7 @@ webhooks:
         name: {{ template "consul.fullname" . }}-connect-injector-svc
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
-      caBundle: {{ .Values.connectInject.certs.caBundle | quote }}
+      caBundle: Cg==
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -26,7 +26,6 @@ webhooks:
         name: {{ template "consul.fullname" . }}-connect-injector-svc
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
-      caBundle: Cg==
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.connectInject.certs.secretName) (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/webhook-cert-manager-clusterrole.yaml
+++ b/templates/webhook-cert-manager-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if or .Values.connectInject.enabled .Values.controller.enabled}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/webhook-cert-manager-clusterrolebinding.yaml
+++ b/templates/webhook-cert-manager-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if or .Values.connectInject.enabled .Values.controller.enabled}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/webhook-cert-manager-configmap.yaml
+++ b/templates/webhook-cert-manager-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if or .Values.connectInject.enabled .Values.controller.enabled}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,10 +13,24 @@ metadata:
 data:
   webhook-config.json: |-
     [
+    {{- if .Values.connectInject.enabled }}
+      {
+        "name": "{{ template "consul.fullname" . }}-connect-injector-cfg",
+        "tlsAutoHosts": [
+          "{{ template "consul.fullname" . }}-connect-injector-svc",
+          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}",
+          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}.svc",
+          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}.svc.cluster.local"
+        ],
+        "secretName": "{{ template "consul.fullname" . }}-connect-inject-webhook-cert",
+        "secretNamespace": "{{ .Release.Namespace }}"
+      },
+    {{- end }}
       {
         "name": "{{ template "consul.fullname" . }}-controller-mutating-webhook-configuration",
         "tlsAutoHosts": [
           "{{ template "consul.fullname" . }}-controller-webhook",
+          "{{ template "consul.fullname" . }}-controller-webhook.{{ .Release.Namespace }}",
           "{{ template "consul.fullname" . }}-controller-webhook.{{ .Release.Namespace }}.svc",
           "{{ template "consul.fullname" . }}-controller-webhook.{{ .Release.Namespace }}.svc.cluster.local"
         ],

--- a/templates/webhook-cert-manager-configmap.yaml
+++ b/templates/webhook-cert-manager-configmap.yaml
@@ -24,8 +24,8 @@ data:
         ],
         "secretName": "{{ template "consul.fullname" . }}-connect-inject-webhook-cert",
         "secretNamespace": "{{ .Release.Namespace }}"
-      },
-    {{- end }}
+      }{{- if and .Values.controller.enabled }},{{- end }}{{- end }}
+    {{- if and .Values.controller.enabled }}
       {
         "name": "{{ template "consul.fullname" . }}-controller-mutating-webhook-configuration",
         "tlsAutoHosts": [
@@ -37,6 +37,6 @@ data:
         "secretName": "{{ template "consul.fullname" . }}-controller-webhook-cert",
         "secretNamespace": "{{ .Release.Namespace }}"
       }
+    {{- end }}
     ]
-
-{{- end }}
+  {{- end }}

--- a/templates/webhook-cert-manager-deployment.yaml
+++ b/templates/webhook-cert-manager-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if or .Values.connectInject.enabled .Values.controller.enabled}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,5 +55,4 @@ spec:
       - name: config
         configMap:
           name: {{ template "consul.fullname" . }}-webhook-cert-manager-config
-
 {{- end }}

--- a/templates/webhook-cert-manager-podsecuritypolicy.yaml
+++ b/templates/webhook-cert-manager-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.enabled .Values.global.enablePodSecurityPolicies }}
+{{- if and (or .Values.controller.enabled .Values.connectInject.enabled) .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/templates/webhook-cert-manager-serviceaccount.yaml
+++ b/templates/webhook-cert-manager-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if or .Values.connectInject.enabled .Values.controller.enabled}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
@@ -1,4 +1,4 @@
-resources:
-  - deployment.yaml
-  - serviceaccount.yaml
-  - rolebinding.yaml
+#resources:
+#  - deployment.yaml
+#  - serviceaccount.yaml
+#  - rolebinding.yaml

--- a/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
   - deployment.yaml
+  - service.yaml
   - serviceaccount.yaml
   - rolebinding.yaml

--- a/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/kustomization.yaml
@@ -1,4 +1,4 @@
-#resources:
-#  - deployment.yaml
-#  - serviceaccount.yaml
-#  - rolebinding.yaml
+resources:
+  - deployment.yaml
+  - serviceaccount.yaml
+  - rolebinding.yaml

--- a/test/acceptance/tests/fixtures/bases/static-client/service.yaml
+++ b/test/acceptance/tests/fixtures/bases/static-client/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-client
+spec:
+  selector:
+    app: static-client
+  ports:
+    - port: 80

--- a/test/unit/connect-inject-clusterrole.bats
+++ b/test/unit/connect-inject-clusterrole.bats
@@ -29,25 +29,6 @@ load _helpers
       .
 }
 
-@test "connectInject/ClusterRole: disabled with connectInject.certs.secretName set" {
-  cd `chart_dir`
-  assert_empty helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.certs.secretName=foo' \
-      .
-}
-
-@test "connectInject/ClusterRole: enabled with connectInject.certs.secretName not set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrole.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 

--- a/test/unit/connect-inject-clusterrolebinding.bats
+++ b/test/unit/connect-inject-clusterrolebinding.bats
@@ -28,22 +28,3 @@ load _helpers
       --set 'connectInject.enabled=false' \
       .
 }
-
-@test "connectInject/ClusterRoleBinding: disabled with connectInject.certs.secretName set" {
-  cd `chart_dir`
-  assert_empty helm template \
-      -s templates/connect-inject-clusterrolebinding.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.certs.secretName=foo' \
-      .
-}
-
-@test "connectInject/ClusterRoleBinding: enabled with connectInject.certs.secretName not set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-clusterrolebinding.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -482,85 +482,6 @@ EOF
 
 
 #--------------------------------------------------------------------
-# cert secrets
-
-@test "connectInject/Deployment: no secretName: no tls-{cert,key}-file set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-cert-file"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-key-file"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-auto"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "connectInject/Deployment: with secretName: tls-{cert,key}-file set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.certs.secretName=foo' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-cert-file"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.certs.secretName=foo' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-key-file"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.certs.secretName=foo' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-tls-auto"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-
-#--------------------------------------------------------------------
-# service account name
-
-@test "connectInject/Deployment: with secretName: no serviceAccountName set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.certs.secretName=foo' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.serviceAccountName | has("serviceAccountName")' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "connectInject/Deployment: no secretName: serviceAccountName set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.serviceAccountName | contains("connect-injector-webhook-svc-account")' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-#--------------------------------------------------------------------
 # affinity
 
 @test "connectInject/Deployment: affinity not set by default" {
@@ -703,18 +624,6 @@ EOF
   [ "${actual}" != "" ]
 }
 
-@test "connectInject/Deployment: Adds both tls-ca-cert and certs volumes when global.tls.enabled is true and connectInject.certs.secretName is set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'connectInject.certs.secretName=foo' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
-}
-
 @test "connectInject/Deployment: Adds tls-ca-cert volumeMounts when global.tls.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -724,18 +633,6 @@ EOF
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" != "" ]
-}
-
-@test "connectInject/Deployment: Adds both tls-ca-cert and certs volumeMounts when global.tls.enabled is true and connectInject.certs.secretName is set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'connectInject.certs.secretName=foo' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
 }
 
 @test "connectInject/Deployment: can overwrite CA secret with the provided one" {

--- a/test/unit/connect-inject-serviceaccount.bats
+++ b/test/unit/connect-inject-serviceaccount.bats
@@ -28,26 +28,6 @@ load _helpers
       --set 'connectInject.enabled=false' \
       .
 }
-
-@test "connectInject/ServiceAccount: disabled with connectInject.certs.secretName set" {
-  cd `chart_dir`
-  assert_empty helm template \
-      -s templates/connect-inject-serviceaccount.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.certs.secretName=foo' \
-      .
-}
-
-@test "connectInject/ServiceAccount: enabled with connectInject.certs.secretName not set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/connect-inject-serviceaccount.yaml  \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 #--------------------------------------------------------------------
 # global.imagePullSecrets
 

--- a/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/test/unit/webhook-cert-manager-clusterrole.bats
@@ -9,11 +9,32 @@ load _helpers
       .
 }
 
-@test "webhookCertManager/ClusterRole: enabled with controller.enabled=true" {
+@test "webhookCertManager/ClusterRole: enabled with controller.enabled=true and connectInject.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/webhook-cert-manager-clusterrole.yaml  \
       --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ClusterRole: enabled with connectInject.enabled=true and controller.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-clusterrole.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ClusterRole: enabled with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-clusterrole.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/webhook-cert-manager-clusterrolebinding.bats
+++ b/test/unit/webhook-cert-manager-clusterrolebinding.bats
@@ -9,11 +9,32 @@ load _helpers
       .
 }
 
-@test "webhookCertManager/ClusterRoleBinding: enabled with controller.enabled=true" {
+@test "webhookCertManager/ClusterRoleBinding: enabled with controller.enabled=true and connectInject.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/webhook-cert-manager-clusterrolebinding.yaml  \
       --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ClusterRoleBinding: enabled with connectInject.enabled=true and controller.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-clusterrolebinding.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ClusterRoleBinding: enabled with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-clusterrolebinding.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/webhook-cert-manager-configmap.bats
+++ b/test/unit/webhook-cert-manager-configmap.bats
@@ -18,3 +18,76 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "webhookCertManager/Configmap: enabled with connectInject.enabled=true and controller.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-configmap.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Configmap: enabled with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-configmap.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Configmap: configuration has only controller webhook with controller.enabled=true" {
+  cd `chart_dir`
+  local cfg=$(helm template \
+      -s templates/webhook-cert-manager-configmap.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.data["webhook-config.json"]' | tee /dev/stderr)
+
+  local actual=$(echo $cfg | jq '. | length == 1')
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $cfg | jq '.[0].name | contains("controller-mutating-webhook-configuration")')
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Configmap: configuration has only controller webhook with connectInject.enabled=true" {
+  cd `chart_dir`
+  local cfg=$(helm template \
+      -s templates/webhook-cert-manager-configmap.yaml  \
+      --set 'controller.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["webhook-config.json"]' | tee /dev/stderr)
+
+  local actual=$(echo $cfg | jq '. | length == 1')
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $cfg | jq '.[0].name | contains("controller-mutating-webhook-configuration")')
+  [ "${actual}" = "false" ]
+}
+
+@test "webhookCertManager/Configmap: configuration contains both controller and connectInject webhook with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local cfg=$(helm template \
+      -s templates/webhook-cert-manager-configmap.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["webhook-config.json"]' | tee /dev/stderr)
+
+
+  local actual=$(echo $cfg | jq '. | length == 2')
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $cfg | jq '.[0].name | contains("connect-injector-cfg")')
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $cfg | jq '.[1].name | contains("controller-mutating-webhook-configuration")')
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/webhook-cert-manager-deployment.bats
+++ b/test/unit/webhook-cert-manager-deployment.bats
@@ -9,11 +9,32 @@ load _helpers
       .
 }
 
-@test "webhookCertManager/Deployment: enabled with controller.enabled=true" {
+@test "webhookCertManager/Deployment: enabled with controller.enabled=true and connectInject.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/webhook-cert-manager-deployment.yaml  \
       --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Deployment: enabled with connectInject.enabled=true and controller.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Deployment: enabled with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/webhook-cert-manager-podsecuritypolicy.bats
+++ b/test/unit/webhook-cert-manager-podsecuritypolicy.bats
@@ -17,7 +17,7 @@ load _helpers
       .
 }
 
-@test "webhookCertManager/PodSecurityPolicy: enabled with controller enabled and global.enablePodSecurityPolicies=true" {
+@test "webhookCertManager/PodSecurityPolicy: enabled with controller.enabled=true, connectInject.enabled=false and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
@@ -25,5 +25,28 @@ load _helpers
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Configmap: enabled with connectInject.enabled=true, controller.enabled=false and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/Configmap: enabled with connectInject.enabled=true, controller.enabled=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/test/unit/webhook-cert-manager-serviceaccount.bats
+++ b/test/unit/webhook-cert-manager-serviceaccount.bats
@@ -9,11 +9,32 @@ load _helpers
       .
 }
 
-@test "webhookCertManager/ServiceAccount: enabled with controller.enabled=true" {
+@test "webhookCertManager/ServiceAccount: enabled with controller.enabled=true and connectInject.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/webhook-cert-manager-serviceaccount.yaml  \
       --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ServiceAccount: enabled with connectInject.enabled=true and controller.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "webhookCertManager/ServiceAccount: enabled with connectInject.enabled=true and controller.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-serviceaccount.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/values.yaml
+++ b/values.yaml
@@ -1451,32 +1451,6 @@ connectInject:
     # `k8s-staging` Consul namespace.
     mirroringK8SPrefix: ""
 
-  # The certs section configures how the webhook TLS certs are configured.
-  # These are the TLS certs for the Kube apiserver communicating to the
-  # webhook. By default, the injector will generate and manage its own certs,
-  # but this requires the ability for the injector to update its own
-  # MutatingWebhookConfiguration. In a production environment, custom certs
-  # should probably be used. Configure the values below to enable this.
-  certs:
-    # Name of the secret that has the TLS certificate and
-    # private key to serve the injector webhook. If this is null, then the
-    # injector will default to its automatic management mode that will assign
-    # a service account to the injector to generate its own certificates.
-    secretName: null
-
-    # Base64-encoded PEM-encoded certificate bundle for the
-    # CA that signed the TLS certificate that the webhook serves. This must
-    # be set if secretName is non-null.
-    caBundle: ""
-
-    # Name of the file within the secret for
-    # the TLS cert.
-    certName: tls.crt
-
-    # Name of the file within the secret for
-    # the private TLS key.
-    keyName: tls.key
-
   # Selector labels for connectInject pod assignment, formatted as a multi-line string.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   #


### PR DESCRIPTION
This PR is a partner to hashicorp/consul-k8s#454 and proposes the following changes:
- Enable webhook-cert-manager whenever either controller or connectInject is enabled
- Remove connectInject.certs values. It seems like this behavior was already broken, and we don't want to support it going forward with webhook-cert-manager.

The draft was created by @thisisnotashwin and cleanup and tests added by @ishustava.

---
[original description]
This is a rough draft but is at a good place to see the changes made and the impact on Helm. This will eventually be a PR against a `feature-tproxy` branch
