### PR TITLE
Update service defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="hashicorp/consul-enterprise:1.10.0-ent-beta1" \
-                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+                    -consul-k8s-image="ashwinvenkatesh/consul-k8s@sha256:2b2a52ddebf7226b7aae7f66c41f903b0053deb0a3c1b88b5b9cdf063deb530e"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -88,7 +88,7 @@ spec:
                     type: string
                 type: object
               transparentProxy:
-                description: TransparentProxy controls configuration specific to proxies in transparent mode.
+                description: 'TransparentProxy controls configuration specific to proxies in transparent mode. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
                 properties:
                   outboundListenerPort:
                     description: The port of the listener where outbound application traffic is being redirected to.

--- a/templates/crd-servicedefaults.yaml
+++ b/templates/crd-servicedefaults.yaml
@@ -86,15 +86,130 @@ spec:
                     description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
                     type: string
                 type: object
+              mode:
+                description: 'Mode can be one of "direct" or "transparent". "transparent" represents that inbound and outbound application traffic is being captured and redirected through the proxy. This mode does not enable the traffic redirection itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected. "direct" represents that the proxy''s listeners must be dialed directly by the local application and other proxies. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
+                type: string
               protocol:
                 description: Protocol sets the protocol of the service. This is used by Connect proxies for things like observability features and to unlock usage of the service-splitter and service-router config entries for a service.
                 type: string
               transparentProxy:
-                description: TransparentProxy controls configuration specific to proxies in transparent mode.
+                description: 'TransparentProxy controls configuration specific to proxies in transparent mode. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
                 properties:
                   outboundListenerPort:
                     description: The port of the listener where outbound application traffic is being redirected to.
                     type: integer
