### PR TITLE
feat: support customized nodePort in ui service

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -25,11 +25,17 @@ spec:
     - name: http
       port: 80
       targetPort: 8500
+      {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.http) }}
+      nodePort: {{ .Values.ui.service.nodePort.http }}
+      {{- end }}{{ end }}
     {{- end }}
     {{- if .Values.global.tls.enabled }}
     - name: https
       port: 443
       targetPort: 8501
+      {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.https) }}
+      nodePort: {{ .Values.ui.service.nodePort.https }}
+      {{- end }}{{ end }}
     {{- end }}
   {{- if .Values.ui.service.type }}
   type: {{ .Values.ui.service.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -984,6 +984,19 @@ ui:
     # @type: string
     type: null
 
+    # Optionally hardcode the nodePort of the ui service if using a NodePort service.
+    # If not set and using a NodePort service, Kubernetes will automatically assign
+    # a port.
+    nodePort:
+
+      # HTTP node port
+      # @type: integer
+      http: null
+
+      # HTTPS node port
+      # @type: integer
+      https: null
+
     # Annotations to apply to the UI service.
     #
     # Example:

--- a/values.yaml
+++ b/values.yaml
@@ -984,7 +984,7 @@ ui:
     # @type: string
     type: null
 
-    # Optionally hardcode the nodePort of the ui service if using a NodePort service.
+    # Optionally set the nodePort value of the ui service if using a NodePort service.
     # If not set and using a NodePort service, Kubernetes will automatically assign
     # a port.
     nodePort:
@@ -1695,7 +1695,7 @@ meshGateway:
     # The targetPort will be set to meshGateway.containerPort.
     port: 443
 
-    # Optionally hardcode the nodePort of the service if using a NodePort service.
+    # Optionally set the nodePort value of the service if using a NodePort service.
     # If not set and using a NodePort service, Kubernetes will automatically assign
     # a port.
     # @type: integer


### PR DESCRIPTION
Changes proposed in this PR:
- add optional nodePort for http or/and https ports in ui service

Checklist:
- [x] Bats tests added

