### PR TITLE
Remove kubeVersion for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ BREAKING CHANGES:
 FEATURES:
 
 IMPROVEMENTS:
-* Remove `kubeVersion` in `Chart.yaml` since it was causing installs to fail on EKS and GKE [[GH-873](https://github.com/hashicorp/consul-helm/pull/873)]
 
 BUG FIXES:
+* Remove `kubeVersion` in `Chart.yaml` since it was causing installs to fail on EKS and GKE [[GH-873](https://github.com/hashicorp/consul-helm/pull/873)]
 
 ## 0.30.0 (March 18, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 ## Unreleased
 
-BREAKING CHANGES:
-
-FEATURES:
-
-IMPROVEMENTS:
-
-BUG FIXES:
-* Remove `kubeVersion` in `Chart.yaml` since it was causing installs to fail on EKS and GKE [[GH-873](https://github.com/hashicorp/consul-helm/pull/873)]
-
 ## 0.30.0 (March 18, 2021)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-## 0.30.0 (March 18, 2021)
-
 BREAKING CHANGES:
 * Helm 2 is no longer supported as of the previous release, 0.30.0. the `apiVersion` for the `Chart.yaml` is now correctly set to `v2` to properly indicate that the chart is now only supported for Helm 3 [[GH-868](https://github.com/hashicorp/consul-helm/pull/868)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 ## Unreleased
 
 BREAKING CHANGES:
+
+FEATURES:
+
+IMPROVEMENTS:
+* Remove `kubeVersion` in `Chart.yaml` since it was causing installs to fail on EKS and GKE [[GH-873](https://github.com/hashicorp/consul-helm/pull/873)]
+
+BUG FIXES:
+
+## 0.30.0 (March 18, 2021)
+
+BREAKING CHANGES:
 * Helm 2 is no longer supported as of the previous release, 0.30.0. the `apiVersion` for the `Chart.yaml` is now correctly set to `v2` to properly indicate that the chart is now only supported for Helm 3 [[GH-868](https://github.com/hashicorp/consul-helm/pull/868)]
 
 FEATURES:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: consul
 version: 0.31.0
 appVersion: 1.9.4
-kubeVersion: ">= 1.13.0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
 icon: https://raw.githubusercontent.com/hashicorp/consul-helm/master/assets/icon.png


### PR DESCRIPTION
`kubeVersion` in `Chart.yaml` was causing installs on EKS and GKE to fail. Should fix #872

Changes proposed in this PR:
- Removing `kubeVersion` field from `Chart.yaml` since it was found to be breaking installs on EKS and GKE

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

