### PR TITLE
Add back kubeVersion with wildcard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,10 +620,6 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
-      - acceptance-kind-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,6 +620,10 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
+      - acceptance-gke-1-16
+      - acceptance-eks-1-17
+      - acceptance-aks-1-18
+      - acceptance-kind-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BREAKING CHANGES 
 
-* Specify `kubeVersion` in `Chart.yaml` to denote that this chart is tested with Kubernetes 1.13+ [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
+* Specify `kubeVersion` in `Chart.yaml` to denote that this chart is compatible with Kubernetes 1.13+. [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
 
 ## 0.31.1 (Mar 19, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-BREAKING CHANGES 
+IMPROVEMENTS: 
 
 * Specify `kubeVersion` in `Chart.yaml` to denote that this chart is compatible with Kubernetes 1.13+. [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BREAKING CHANGES 
+
+* Specify kubeVersion in Chart.yaml to denote that this chart is tested with Kubernetes 1.13+ [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
+
 ## 0.31.1 (Mar 19, 2021)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BREAKING CHANGES 
 
-* Specify kubeVersion in Chart.yaml to denote that this chart is tested with Kubernetes 1.13+ [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
+* Specify `kubeVersion` in `Chart.yaml` to denote that this chart is tested with Kubernetes 1.13+ [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
 
 ## 0.31.1 (Mar 19, 2021)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: consul
 version: 0.31.1
 appVersion: 1.9.4
+kubeVersion: ">=1.13.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
 icon: https://raw.githubusercontent.com/hashicorp/consul-helm/master/assets/icon.png


### PR DESCRIPTION
Since Helm uses `Masterminds/semver` previous `kubeVersion` fields with any additional alphanumeric characters after the version would cause installs to fail on GKE and EKS. Since https://github.com/Masterminds/semver/pull/70, we should now be able pass the pre-install check since ` 1.13.0-gke-version` < `1.13.0-0 `, `1.13.0-eks-version` < `1.13.0-0`, and `1.13.0` < `1.13.0-0`.

Changes proposed in this PR:
- Add back `kubeVersion` with wildcard value `1.13.0-0`

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