+                type: object
+              upstreamConfig:
+                description: UpstreamConfig controls default configuration settings that apply across all upstreams, and per-upstream configuration overrides. Note that per-upstream configuration applies across all federated datacenters to the pairing of source and upstream destination services.
+                properties:
+                  defaults:
+                    description: Defaults contains default configuration for all upstreams of a given service. The name field must be empty.
+                    properties:
+                      connectTimeoutMs:
+                        description: ConnectTimeoutMs is the number of milliseconds to timeout making a new connection to this upstream. Defaults to 5000 (5 seconds) if not set.
+                        type: integer
+                      envoyClusterJSON:
+                        description: 'EnvoyClusterJSON is a complete override ("escape hatch") for the upstream''s cluster. The Connect client TLS certificate and context will be injected overriding any TLS settings present. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                        type: string
+                      envoyListenerJSON:
+                        description: 'EnvoyListenerJSON is a complete override ("escape hatch") for the upstream''s listener. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                        type: string
+                      limits:
+                        description: Limits are the set of limits that are applied to the proxy for a specific upstream of a service instance.
+                        properties:
+                          maxConcurrentRequests:
+                            description: MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed to the upstream cluster at a point in time. This is mostly applicable to HTTP/2 clusters since all HTTP/1.1 requests are limited by MaxConnections.
+                            type: integer
+                          maxConnections:
+                            description: MaxConnections is the maximum number of connections the local proxy can make to the upstream service.
+                            type: integer
+                          maxPendingRequests:
+                            description: MaxPendingRequests is the maximum number of requests that will be queued waiting for an available connection. This is mostly applicable to HTTP/1.1 clusters since all HTTP/2 requests are streamed over a single connection.
+                            type: integer
+                        type: object
+                      meshGateway:
+                        description: MeshGatewayConfig controls how Mesh Gateways are configured and used.
+                        properties:
+                          mode:
+                            description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                            type: string
+                        type: object
+                      name:
+                        description: Name is only accepted within a service-defaults config entry.
+                        type: string
+                      namespace:
+                        description: Namespace is only accepted within a service-defaults config entry.
+                        type: string
+                      passiveHealthCheck:
+                        description: PassiveHealthCheck configuration determines how upstream proxy instances will be monitored for removal from the load balancing pool.
+                        properties:
+                          interval:
+                            description: Interval between health check analysis sweeps. Each sweep may remove hosts or return hosts to the pool.
+                            type: string
+                          maxFailures:
+                            description: MaxFailures is the count of consecutive failures that results in a host being removed from the pool.
+                            format: int32
+                            type: integer
+                        type: object
+                      protocol:
+                        description: Protocol describes the upstream's service protocol. Valid values are "tcp", "http" and "grpc". Anything else is treated as tcp. This enables protocol aware features like per-request metrics and connection pooling, tracing, routing etc.
+                        type: string
+                    type: object
+                  overrides:
+                    description: Overrides is a slice of per-service configuration. The name field is required.
+                    items:
+                      properties:
+                        connectTimeoutMs:
+                          description: ConnectTimeoutMs is the number of milliseconds to timeout making a new connection to this upstream. Defaults to 5000 (5 seconds) if not set.
+                          type: integer
+                        envoyClusterJSON:
+                          description: 'EnvoyClusterJSON is a complete override ("escape hatch") for the upstream''s cluster. The Connect client TLS certificate and context will be injected overriding any TLS settings present. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                          type: string
+                        envoyListenerJSON:
+                          description: 'EnvoyListenerJSON is a complete override ("escape hatch") for the upstream''s listener. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                          type: string
+                        limits:
+                          description: Limits are the set of limits that are applied to the proxy for a specific upstream of a service instance.
+                          properties:
+                            maxConcurrentRequests:
+                              description: MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed to the upstream cluster at a point in time. This is mostly applicable to HTTP/2 clusters since all HTTP/1.1 requests are limited by MaxConnections.
+                              type: integer
+                            maxConnections:
+                              description: MaxConnections is the maximum number of connections the local proxy can make to the upstream service.
+                              type: integer
+                            maxPendingRequests:
+                              description: MaxPendingRequests is the maximum number of requests that will be queued waiting for an available connection. This is mostly applicable to HTTP/1.1 clusters since all HTTP/2 requests are streamed over a single connection.
+                              type: integer
+                          type: object
+                        meshGateway:
+                          description: MeshGatewayConfig controls how Mesh Gateways are configured and used.
+                          properties:
+                            mode:
+                              description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                              type: string
+                          type: object
+                        name:
+                          description: Name is only accepted within a service-defaults config entry.
+                          type: string
+                        namespace:
+                          description: Namespace is only accepted within a service-defaults config entry.
+                          type: string
+                        passiveHealthCheck:
+                          description: PassiveHealthCheck configuration determines how upstream proxy instances will be monitored for removal from the load balancing pool.
+                          properties:
+                            interval:
+                              description: Interval between health check analysis sweeps. Each sweep may remove hosts or return hosts to the pool.
+                              type: string
+                            maxFailures:
+                              description: MaxFailures is the count of consecutive failures that results in a host being removed from the pool.
+                              format: int32
+                              type: integer
+                          type: object
+                        protocol:
+                          description: Protocol describes the upstream's service protocol. Valid values are "tcp", "http" and "grpc". Anything else is treated as tcp. This enables protocol aware features like per-request metrics and connection pooling, tracing, routing etc.
+                          type: string
+                      type: object
+                    type: array
                 type: object
             type: object
           status:

--- a/test/acceptance/tests/fixtures/crds/servicedefaults.yaml
+++ b/test/acceptance/tests/fixtures/crds/servicedefaults.yaml
@@ -4,3 +4,23 @@ metadata:
   name: defaults
 spec:
   protocol: "http"
+  upstreamConfig:
+    defaults:
+      limits:
+        maxConnections: 3
+      passiveHealthCheck:
+        interval: 3s
+        maxFailures: 5
+    overrides:
+    - name: "foo"
+      limits:
+        maxConnections: 3
+      passiveHealthCheck:
+        interval: 1s
+        maxFailures: 10
+    - name: "bar"
+      limits:
+        maxConnections: 5
+      passiveHealthCheck:
+        interval: 10s
+        maxFailures: 2


### PR DESCRIPTION
Changes proposed in this PR:
- Update ServiceDefaults CRD with Mode and UpstreamConfigs
- Adds notes to let users know not to use the Mode and TransparentProxy fields on ServiceDefaults and ProxyDefaults

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

