### PR TITLE
sync-catalog to use consul-ca-cert with client disabled and auto encrypt enabled

### DIFF
--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -1,3 +1,4 @@
+{{ $clientEnabled := ternary true false (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }} 
 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
 # The deployment for running the sync-catalog pod
 apiVersion: apps/v1
@@ -43,7 +44,7 @@ spec:
           - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
             path: tls.crt
       {{- end }}
-      {{- if .Values.global.tls.enableAutoEncrypt }}
+      {{- if (and .Values.global.tls.enableAutoEncrypt $clientEnabled) }}
       - name: consul-auto-encrypt-ca-cert
         emptyDir:
           medium: "Memory"
@@ -96,7 +97,7 @@ spec:
             {{- end }}
           {{- if .Values.global.tls.enabled }}
           volumeMounts:
-            {{- if .Values.global.tls.enableAutoEncrypt }}
+            {{- if (and .Values.global.tls.enableAutoEncrypt $clientEnabled) }}
             - name: consul-auto-encrypt-ca-cert
             {{- else }}
             - name: consul-ca-cert
@@ -193,7 +194,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if or .Values.global.acls.manageSystemACLs (and (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) $clientEnabled) }}
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: sync-acl-init
@@ -213,7 +214,7 @@ spec:
             memory: "25Mi"
             cpu: "50m"
       {{- end }}
-      {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
+      {{- if (and (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) $clientEnabled) }}
       {{- include "consul.getAutoEncryptClientCA" . | nindent 6 }}
       {{- end }}
       {{- end }}

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -1,4 +1,4 @@
-{{ $clientEnabled := ternary true false (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }} 
+{{ $clientEnabled := ternary true false (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
 # The deployment for running the sync-catalog pod
 apiVersion: apps/v1

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -1,4 +1,4 @@
-{{ $clientEnabled := ternary true false (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- $clientEnabled := (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
 # The deployment for running the sync-catalog pod
 apiVersion: apps/v1
@@ -194,7 +194,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or .Values.global.acls.manageSystemACLs (and (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) $clientEnabled) }}
+      {{- if or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt $clientEnabled) }}
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: sync-acl-init
@@ -214,7 +214,7 @@ spec:
             memory: "25Mi"
             cpu: "50m"
       {{- end }}
-      {{- if (and (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) $clientEnabled) }}
+      {{- if (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt $clientEnabled) }}
       {{- include "consul.getAutoEncryptClientCA" . | nindent 6 }}
       {{- end }}
       {{- end }}

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -517,7 +517,7 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "syncCatalog/DeploymentABC: consul-ca-cert volume is used when TLS with auto-encrypt is enabled and client disabled" {
+@test "syncCatalog/DeploymentABC: consul-ca-cert volume is used when TLS with auto-encrypt is enabled and client.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/sync-catalog-deployment.yaml  \
@@ -528,6 +528,19 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "consul-ca-cert") | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/DeploymentABC: consul-auto-encrypt-ca-cert volume is not added with auto-encrypt and client.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[] | select(.name == "consul-auto-encrypt-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
 }
 
 @test "syncCatalog/Deployment: consul-auto-encrypt-ca-cert volume is added when TLS with auto-encrypt is enabled" {

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -517,7 +517,7 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "syncCatalog/DeploymentABC: consul-ca-cert volume is used when TLS with auto-encrypt is enabled and client.enabled=false" {
+@test "syncCatalog/Deployment: consul-ca-cert volume is used when TLS with auto-encrypt is enabled and client.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/sync-catalog-deployment.yaml  \
@@ -530,7 +530,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/DeploymentABC: consul-auto-encrypt-ca-cert volume is not added with auto-encrypt and client.enabled=false" {
+@test "syncCatalog/Deployment: consul-auto-encrypt-ca-cert volume is not added with auto-encrypt and client.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/sync-catalog-deployment.yaml  \
@@ -567,7 +567,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "syncCatalog/DeploymentABC: consul-ca-cert volumeMount is added when TLS with auto-encrypt is enabled and client disabled" {
+@test "syncCatalog/Deployment: consul-ca-cert volumeMount is added when TLS with auto-encrypt is enabled and client disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/sync-catalog-deployment.yaml  \
@@ -887,7 +887,7 @@ load _helpers
   [ "${actual}" = 'http://RELEASE-NAME-consul-server:8500' ]
 }
 
-@test "syncCatalog/DeploymentABC: consul service is used when client.enabled=false and global.tls.enabled=true and autoencrypt on" {
+@test "syncCatalog/Deployment: consul service is used when client.enabled=false and global.tls.enabled=true and autoencrypt on" {
   cd `chart_dir`
   local env=$(helm template \
       -s templates/sync-catalog-deployment.yaml  \


### PR DESCRIPTION
Changes proposed in this PR:
- With `client.enabled=false` and `tls.autoEncrypt.enabled=true` sync-catalog needs to use`consul-ca-cert` instead of the autoencrypt CA cert, otherwise it will not be able to use it's readinessProbe which issues consul client API calls.
- Add a check for each place where we test autoEncrypt for if the client is enabled and use the correct CA cert accordingly.

How I've tested this PR:
deployed with : 
```
client:
  enabled: false
server:
  replicas: 1
global:
  enabled: true
  image: hashicorp/consul:1.9.3
  imageEnvoy: envoyproxy/envoy-alpine:v1.16.0
  imageK8S: hashicorp/consul-k8s:0.25.0
  acls:
    manageSystemACLs: true
  tls:
    enableAutoEncrypt: true
    enabled: true
syncCatalog:
  enabled: true
```
And saw that the failure in GH-869 reproduces : `x509: certificate signed by unknown authority` from the readinessProbe.
With proposed changes this goes away and sync-catalog becomes Ready.

How I expect reviewers to test this PR:
Deploy with a build of this branch and yaml above with correct images, sync-catalog should become Ready.
Code review.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

