### PR TITLE
Give time for injector to come up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ BREAKING CHANGES:
 * Minimum Kubernetes versions supported is 1.16+. [[GH-883](https://github.com/hashicorp/consul-helm/pull/883)]
 
 BUG FIXES:
-* Increase initial delay seconds for connect-inject deployment to 30 to give time for certificates to be available.
+* Add startup probe to connect-inject deployment to give time for certificates to be available.
   Previously, the deployment could be killed by Kubernetes and crash loop because certificates would take a couple
   of seconds. [[GH-885](https://github.com/hashicorp/consul-helm/pull/885)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ IMPROVEMENTS:
 BREAKING CHANGES:
 * Minimum Kubernetes versions supported is 1.16+. [[GH-883](https://github.com/hashicorp/consul-helm/pull/883)]
 
+BUG FIXES:
+* Increase initial delay seconds for connect-inject deployment to 30 to give time for certificates to be available.
+  Previously, the deployment could be killed by Kubernetes and crash loop because certificates would take a couple
+  of seconds. [[GH-885](https://github.com/hashicorp/consul-helm/pull/885)]
+
 ## 0.31.1 (Mar 19, 2021)
 
 BUG FIXES:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -191,7 +191,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 1
+            initialDelaySeconds: 30
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -201,7 +201,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 2
+            initialDelaySeconds: 30
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -191,7 +191,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 30
+            initialDelaySeconds: 1
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -201,9 +201,17 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 30
+            initialDelaySeconds: 2
             periodSeconds: 2
             successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 15
+            periodSeconds: 2
             timeoutSeconds: 5
           {{- if (or .Values.connectInject.certs.secretName .Values.global.tls.enabled) }}
           volumeMounts:


### PR DESCRIPTION
Getting certificates can take a couple of seconds

Fixes https://github.com/hashicorp/consul-helm/issues/610, may fix https://github.com/hashicorp/consul-k8s/issues/451

How I've tested this PR:
* installed on `kind` and saw how container would be ready in ~10s

How I expect reviewers to test this PR:
* code, can test locally as well

Checklist:
- [ ] Bats tests added (not applicable)
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

