### PR TITLE
Fix a bug where we weren't setting -enable-transparent-proxy flag to false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,8 @@ jobs:
             # exit early if any test fails (-failfast only works within a single
             # package).
             exit_code=0
-            pkgs=$(go list ./... | circleci tests split)
-            echo "Running $pkgs"
+            pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            echo "Running $(echo $pkgs | wc -w) packages"
             for pkg in $pkgs
             do
               if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
@@ -622,10 +622,10 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
-      - acceptance-kind-1-20
+#      - acceptance-gke-1-16
+#      - acceptance-eks-1-17
+#      - acceptance-aks-1-18
+#      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="ishustava/consul-enterprise:tproxy-test" \
-                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:296675a"
+                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1
@@ -224,7 +224,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -238,9 +238,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-18:
     environment:
@@ -287,7 +287,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -301,9 +301,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-17:
     environment:
@@ -361,7 +361,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -375,9 +375,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -492,15 +492,15 @@ jobs:
               -secondary-kubecontext="kind-dc2" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-      - slack/status:
-          fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   go-fmt-and-vet-helm-gen:
     executor: go
@@ -622,10 +622,10 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-#      - acceptance-gke-1-16
-#      - acceptance-eks-1-17
-#      - acceptance-aks-1-18
-#      - acceptance-kind-1-20
+      - acceptance-gke-1-16
+      - acceptance-eks-1-17
+      - acceptance-aks-1-18
+      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
             exit_code=0
             pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
             echo "Running $(echo $pkgs | wc -w) packages:"
-            echo $pkg
+            echo $pkgs
             for pkg in $pkgs
             do
               if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,8 @@ jobs:
             # package).
             exit_code=0
             pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-            echo "Running $(echo $pkgs | wc -w) packages"
+            echo "Running $(echo $pkgs | wc -w) packages:"
+            echo $pkg
             for pkg in $pkgs
             do
               if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
@@ -484,7 +485,7 @@ jobs:
           working_directory: test/acceptance/tests
           no_output_timeout: 1h
           command: |
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 30m -failfast \
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 50m -failfast \
               -use-kind \
               -enable-multi-cluster \
               -enable-enterprise \
@@ -622,10 +623,10 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-#      - acceptance-gke-1-16
-#      - acceptance-eks-1-17
-#      - acceptance-aks-1-18
-#      - acceptance-kind-1-20
+      - acceptance-gke-1-16
+      - acceptance-eks-1-17
+      - acceptance-aks-1-18
+      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="ishustava/consul-enterprise:tproxy-test" \
-                    -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
+                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1
@@ -224,8 +224,7 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -239,9 +238,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-18:
     environment:
@@ -287,8 +286,7 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -302,9 +300,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-17:
     environment:
@@ -361,8 +359,7 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
@@ -376,9 +373,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -426,8 +423,7 @@ jobs:
               -kubeconfig="$HOME/.kube/$OC_PRIMARY_NAME" \
               -secondary-kubeconfig="$HOME/.kube/$OC_SECONDARY_NAME" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image=ashwinvenkatesh/consul-k8s:logger
+              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
           path: /tmp/test-results
@@ -492,16 +488,15 @@ jobs:
               -kubecontext="kind-dc1" \
               -secondary-kubecontext="kind-dc2" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
+              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
 
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   go-fmt-and-vet-helm-gen:
     executor: go
@@ -623,10 +618,6 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
-      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,8 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -consul-image="ishustava/consul-enterprise:tproxy-test" \
+              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
 
       - store_test_results:
           path: /tmp/test-results
@@ -285,7 +286,8 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -consul-image="ishustava/consul-enterprise:tproxy-test" \
+              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
 
       - store_test_results:
           path: /tmp/test-results
@@ -358,7 +360,8 @@ jobs:
               -kubeconfig="$primary_kubeconfig" \
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -consul-image="ishustava/consul-enterprise:tproxy-test" \
+              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
 
       - store_test_results:
           path: /tmp/test-results
@@ -422,6 +425,7 @@ jobs:
               -kubeconfig="$HOME/.kube/$OC_PRIMARY_NAME" \
               -secondary-kubeconfig="$HOME/.kube/$OC_SECONDARY_NAME" \
               -debug-directory="$TEST_RESULTS/debug" \
+              -consul-image="ishustava/consul-enterprise:tproxy-test" \
               -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
 
       - store_test_results:
@@ -487,7 +491,8 @@ jobs:
               -kubecontext="kind-dc1" \
               -secondary-kubecontext="kind-dc2" \
               -debug-directory="$TEST_RESULTS/debug" \
-              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -consul-image="ishustava/consul-enterprise:tproxy-test" \
+              -consul-k8s-image="kschoche/consul-k8s-dev2:2021-4-14" # TODO: change once feature-tproxy consul-k8s branch is merged
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
             echo "Running $pkgs"
             for pkg in $pkgs
             do
-              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 50m -failfast \
+              if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                     -use-kind \
                     -enable-enterprise \
                     -enable-multi-cluster \
@@ -617,6 +617,10 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
+      - acceptance-gke-1-16
+      - acceptance-eks-1-17
+      - acceptance-aks-1-18
+      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="ishustava/consul-enterprise:tproxy-test" \
-                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+                    -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1
@@ -225,7 +225,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
 
       - store_test_results:
           path: /tmp/test-results
@@ -288,7 +288,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
 
       - store_test_results:
           path: /tmp/test-results
