### PR TITLE
change apiVersion to v2 for Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 BREAKING CHANGES:
+* Helm 2 is no longer supported as of the previous release, 0.30.0. the `apiVersion` for the `Charts.yaml` is now correctly set to `v2` to properly indicate that the chart is now only supported for Helm 3 [[GH-868](https://github.com/hashicorp/consul-helm/pull/868)]
 
 FEATURES:
 * Metrics: add support for metrics in Consul. This enables support for Consul Agent metrics,

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: consul
 version: 0.30.0
 appVersion: 1.9.3


### PR DESCRIPTION
[apiVersion](https://helm.sh/docs/topics/charts/#the-apiversion-field) sets the apiVersion to dictate whether a chart is Helm 2 or Helm 3. Helm 3 is currently on apiVersion `v2`, and as of release 0.30.0 we only support Helm 3. 

Changes proposed in this PR:
- Change apiVersion for chart to v2

How I've tested this PR:

How I expect reviewers to test this PR:

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

