### PR TITLE
use non-root folder to create apply-license script

### DIFF
--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -77,7 +77,8 @@ spec:
             - "-c"
             - |
                 # Create a script that we can execute with the timeout command.
-                cat > apply-license.sh << 'EOF'
+                mkdir -p /tmp/scripts/
+                cat > /tmp/scripts/apply-license.sh << 'EOF'
                 #!/bin/sh
                 while true; do
                   echo "Applying license..."
@@ -89,10 +90,10 @@ spec:
                   sleep 2
                 done
                 EOF
-                chmod +x ./apply-license.sh
+                chmod +x /tmp/scripts/apply-license.sh
 
                 # Time out after 20 minutes. Use || to support new timeout versions that don't accept -t
-                timeout -t 1200 ./apply-license.sh 2> /dev/null || timeout 1200 ./apply-license.sh 2> /dev/null
+                timeout -t 1200 /tmp/scripts/apply-license.sh 2> /dev/null || timeout 1200 /tmp/scripts/apply-license.sh 2> /dev/null
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
             - name: consul-ca-cert


### PR DESCRIPTION
Changes proposed in this PR:
- Use `/tmp/scripts` folder instead of the WORKDIR which is `/` to avoid getting permission denied errors when security context defaults to the non-root users

How I've tested this PR:
- I installed the helm chart with enterprise license on a k8s cluster that doesn't allow root user in security context by default and made sure the job runs Ok.

How I expect reviewers to test this PR:
- Inatall the helm chart in an openshift cluster with enterprise license and compare the pre-PR and post-PR behavior. The chart gets failed with permission denied error as openshift assigns a non-root user to the pods by default.


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

