### PR TITLE
Acceptance: fix connection failing error

### DIFF
--- a/test/acceptance/framework/k8s/deploy.go
+++ b/test/acceptance/framework/k8s/deploy.go
@@ -139,8 +139,8 @@ func CheckStaticServerConnectionSuccessful(t *testing.T, options *k8s.KubectlOpt
 	logger.Logf(t, "Took %s to check if static server connection was successful", time.Since(start))
 }
 
-// CheckStaticServerConnectionSuccessful is just like CheckStaticServerConnection
-// but it always expects a failing connection with error "Empty reply from server."
+// CheckStaticServerConnectionFailing is just like CheckStaticServerConnection
+// but it always expects a failing connection with various errors.
 func CheckStaticServerConnectionFailing(t *testing.T, options *k8s.KubectlOptions, deploymentName string, curlArgs ...string) {
 	t.Helper()
 	CheckStaticServerConnection(t,
@@ -149,9 +149,7 @@ func CheckStaticServerConnectionFailing(t *testing.T, options *k8s.KubectlOption
 		deploymentName,
 		[]string{
 			"curl: (52) Empty reply from server",
-			"curl: (7) Failed to connect to localhost port 1234: Connection refused",
-			"curl: (7) Failed to connect to static-server port 80: Connection refused",
-			"curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused",
+			"curl: (7) Failed to connect",
 		},
 		curlArgs...)
 }


### PR DESCRIPTION
With the introduction of tproxy, the errors when a connection fail
include the KubeDNS names, for example:

```
curl: (7) Failed to connect to test-er1l1u-consul-ingress-gateway.default port 8080: Connection refused
```

Rather than match on the name it's connecting to, we can instead rely on
the "curl: (7) Failed to connect" part of the string since error code 7
is always a connection refused error and that's all we're really
testing.

This is the specific test that was failing:
https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2850/workflows/f145253b-2068-47d4-a427-b1ad7be6275c/jobs/11011.
I think it only passed before because it must have been getting "curl:
(52) Empty reply from server".


