### PR TITLE
Upgrade CRD versions to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 IMPROVEMENTS: 
 
-* Specify `kubeVersion` in `Chart.yaml` to denote that this chart is compatible with Kubernetes 1.13+. [[GH-877](https://github.com/hashicorp/consul-helm/pull/877]
+* Specify `kubeVersion` in `Chart.yaml` to denote that this chart is compatible with Kubernetes 1.16+. [[GH-883](https://github.com/hashicorp/consul-helm/pull/883)]
+* CRDs: update the CRD versions from v1beta1 to v1. [[GH-883](https://github.com/hashicorp/consul-helm/pull/883)]
+
+BREAKING CHANGES:
+* Minimum Kubernetes versions supported is 1.16+. [[GH-883](https://github.com/hashicorp/consul-helm/pull/883)]
 
 ## 0.31.1 (Mar 19, 2021)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: consul
 version: 0.31.1
 appVersion: 1.9.4
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
 icon: https://raw.githubusercontent.com/hashicorp/consul-helm/master/assets/icon.png

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use Consul with Kubernetes, please see the
 
 ## Prerequisites
   * **Helm 3.0+** (Helm 2 is not supported)
-  * **Kubernetes 1.13+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.16+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/templates/controller-clusterrole.yaml
+++ b/templates/controller-clusterrole.yaml
@@ -44,6 +44,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 {{- if .Values.global.acls.manageSystemACLs }}
 - apiGroups: [""]
   resources:

--- a/templates/crd-ingressgateways.yaml
+++ b/templates/crd-ingressgateways.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: ingressgateways.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: IngressGateway
@@ -34,103 +21,115 @@ spec:
     plural: ingressgateways
     singular: ingressgateway
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: IngressGateway is the Schema for the ingressgateways API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IngressGatewaySpec defines the desired state of IngressGateway
-          properties:
-            listeners:
-              description: Listeners declares what ports the ingress gateway should listen on, and what services to associated to those ports.
-              items:
-                description: IngressListener manages the configuration for a listener on a specific port.
-                properties:
-                  port:
-                    description: Port declares the port on which the ingress gateway should listen for traffic.
-                    type: integer
-                  protocol:
-                    description: 'Protocol declares what type of traffic this listener is expected to receive. Depending on the protocol, a listener might support multiplexing services over a single port, or additional discovery chain features. The current supported values are: (tcp | http | http2 | grpc).'
-                    type: string
-                  services:
-                    description: "Services declares the set of services to which the listener forwards traffic. \n For \"tcp\" protocol listeners, only a single service is allowed. For \"http\" listeners, multiple services can be declared."
-                    items:
-                      description: IngressService manages configuration for services that are exposed to ingress traffic.
-                      properties:
-                        hosts:
-                          description: "Hosts is a list of hostnames which should be associated to this service on the defined listener. Only allowed on layer 7 protocols, this will be used to route traffic to the service by matching the Host header of the HTTP request. \n If a host is provided for a service that also has a wildcard specifier defined, the host will override the wildcard-specifier-provided \"<service-name>.*\" domain for that listener. \n This cannot be specified when using the wildcard specifier, \"*\", or when using a \"tcp\" listener."
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          description: "Name declares the service to which traffic should be forwarded. \n This can either be a specific service, or the wildcard specifier, \"*\". If the wildcard specifier is provided, the listener must be of \"http\" protocol and means that the listener will forward traffic to all services. \n A name can be specified on multiple listeners, and will be exposed on both of the listeners."
-                          type: string
-                        namespace:
-                          description: Namespace is the namespace where the service is located. Namespacing is a Consul Enterprise feature.
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            tls:
-              description: TLS holds the TLS configuration for this gateway.
-              properties:
-                enabled:
-                  description: Indicates that TLS should be enabled for this gateway service.
-                  type: boolean
-              required:
-              - enabled
-              type: object
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressGateway is the Schema for the ingressgateways API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressGatewaySpec defines the desired state of IngressGateway
+            properties:
+              listeners:
+                description: Listeners declares what ports the ingress gateway should listen on, and what services to associated to those ports.
+                items:
+                  description: IngressListener manages the configuration for a listener on a specific port.
+                  properties:
+                    port:
+                      description: Port declares the port on which the ingress gateway should listen for traffic.
+                      type: integer
+                    protocol:
+                      description: 'Protocol declares what type of traffic this listener is expected to receive. Depending on the protocol, a listener might support multiplexing services over a single port, or additional discovery chain features. The current supported values are: (tcp | http | http2 | grpc).'
+                      type: string
+                    services:
+                      description: "Services declares the set of services to which the listener forwards traffic. \n For \"tcp\" protocol listeners, only a single service is allowed. For \"http\" listeners, multiple services can be declared."
+                      items:
+                        description: IngressService manages configuration for services that are exposed to ingress traffic.
+                        properties:
+                          hosts:
+                            description: "Hosts is a list of hostnames which should be associated to this service on the defined listener. Only allowed on layer 7 protocols, this will be used to route traffic to the service by matching the Host header of the HTTP request. \n If a host is provided for a service that also has a wildcard specifier defined, the host will override the wildcard-specifier-provided \"<service-name>.*\" domain for that listener. \n This cannot be specified when using the wildcard specifier, \"*\", or when using a \"tcp\" listener."
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: "Name declares the service to which traffic should be forwarded. \n This can either be a specific service, or the wildcard specifier, \"*\". If the wildcard specifier is provided, the listener must be of \"http\" protocol and means that the listener will forward traffic to all services. \n A name can be specified on multiple listeners, and will be exposed on both of the listeners."
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace where the service is located. Namespacing is a Consul Enterprise feature.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                description: TLS holds the TLS configuration for this gateway.
+                properties:
+                  enabled:
+                    description: Indicates that TLS should be enabled for this gateway service.
+                    type: boolean
+                required:
+                - enabled
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: proxydefaults.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ProxyDefaults
@@ -34,98 +21,110 @@ spec:
     plural: proxydefaults
     singular: proxydefaults
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ProxyDefaults is the Schema for the proxydefaults API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProxyDefaultsSpec defines the desired state of ProxyDefaults
-          properties:
-            config:
-              description: Config is an arbitrary map of configuration values used by Connect proxies. Any values that your proxy allows can be configured globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
-              type: object
-            expose:
-              description: Expose controls the default expose path configuration for Envoy.
-              properties:
-                checks:
-                  description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
-                  type: boolean
-                paths:
-                  description: Paths is the list of paths exposed through the proxy.
-                  items:
-                    properties:
-                      listenerPort:
-                        description: ListenerPort defines the port of the proxy's listener for exposed paths.
-                        type: integer
-                      localPathPort:
-                        description: LocalPathPort is the port that the service is listening on for the given path.
-                        type: integer
-                      path:
-                        description: Path is the path to expose through the proxy, ie. "/metrics".
-                        type: string
-                      protocol:
-                        description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            meshGateway:
-              description: MeshGateway controls the default mesh gateway configuration for this service.
-              properties:
-                mode:
-                  description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
-                  type: string
-              type: object
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProxyDefaults is the Schema for the proxydefaults API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProxyDefaultsSpec defines the desired state of ProxyDefaults
+            properties:
+              config:
+                description: Config is an arbitrary map of configuration values used by Connect proxies. Any values that your proxy allows can be configured globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
+                type: object
+              expose:
+                description: Expose controls the default expose path configuration for Envoy.
+                properties:
+                  checks:
+                    description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
+                    type: boolean
+                  paths:
+                    description: Paths is the list of paths exposed through the proxy.
+                    items:
+                      properties:
+                        listenerPort:
+                          description: ListenerPort defines the port of the proxy's listener for exposed paths.
+                          type: integer
+                        localPathPort:
+                          description: LocalPathPort is the port that the service is listening on for the given path.
+                          type: integer
+                        path:
+                          description: Path is the path to expose through the proxy, ie. "/metrics".
+                          type: string
+                        protocol:
+                          description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              meshGateway:
+                description: MeshGateway controls the default mesh gateway configuration for this service.
+                properties:
+                  mode:
+                    description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-servicedefaults.yaml
+++ b/templates/crd-servicedefaults.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: servicedefaults.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceDefaults
@@ -34,101 +21,113 @@ spec:
     plural: servicedefaults
     singular: servicedefaults
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceDefaults is the Schema for the servicedefaults API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceDefaultsSpec defines the desired state of ServiceDefaults
-          properties:
-            expose:
-              description: Expose controls the default expose path configuration for Envoy.
-              properties:
-                checks:
-                  description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
-                  type: boolean
-                paths:
-                  description: Paths is the list of paths exposed through the proxy.
-                  items:
-                    properties:
-                      listenerPort:
-                        description: ListenerPort defines the port of the proxy's listener for exposed paths.
-                        type: integer
-                      localPathPort:
-                        description: LocalPathPort is the port that the service is listening on for the given path.
-                        type: integer
-                      path:
-                        description: Path is the path to expose through the proxy, ie. "/metrics".
-                        type: string
-                      protocol:
-                        description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            externalSNI:
-              description: ExternalSNI is an optional setting that allows for the TLS SNI value to be changed to a non-connect value when federating with an external system.
-              type: string
-            meshGateway:
-              description: MeshGateway controls the default mesh gateway configuration for this service.
-              properties:
-                mode:
-                  description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
-                  type: string
-              type: object
-            protocol:
-              description: Protocol sets the protocol of the service. This is used by Connect proxies for things like observability features and to unlock usage of the service-splitter and service-router config entries for a service.
-              type: string
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceDefaults is the Schema for the servicedefaults API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceDefaultsSpec defines the desired state of ServiceDefaults
+            properties:
+              expose:
+                description: Expose controls the default expose path configuration for Envoy.
+                properties:
+                  checks:
+                    description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
+                    type: boolean
+                  paths:
+                    description: Paths is the list of paths exposed through the proxy.
+                    items:
+                      properties:
+                        listenerPort:
+                          description: ListenerPort defines the port of the proxy's listener for exposed paths.
+                          type: integer
+                        localPathPort:
+                          description: LocalPathPort is the port that the service is listening on for the given path.
+                          type: integer
+                        path:
+                          description: Path is the path to expose through the proxy, ie. "/metrics".
+                          type: string
+                        protocol:
+                          description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              externalSNI:
+                description: ExternalSNI is an optional setting that allows for the TLS SNI value to be changed to a non-connect value when federating with an external system.
+                type: string
+              meshGateway:
+                description: MeshGateway controls the default mesh gateway configuration for this service.
+                properties:
+                  mode:
+                    description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                    type: string
+                type: object
+              protocol:
+                description: Protocol sets the protocol of the service. This is used by Connect proxies for things like observability features and to unlock usage of the service-splitter and service-router config entries for a service.
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-serviceintentions.yaml
+++ b/templates/crd-serviceintentions.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: serviceintentions.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceIntentions
@@ -34,145 +21,157 @@ spec:
     plural: serviceintentions
     singular: serviceintentions
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceIntentions is the Schema for the serviceintentions API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceIntentionsSpec defines the desired state of ServiceIntentions
-          properties:
-            destination:
-              description: Destination is the intention destination that will have the authorization granted to.
-              properties:
-                name:
-                  description: Name is the destination of all intentions defined in this config entry. This may be set to the wildcard character (*) to match all services that don't otherwise have intentions defined.
-                  type: string
-                namespace:
-                  description: Namespace specifies the namespace the config entry will apply to. This may be set to the wildcard character (*) to match all services in all namespaces that don't otherwise have intentions defined.
-                  type: string
-              type: object
-            sources:
-              description: Sources is the list of all intention sources and the authorization granted to those sources. The order of this list does not matter, but out of convenience Consul will always store this reverse sorted by intention precedence, as that is the order that they will be evaluated at enforcement time.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceIntentions is the Schema for the serviceintentions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceIntentionsSpec defines the desired state of ServiceIntentions
+            properties:
+              destination:
+                description: Destination is the intention destination that will have the authorization granted to.
                 properties:
-                  action:
-                    description: Action is required for an L4 intention, and should be set to one of "allow" or "deny" for the action that should be taken if this intention matches a request.
-                    type: string
-                  description:
-                    description: Description for the intention. This is not used by Consul, but is presented in API responses to assist tooling.
-                    type: string
                   name:
-                    description: Name is the source of the intention. This is the name of a Consul service. The service doesn't need to be registered.
+                    description: Name is the destination of all intentions defined in this config entry. This may be set to the wildcard character (*) to match all services that don't otherwise have intentions defined.
                     type: string
                   namespace:
-                    description: Namespace is the namespace for the Name parameter.
+                    description: Namespace specifies the namespace the config entry will apply to. This may be set to the wildcard character (*) to match all services in all namespaces that don't otherwise have intentions defined.
                     type: string
-                  permissions:
-                    description: Permissions is the list of all additional L7 attributes that extend the intention match criteria. Permission precedence is applied top to bottom. For any given request the first permission to match in the list is terminal and stops further evaluation. As with L4 intentions, traffic that fails to match any of the provided permissions in this intention will be subject to the default intention behavior is defined by the default ACL policy. This should be omitted for an L4 intention as it is mutually exclusive with the Action field.
-                    items:
-                      properties:
-                        action:
-                          description: Action is one of "allow" or "deny" for the action that should be taken if this permission matches a request.
-                          type: string
-                        http:
-                          description: HTTP is a set of HTTP-specific authorization criteria.
-                          properties:
-                            header:
-                              description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
-                              items:
-                                properties:
-                                  exact:
-                                    description: Exact matches if the header with the given name is this value.
-                                    type: string
-                                  invert:
-                                    description: Invert inverts the logic of the match.
-                                    type: boolean
-                                  name:
-                                    description: Name is the name of the header to match.
-                                    type: string
-                                  prefix:
-                                    description: Prefix matches if the header with the given name has this prefix.
-                                    type: string
-                                  present:
-                                    description: Present matches if the header with the given name is present with any value.
-                                    type: boolean
-                                  regex:
-                                    description: Regex matches if the header with the given name matches this pattern.
-                                    type: string
-                                  suffix:
-                                    description: Suffix matches if the header with the given name has this suffix.
-                                    type: string
-                                type: object
-                              type: array
-                            methods:
-                              description: Methods is a list of HTTP methods for which this match applies. If unspecified all HTTP methods are matched. If provided the names must be a valid method.
-                              items:
+                type: object
+              sources:
+                description: Sources is the list of all intention sources and the authorization granted to those sources. The order of this list does not matter, but out of convenience Consul will always store this reverse sorted by intention precedence, as that is the order that they will be evaluated at enforcement time.
+                items:
+                  properties:
+                    action:
+                      description: Action is required for an L4 intention, and should be set to one of "allow" or "deny" for the action that should be taken if this intention matches a request.
+                      type: string
+                    description:
+                      description: Description for the intention. This is not used by Consul, but is presented in API responses to assist tooling.
+                      type: string
+                    name:
+                      description: Name is the source of the intention. This is the name of a Consul service. The service doesn't need to be registered.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace for the Name parameter.
+                      type: string
+                    permissions:
+                      description: Permissions is the list of all additional L7 attributes that extend the intention match criteria. Permission precedence is applied top to bottom. For any given request the first permission to match in the list is terminal and stops further evaluation. As with L4 intentions, traffic that fails to match any of the provided permissions in this intention will be subject to the default intention behavior is defined by the default ACL policy. This should be omitted for an L4 intention as it is mutually exclusive with the Action field.
+                      items:
+                        properties:
+                          action:
+                            description: Action is one of "allow" or "deny" for the action that should be taken if this permission matches a request.
+                            type: string
+                          http:
+                            description: HTTP is a set of HTTP-specific authorization criteria.
+                            properties:
+                              header:
+                                description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
+                                items:
+                                  properties:
+                                    exact:
+                                      description: Exact matches if the header with the given name is this value.
+                                      type: string
+                                    invert:
+                                      description: Invert inverts the logic of the match.
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the header to match.
+                                      type: string
+                                    prefix:
+                                      description: Prefix matches if the header with the given name has this prefix.
+                                      type: string
+                                    present:
+                                      description: Present matches if the header with the given name is present with any value.
+                                      type: boolean
+                                    regex:
+                                      description: Regex matches if the header with the given name matches this pattern.
+                                      type: string
+                                    suffix:
+                                      description: Suffix matches if the header with the given name has this suffix.
+                                      type: string
+                                  type: object
+                                type: array
+                              methods:
+                                description: Methods is a list of HTTP methods for which this match applies. If unspecified all HTTP methods are matched. If provided the names must be a valid method.
+                                items:
+                                  type: string
+                                type: array
+                              pathExact:
+                                description: PathExact is the exact path to match on the HTTP request path.
                                 type: string
-                              type: array
-                            pathExact:
-                              description: PathExact is the exact path to match on the HTTP request path.
-                              type: string
-                            pathPrefix:
-                              description: PathPrefix is the path prefix to match on the HTTP request path.
-                              type: string
-                            pathRegex:
-                              description: PathRegex is the regular expression to match on the HTTP request path.
-                              type: string
-                          type: object
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                              pathPrefix:
+                                description: PathPrefix is the path prefix to match on the HTTP request path.
+                                type: string
+                              pathRegex:
+                                description: PathRegex is the regular expression to match on the HTTP request path.
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-serviceresolvers.yaml
+++ b/templates/crd-serviceresolvers.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: serviceresolvers.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceResolver
@@ -34,177 +21,189 @@ spec:
     plural: serviceresolvers
     singular: serviceresolver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceResolver is the Schema for the serviceresolvers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceResolverSpec defines the desired state of ServiceResolver
-          properties:
-            connectTimeout:
-              description: ConnectTimeout is the timeout for establishing new network connections to this service.
-              format: int64
-              type: integer
-            defaultSubset:
-              description: DefaultSubset is the subset to use when no explicit subset is requested. If empty the unnamed subset is used.
-              type: string
-            failover:
-              additionalProperties:
-                properties:
-                  datacenters:
-                    description: Datacenters is a fixed list of datacenters to try during failover.
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceResolver is the Schema for the serviceresolvers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceResolverSpec defines the desired state of ServiceResolver
+            properties:
+              connectTimeout:
+                description: ConnectTimeout is the timeout for establishing new network connections to this service.
+                format: int64
+                type: integer
+              defaultSubset:
+                description: DefaultSubset is the subset to use when no explicit subset is requested. If empty the unnamed subset is used.
+                type: string
+              failover:
+                additionalProperties:
+                  properties:
+                    datacenters:
+                      description: Datacenters is a fixed list of datacenters to try during failover.
+                      items:
+                        type: string
+                      type: array
+                    namespace:
+                      description: Namespace is the namespace to resolve the requested service from to form the failover group of instances. If empty the current namespace is used.
                       type: string
+                    service:
+                      description: Service is the service to resolve instead of the default as the failover group of instances during failover.
+                      type: string
+                    serviceSubset:
+                      description: ServiceSubset is the named subset of the requested service to resolve as the failover group of instances. If empty the default subset for the requested service is used.
+                      type: string
+                  type: object
+                description: Failover controls when and how to reroute traffic to an alternate pool of service instances. The map is keyed by the service subset it applies to and the special string "*" is a wildcard that applies to any subset not otherwise specified here.
+                type: object
+              loadBalancer:
+                description: LoadBalancer determines the load balancing policy and configuration for services issuing requests to this upstream service.
+                properties:
+                  hashPolicies:
+                    description: HashPolicies is a list of hash policies to use for hashing load balancing algorithms. Hash policies are evaluated individually and combined such that identical lists result in the same hash. If no hash policies are present, or none are successfully evaluated, then a random backend host will be selected.
+                    items:
+                      properties:
+                        cookieConfig:
+                          description: CookieConfig contains configuration for the "cookie" hash policy type.
+                          properties:
+                            path:
+                              description: Path is the path to set for the cookie.
+                              type: string
+                            session:
+                              description: Session determines whether to generate a session cookie with no expiration.
+                              type: boolean
+                            ttl:
+                              description: TTL is the ttl for generated cookies. Cannot be specified for session cookies.
+                              format: int64
+                              type: integer
+                          type: object
+                        field:
+                          description: Field is the attribute type to hash on. Must be one of "header", "cookie", or "query_parameter". Cannot be specified along with sourceIP.
+                          type: string
+                        fieldValue:
+                          description: FieldValue is the value to hash. ie. header name, cookie name, URL query parameter name Cannot be specified along with sourceIP.
+                          type: string
+                        sourceIP:
+                          description: SourceIP determines whether the hash should be of the source IP rather than of a field and field value. Cannot be specified along with field or fieldValue.
+                          type: boolean
+                        terminal:
+                          description: Terminal will short circuit the computation of the hash when multiple hash policies are present. If a hash is computed when a Terminal policy is evaluated, then that hash will be used and subsequent hash policies will be ignored.
+                          type: boolean
+                      type: object
                     type: array
+                  leastRequestConfig:
+                    description: LeastRequestConfig contains configuration for the "leastRequest" policy type.
+                    properties:
+                      choiceCount:
+                        description: ChoiceCount determines the number of random healthy hosts from which to select the one with the least requests.
+                        format: int32
+                        type: integer
+                    type: object
+                  policy:
+                    description: Policy is the load balancing policy used to select a host.
+                    type: string
+                  ringHashConfig:
+                    description: RingHashConfig contains configuration for the "ringHash" policy type.
+                    properties:
+                      maximumRingSize:
+                        description: MaximumRingSize determines the maximum number of entries in the hash ring.
+                        format: int64
+                        type: integer
+                      minimumRingSize:
+                        description: MinimumRingSize determines the minimum number of entries in the hash ring.
+                        format: int64
+                        type: integer
+                    type: object
+                type: object
+              redirect:
+                description: Redirect when configured, all attempts to resolve the service this resolver defines will be substituted for the supplied redirect EXCEPT when the redirect has already been applied. When substituting the supplied redirect, all other fields besides Kind, Name, and Redirect will be ignored.
+                properties:
+                  datacenter:
+                    description: Datacenter is the datacenter to resolve the service from instead of the current one.
+                    type: string
                   namespace:
-                    description: Namespace is the namespace to resolve the requested service from to form the failover group of instances. If empty the current namespace is used.
+                    description: Namespace is the namespace to resolve the service from instead of the current one.
                     type: string
                   service:
-                    description: Service is the service to resolve instead of the default as the failover group of instances during failover.
+                    description: Service is a service to resolve instead of the current service.
                     type: string
                   serviceSubset:
-                    description: ServiceSubset is the named subset of the requested service to resolve as the failover group of instances. If empty the default subset for the requested service is used.
+                    description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset If empty the default subset is used.
                     type: string
                 type: object
-              description: Failover controls when and how to reroute traffic to an alternate pool of service instances. The map is keyed by the service subset it applies to and the special string "*" is a wildcard that applies to any subset not otherwise specified here.
-              type: object
-            loadBalancer:
-              description: LoadBalancer determines the load balancing policy and configuration for services issuing requests to this upstream service.
-              properties:
-                hashPolicies:
-                  description: HashPolicies is a list of hash policies to use for hashing load balancing algorithms. Hash policies are evaluated individually and combined such that identical lists result in the same hash. If no hash policies are present, or none are successfully evaluated, then a random backend host will be selected.
-                  items:
-                    properties:
-                      cookieConfig:
-                        description: CookieConfig contains configuration for the "cookie" hash policy type.
-                        properties:
-                          path:
-                            description: Path is the path to set for the cookie.
-                            type: string
-                          session:
-                            description: Session determines whether to generate a session cookie with no expiration.
-                            type: boolean
-                          ttl:
-                            description: TTL is the ttl for generated cookies. Cannot be specified for session cookies.
-                            format: int64
-                            type: integer
-                        type: object
-                      field:
-                        description: Field is the attribute type to hash on. Must be one of "header", "cookie", or "query_parameter". Cannot be specified along with sourceIP.
-                        type: string
-                      fieldValue:
-                        description: FieldValue is the value to hash. ie. header name, cookie name, URL query parameter name Cannot be specified along with sourceIP.
-                        type: string
-                      sourceIP:
-                        description: SourceIP determines whether the hash should be of the source IP rather than of a field and field value. Cannot be specified along with field or fieldValue.
-                        type: boolean
-                      terminal:
-                        description: Terminal will short circuit the computation of the hash when multiple hash policies are present. If a hash is computed when a Terminal policy is evaluated, then that hash will be used and subsequent hash policies will be ignored.
-                        type: boolean
-                    type: object
-                  type: array
-                leastRequestConfig:
-                  description: LeastRequestConfig contains configuration for the "leastRequest" policy type.
+              subsets:
+                additionalProperties:
                   properties:
-                    choiceCount:
-                      description: ChoiceCount determines the number of random healthy hosts from which to select the one with the least requests.
-                      format: int32
-                      type: integer
+                    filter:
+                      description: Filter is the filter expression to be used for selecting instances of the requested service. If empty all healthy instances are returned. This expression can filter on the same selectors as the Health API endpoint.
+                      type: string
+                    onlyPassing:
+                      description: OnlyPassing specifies the behavior of the resolver's health check interpretation. If this is set to false, instances with checks in the passing as well as the warning states will be considered healthy. If this is set to true, only instances with checks in the passing state will be considered healthy.
+                      type: boolean
                   type: object
-                policy:
-                  description: Policy is the load balancing policy used to select a host.
-                  type: string
-                ringHashConfig:
-                  description: RingHashConfig contains configuration for the "ringHash" policy type.
+                description: Subsets is map of subset name to subset definition for all usable named subsets of this service. The map key is the name of the subset and all names must be valid DNS subdomain elements. This may be empty, in which case only the unnamed default subset will be usable.
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
-                    maximumRingSize:
-                      description: MaximumRingSize determines the maximum number of entries in the hash ring.
-                      format: int64
-                      type: integer
-                    minimumRingSize:
-                      description: MinimumRingSize determines the minimum number of entries in the hash ring.
-                      format: int64
-                      type: integer
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
                   type: object
-              type: object
-            redirect:
-              description: Redirect when configured, all attempts to resolve the service this resolver defines will be substituted for the supplied redirect EXCEPT when the redirect has already been applied. When substituting the supplied redirect, all other fields besides Kind, Name, and Redirect will be ignored.
-              properties:
-                datacenter:
-                  description: Datacenter is the datacenter to resolve the service from instead of the current one.
-                  type: string
-                namespace:
-                  description: Namespace is the namespace to resolve the service from instead of the current one.
-                  type: string
-                service:
-                  description: Service is a service to resolve instead of the current service.
-                  type: string
-                serviceSubset:
-                  description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset If empty the default subset is used.
-                  type: string
-              type: object
-            subsets:
-              additionalProperties:
-                properties:
-                  filter:
-                    description: Filter is the filter expression to be used for selecting instances of the requested service. If empty all healthy instances are returned. This expression can filter on the same selectors as the Health API endpoint.
-                    type: string
-                  onlyPassing:
-                    description: OnlyPassing specifies the behavior of the resolver's health check interpretation. If this is set to false, instances with checks in the passing as well as the warning states will be considered healthy. If this is set to true, only instances with checks in the passing state will be considered healthy.
-                    type: boolean
-                type: object
-              description: Subsets is map of subset name to subset definition for all usable named subsets of this service. The map key is the name of the subset and all names must be valid DNS subdomain elements. This may be empty, in which case only the unnamed default subset will be usable.
-              type: object
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-servicerouters.yaml
+++ b/templates/crd-servicerouters.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: servicerouters.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceRouter
@@ -34,173 +21,185 @@ spec:
     plural: servicerouters
     singular: servicerouter
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceRouter is the Schema for the servicerouters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceRouterSpec defines the desired state of ServiceRouter
-          properties:
-            routes:
-              description: Routes are the list of routes to consider when processing L7 requests. The first route to match in the list is terminal and stops further evaluation. Traffic that fails to match any of the provided routes will be routed to the default service.
-              items:
-                properties:
-                  destination:
-                    description: Destination controls how to proxy the matching request(s) to a service.
-                    properties:
-                      namespace:
-                        description: Namespace is the Consul namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
-                        type: string
-                      numRetries:
-                        description: NumRetries is the number of times to retry the request when a retryable result occurs
-                        format: int32
-                        type: integer
-                      prefixRewrite:
-                        description: PrefixRewrite defines how to rewrite the HTTP request path before proxying it to its final destination. This requires that either match.http.pathPrefix or match.http.pathExact be configured on this route.
-                        type: string
-                      requestTimeout:
-                        description: RequestTimeout is the total amount of time permitted for the entire downstream request (and retries) to be processed.
-                        format: int64
-                        type: integer
-                      retryOnConnectFailure:
-                        description: RetryOnConnectFailure allows for connection failure errors to trigger a retry.
-                        type: boolean
-                      retryOnStatusCodes:
-                        description: RetryOnStatusCodes is a flat list of http response status codes that are eligible for retry.
-                        items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceRouter is the Schema for the servicerouters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceRouterSpec defines the desired state of ServiceRouter
+            properties:
+              routes:
+                description: Routes are the list of routes to consider when processing L7 requests. The first route to match in the list is terminal and stops further evaluation. Traffic that fails to match any of the provided routes will be routed to the default service.
+                items:
+                  properties:
+                    destination:
+                      description: Destination controls how to proxy the matching request(s) to a service.
+                      properties:
+                        namespace:
+                          description: Namespace is the Consul namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
+                          type: string
+                        numRetries:
+                          description: NumRetries is the number of times to retry the request when a retryable result occurs
                           format: int32
                           type: integer
-                        type: array
-                      service:
-                        description: Service is the service to resolve instead of the default service. If empty then the default service name is used.
-                        type: string
-                      serviceSubset:
-                        description: ServiceSubset is a named subset of the given service to resolve instead of the one defined as that service's DefaultSubset. If empty, the default subset is used.
-                        type: string
-                    type: object
-                  match:
-                    description: Match is a set of criteria that can match incoming L7 requests. If empty or omitted it acts as a catch-all.
-                    properties:
-                      http:
-                        description: HTTP is a set of http-specific match criteria.
-                        properties:
-                          header:
-                            description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
-                            items:
-                              properties:
-                                exact:
-                                  description: Exact will match if the header with the given name is this value.
-                                  type: string
-                                invert:
-                                  description: Invert inverts the logic of the match.
-                                  type: boolean
-                                name:
-                                  description: Name is the name of the header to match.
-                                  type: string
-                                prefix:
-                                  description: Prefix will match if the header with the given name has this prefix.
-                                  type: string
-                                present:
-                                  description: Present will match if the header with the given name is present with any value.
-                                  type: boolean
-                                regex:
-                                  description: Regex will match if the header with the given name matches this pattern.
-                                  type: string
-                                suffix:
-                                  description: Suffix will match if the header with the given name has this suffix.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          methods:
-                            description: Methods is a list of HTTP methods for which this match applies. If unspecified all http methods are matched.
-                            items:
+                        prefixRewrite:
+                          description: PrefixRewrite defines how to rewrite the HTTP request path before proxying it to its final destination. This requires that either match.http.pathPrefix or match.http.pathExact be configured on this route.
+                          type: string
+                        requestTimeout:
+                          description: RequestTimeout is the total amount of time permitted for the entire downstream request (and retries) to be processed.
+                          format: int64
+                          type: integer
+                        retryOnConnectFailure:
+                          description: RetryOnConnectFailure allows for connection failure errors to trigger a retry.
+                          type: boolean
+                        retryOnStatusCodes:
+                          description: RetryOnStatusCodes is a flat list of http response status codes that are eligible for retry.
+                          items:
+                            format: int32
+                            type: integer
+                          type: array
+                        service:
+                          description: Service is the service to resolve instead of the default service. If empty then the default service name is used.
+                          type: string
+                        serviceSubset:
+                          description: ServiceSubset is a named subset of the given service to resolve instead of the one defined as that service's DefaultSubset. If empty, the default subset is used.
+                          type: string
+                      type: object
+                    match:
+                      description: Match is a set of criteria that can match incoming L7 requests. If empty or omitted it acts as a catch-all.
+                      properties:
+                        http:
+                          description: HTTP is a set of http-specific match criteria.
+                          properties:
+                            header:
+                              description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
+                              items:
+                                properties:
+                                  exact:
+                                    description: Exact will match if the header with the given name is this value.
+                                    type: string
+                                  invert:
+                                    description: Invert inverts the logic of the match.
+                                    type: boolean
+                                  name:
+                                    description: Name is the name of the header to match.
+                                    type: string
+                                  prefix:
+                                    description: Prefix will match if the header with the given name has this prefix.
+                                    type: string
+                                  present:
+                                    description: Present will match if the header with the given name is present with any value.
+                                    type: boolean
+                                  regex:
+                                    description: Regex will match if the header with the given name matches this pattern.
+                                    type: string
+                                  suffix:
+                                    description: Suffix will match if the header with the given name has this suffix.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            methods:
+                              description: Methods is a list of HTTP methods for which this match applies. If unspecified all http methods are matched.
+                              items:
+                                type: string
+                              type: array
+                            pathExact:
+                              description: PathExact is an exact path to match on the HTTP request path.
                               type: string
-                            type: array
-                          pathExact:
-                            description: PathExact is an exact path to match on the HTTP request path.
-                            type: string
-                          pathPrefix:
-                            description: PathPrefix is a path prefix to match on the HTTP request path.
-                            type: string
-                          pathRegex:
-                            description: PathRegex is a regular expression to match on the HTTP request path.
-                            type: string
-                          queryParam:
-                            description: QueryParam is a set of criteria that can match on HTTP query parameters. If more than one is configured all must match for the overall match to apply.
-                            items:
-                              properties:
-                                exact:
-                                  description: Exact will match if the query parameter with the given name is this value.
-                                  type: string
-                                name:
-                                  description: Name is the name of the query parameter to match on.
-                                  type: string
-                                present:
-                                  description: Present will match if the query parameter with the given name is present with any value.
-                                  type: boolean
-                                regex:
-                                  description: Regex will match if the query parameter with the given name matches this pattern.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                            pathPrefix:
+                              description: PathPrefix is a path prefix to match on the HTTP request path.
+                              type: string
+                            pathRegex:
+                              description: PathRegex is a regular expression to match on the HTTP request path.
+                              type: string
+                            queryParam:
+                              description: QueryParam is a set of criteria that can match on HTTP query parameters. If more than one is configured all must match for the overall match to apply.
+                              items:
+                                properties:
+                                  exact:
+                                    description: Exact will match if the query parameter with the given name is this value.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the query parameter to match on.
+                                    type: string
+                                  present:
+                                    description: Present will match if the query parameter with the given name is present with any value.
+                                    type: boolean
+                                  regex:
+                                    description: Regex will match if the query parameter with the given name matches this pattern.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-servicesplitters.yaml
+++ b/templates/crd-servicesplitters.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: servicesplitters.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceSplitter
@@ -34,81 +21,93 @@ spec:
     plural: servicesplitters
     singular: servicesplitter
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceSplitter is the Schema for the servicesplitters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceSplitterSpec defines the desired state of ServiceSplitter
-          properties:
-            splits:
-              description: Splits defines how much traffic to send to which set of service instances during a traffic split. The sum of weights across all splits must add up to 100.
-              items:
-                properties:
-                  namespace:
-                    description: The namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
-                    type: string
-                  service:
-                    description: Service is the service to resolve instead of the default.
-                    type: string
-                  serviceSubset:
-                    description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset. If empty the default subset is used.
-                    type: string
-                  weight:
-                    description: Weight is a value between 0 and 100 reflecting what portion of traffic should be directed to this split. The smallest representable weight is 1/10000 or .01%.
-                    type: number
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceSplitter is the Schema for the servicesplitters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceSplitterSpec defines the desired state of ServiceSplitter
+            properties:
+              splits:
+                description: Splits defines how much traffic to send to which set of service instances during a traffic split. The sum of weights across all splits must add up to 100.
+                items:
+                  properties:
+                    namespace:
+                      description: The namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
+                      type: string
+                    service:
+                      description: Service is the service to resolve instead of the default.
+                      type: string
+                    serviceSubset:
+                      description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset. If empty the default subset is used.
+                      type: string
+                    weight:
+                      description: Weight is a value between 0 and 100 reflecting what portion of traffic should be directed to this split. The smallest representable weight is 1/10000 or .01%.
+                      type: number
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/templates/crd-terminatinggateways.yaml
+++ b/templates/crd-terminatinggateways.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.enabled }}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: terminatinggateways.consul.hashicorp.com
   labels:
@@ -14,19 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     component: crd
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Synced")].status
-    description: The sync status of the resource with Consul
-    name: Synced
-    type: string
-  - JSONPath: .status.lastSyncedTime
-    description: The last successful synced time of the resource with Consul
-    name: Last Synced
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: The age of the resource
-    name: Age
-    type: date
   group: consul.hashicorp.com
   names:
     kind: TerminatingGateway
@@ -34,88 +21,100 @@ spec:
     plural: terminatinggateways
     singular: terminatinggateway
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: TerminatingGateway is the Schema for the terminatinggateways API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TerminatingGatewaySpec defines the desired state of TerminatingGateway
-          properties:
-            services:
-              description: Services is a list of service names represented by the terminating gateway.
-              items:
-                description: A LinkedService is a service represented by a terminating gateway
-                properties:
-                  caFile:
-                    description: CAFile is the optional path to a CA certificate to use for TLS connections from the gateway to the linked service.
-                    type: string
-                  certFile:
-                    description: CertFile is the optional path to a client certificate to use for TLS connections from the gateway to the linked service.
-                    type: string
-                  keyFile:
-                    description: KeyFile is the optional path to a private key to use for TLS connections from the gateway to the linked service.
-                    type: string
-                  name:
-                    description: Name is the name of the service, as defined in Consul's catalog.
-                    type: string
-                  namespace:
-                    description: The namespace the service is registered in.
-                    type: string
-                  sni:
-                    description: SNI is the optional name to specify during the TLS handshake with a linked service.
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions indicate the latest available observations of a resource's current state.
-              items:
-                description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastSyncedTime:
-              description: LastSyncedTime is the last time the resource successfully synced with Consul.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The sync status of the resource with Consul
+      jsonPath: .status.conditions[?(@.type=="Synced")].status
+      name: Synced
+      type: string
+    - description: The last successful synced time of the resource with Consul
+      jsonPath: .status.lastSyncedTime
+      name: Last Synced
+      type: date
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TerminatingGateway is the Schema for the terminatinggateways API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TerminatingGatewaySpec defines the desired state of TerminatingGateway
+            properties:
+              services:
+                description: Services is a list of service names represented by the terminating gateway.
+                items:
+                  description: A LinkedService is a service represented by a terminating gateway
+                  properties:
+                    caFile:
+                      description: CAFile is the optional path to a CA certificate to use for TLS connections from the gateway to the linked service.
+                      type: string
+                    certFile:
+                      description: CertFile is the optional path to a client certificate to use for TLS connections from the gateway to the linked service.
+                      type: string
+                    keyFile:
+                      description: KeyFile is the optional path to a private key to use for TLS connections from the gateway to the linked service.
+                      type: string
+                    name:
+                      description: Name is the name of the service, as defined in Consul's catalog.
+                      type: string
+                    namespace:
+                      description: The namespace the service is registered in.
+                      type: string
+                    sni:
+                      description: SNI is the optional name to specify during the TLS handshake with a linked service.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions indicate the latest available observations of a resource's current state.
+                items:
+                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Changes proposed in this PR:
- Update CRD versions from v1beta1 to v1
- The new version of controller-runtime requires the controller to have CRUD access on coordination.k8s.io/lease.
The above resource was promoted to v1 in Kubernetes 1.14.1

How I've tested this PR: Acceptance tests

How I expect reviewers to test this PR: Code Review


Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

