### PR TITLE
Add `topologySpreadConstraints` support for server pods

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
-    {{- if .Values.server.topologySpreadConstraints }}
+    {{- if and (.Values.server.topologySpreadConstraints) (and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "18")) }}
       topologySpreadConstraints:
         {{ tpl .Values.server.topologySpreadConstraints . | nindent 8 | trim }}
     {{- end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -64,6 +64,10 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
+    {{- if .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.server.topologySpreadConstraints . | nindent 8 | trim }}
+    {{- end }}
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "consul.fullname" . }}-server
       {{- if not .Values.global.openshift.enabled }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -64,9 +64,13 @@ spec:
       tolerations:
         {{ tpl .Values.server.tolerations . | nindent 8 | trim }}
     {{- end }}
-    {{- if and (.Values.server.topologySpreadConstraints) (and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "18")) }}
+    {{- if .Values.server.topologySpreadConstraints }}
+    {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "18") }}
       topologySpreadConstraints:
         {{ tpl .Values.server.topologySpreadConstraints . | nindent 8 | trim }}
+    {{- else }}
+    {{- fail "`topologySpreadConstraints` requires Kubernetes 1.18 and above." }}
+    {{- end }}
     {{- end }}
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "consul.fullname" . }}-server

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -670,6 +670,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# tolerations
+
+@test "server/StatefulSet: topologySpreadConstraints not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec | .topologySpreadConstraints? == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/StatefulSet: topologySpreadConstraints can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.topologySpreadConstraints=foobar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.topologySpreadConstraints == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # global.openshift.enabled & server.securityContext
 
 @test "server/StatefulSet: setting server.disableFsGroupSecurityContext fails" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -689,6 +689,15 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec.topologySpreadConstraints == "foobar"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+
+  # todo: test for Kube versions < 1.18 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
+  # not supported before 1.18
+  # local actual=$(helm template \
+  #     -s templates/server-statefulset.yaml  \
+  #     --kube-version "1.17" \
+  #     . | tee /dev/stderr |
+  #     yq '.spec.template.spec | .topologySpreadConstraints? == null' | tee /dev/stderr)
+  # [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -692,12 +692,12 @@ load _helpers
 
   # todo: test for Kube versions < 1.18 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
   # not supported before 1.18
-  # local actual=$(helm template \
+  # run helm template \
   #     -s templates/server-statefulset.yaml  \
   #     --kube-version "1.17" \
-  #     . | tee /dev/stderr |
-  #     yq '.spec.template.spec | .topologySpreadConstraints? == null' | tee /dev/stderr)
-  # [ "${actual}" = "true" ]
+  #     .
+  # [ "$status" -eq 1 ]
+  # [[ "$output" =~ "`topologySpreadConstraints` requires Kubernetes 1.18 and above." ]]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -519,6 +519,27 @@ server:
   # (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
   tolerations: ""
 
+  # Pod topology spread constaints for server pods.
+  # This should be a multi-line YAML string matching the `topologySpreadConstraints` array
+  # (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
+  #
+  # This requires K8S >= 1.18 (beta) or 1.19 (stable)
+  #
+  # Example:
+  #
+  # ```yaml
+  # topologySpreadConstraints: |
+  #   - maxSkew: 1
+  #     topologyKey: topology.kubernetes.io/zone
+  #     whenUnsatisfiable: DoNotSchedule
+  #     labelSelector:
+  #       matchLabels:
+  #         app: {{ template "consul.name" . }}
+  #         release: "{{ .Release.Name }}"
+  #         component: server
+  # ```
+  topologySpreadConstraints: ""
+
   # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
   # labels for server pod assignment, formatted as a multi-line string.
   #

--- a/values.yaml
+++ b/values.yaml
@@ -519,11 +519,11 @@ server:
   # (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
   tolerations: ""
 
-  # Pod topology spread constaints for server pods.
+  # Pod topology spread constraints for server pods.
   # This should be a multi-line YAML string matching the `topologySpreadConstraints` array
   # (https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) in a Pod Spec.
   #
-  # This requires K8S >= 1.18 (beta) or 1.19 (stable)
+  # This requires K8S >= 1.18 (beta) or 1.19 (stable).
   #
   # Example:
   #


### PR DESCRIPTION
Changes proposed in this PR:

- Add `topologySpreadConstraints` support for server pods

How I've tested this PR:

- Deploy a new Consul cluster with `server.topologySpreadConstraints` set.

How I expect reviewers to test this PR:

- Deploy a new Consul cluster with `server.topologySpreadConstraints` set.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

Note:

This helps to spread server pods evenly into all AZs.

- This is best used with `podAntiAffinity` set to the topology key.
- Cluster Autoscaler does not understand this at the moment. See https://github.com/kubernetes/autoscaler/issues/3879