@@ -362,7 +362,7 @@ jobs:
               -secondary-kubeconfig="$secondary_kubeconfig" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
 
       - store_test_results:
           path: /tmp/test-results
@@ -427,7 +427,7 @@ jobs:
               -secondary-kubeconfig="$HOME/.kube/$OC_SECONDARY_NAME" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image=docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest
+              -consul-k8s-image=ashwinvenkatesh/consul-k8s:logger
 
       - store_test_results:
           path: /tmp/test-results
@@ -493,7 +493,7 @@ jobs:
               -secondary-kubecontext="kind-dc2" \
               -debug-directory="$TEST_RESULTS/debug" \
               -consul-image="ishustava/consul-enterprise:tproxy-test" \
-              -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+              -consul-k8s-image="ashwinvenkatesh/consul-k8s:logger"
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,10 +622,10 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
-      - acceptance-kind-1-20
+#      - acceptance-gke-1-16
+#      - acceptance-eks-1-17
+#      - acceptance-aks-1-18
+#      - acceptance-kind-1-20
       - acceptance:
           requires:
             - unit-helm

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -91,7 +91,9 @@ spec:
                 -release-namespace="{{ .Release.Namespace }}" \
                 -listen=:8080 \
                 {{- if .Values.connectInject.transparentProxy.defaultEnabled }}
-                -enable-transparent-proxy \
+                -enable-transparent-proxy=true \
+                {{- else }}
+                -enable-transparent-proxy=false \
                 {{- end }}
                 {{- if .Values.connectInject.logLevel }}
                 -log-level={{ .Values.connectInject.logLevel }} \

--- a/test/acceptance/framework/consul/consul_cluster.go
+++ b/test/acceptance/framework/consul/consul_cluster.go
@@ -120,6 +120,11 @@ func (h *HelmCluster) Create(t *testing.T) {
 	helm.Install(t, h.helmOptions, config.HelmChartPath, h.releaseName)
 
 	helpers.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))
+
+	// We no longer have readiness checks in the connect-inject webhook,
+	// and we need to allow some extra time for the webhook to come up and start serving requests.
+	// TODO: remove once we have readiness checks for the webhook (before GA)
+	time.Sleep(30 * time.Second)
 }
 
 func (h *HelmCluster) Destroy(t *testing.T) {

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -65,8 +65,8 @@ func DeployKustomize(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailu
 		KubectlDeleteK(t, options, kustomizeDir)
 	})
 
-	// The timeout is 2min to allow for connect-init to wait for services to be registered by the endpoints controller.
-	RunKubectl(t, options, "wait", "--for=condition=available", "--timeout=2m", fmt.Sprintf("deploy/%s", deployment.Name))
+	// The timeout is 3min to allow for connect-init to wait for services to be registered by the endpoints controller.
+	RunKubectl(t, options, "wait", "--for=condition=available", "--timeout=3m", fmt.Sprintf("deploy/%s", deployment.Name))
 }
 
 // CheckStaticServerConnection execs into a pod of the deployment given by deploymentName

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -66,7 +66,7 @@ func DeployKustomize(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailu
 	})
 
 	// The timeout is 3min to allow for connect-init to wait for services to be registered by the endpoints controller.
-	RunKubectl(t, options, "wait", "--for=condition=available", "--timeout=3m", fmt.Sprintf("deploy/%s", deployment.Name))
+	RunKubectl(t, options, "wait", "--for=condition=available", "--timeout=5m", fmt.Sprintf("deploy/%s", deployment.Name))
 }
 
 // CheckStaticServerConnection execs into a pod of the deployment given by deploymentName

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -149,6 +149,7 @@ func CheckStaticServerConnectionFailing(t *testing.T, options *k8s.KubectlOption
 		deploymentName,
 		[]string{
 			"curl: (52) Empty reply from server",
+			"curl: (7) Failed to connect to localhost port 1234: Connection refused",
 			"curl: (7) Failed to connect to static-server port 80: Connection refused",
 			"curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused",
 		},

--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -65,7 +65,7 @@ func DeployKustomize(t *testing.T, options *k8s.KubectlOptions, noCleanupOnFailu
 		KubectlDeleteK(t, options, kustomizeDir)
 	})
 
-	// The timeout is 3min to allow for connect-init to wait for services to be registered by the endpoints controller.
+	// The timeout to allow for connect-init to wait for services to be registered by the endpoints controller.
 	RunKubectl(t, options, "wait", "--for=condition=available", "--timeout=5m", fmt.Sprintf("deploy/%s", deployment.Name))
 }
 

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -1382,7 +1382,7 @@ EOF
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-enable-transparent-proxy"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-transparent-proxy=true"))' | tee /dev/stderr)
 
   [ "${actual}" = "true" ]
 }
@@ -1394,7 +1394,7 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'connectInject.transparentProxy.defaultEnabled=false' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-enable-transparent-proxy"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-transparent-proxy=false"))' | tee /dev/stderr)
 
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }


### PR DESCRIPTION
Changes proposed in this PR:
- `enable-transparent-proxy` flag for the `inject-connect` command in consul-k8s defaults to true, but the helm chart was not passing `enable-transparent-proxy` when `connectInject.transparentProxy.defaultEnabled` is set to false.
- A few fixes to acceptance tests:
   - Increase timeout to wait for deployments to come up
   - Add 30sec sleep to all helm installs to compensate for the removed readiness check in the connect-inject webhook.

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
- code review
- 👁️ acceptance tests


Checklist:
- [x] Bats tests added
- Don't think this needs a separate changelog entry since it'll be part of `feature-tproxy`

