### PR TITLE
Remove -disable-host-node-id=false flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ FEATURES:
 BUG FIXES:
 * CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because
   `apiextensions.k8s.io/v1` requires CRD spec to have structured schema. [[GH-921](https://github.com/hashicorp/consul-helm/pull/921)]
+* Don't set `-disable-host-node-id=false` on Consul Clients because it causes Clients to
+  not be able to join the cluster on certain hypervisor or Kind setups. This flag was
+  added in 0.30.0 to stop Consul logging an error when a Client pod was force deleted,
+  but this error does not affect the pod restarting so removing the flag will have
+  no real effect. [[GH-936](https://github.com/hashicorp/consul-helm/pull/936)]
 
 BREAKING CHANGES:
 * Remove templates for a demo installation of Grafana in light of recent license changes to Grafana. [[GH-930](https://github.com/hashicorp/consul-helm/pull/930)]

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -191,7 +191,6 @@ spec:
                 -node-meta=pod-name:${HOSTNAME} \
                 -node-meta=host-ip:${HOST_IP} \
                 -hcl='leave_on_terminate = true' \
-                -disable-host-node-id={{ .Values.client.disableHostNodeID }} \
                 {{- if .Values.global.tls.enabled }}
                 -hcl='ca_file = "/consul/tls/ca/tls.crt"' \
                 {{- if .Values.global.tls.enableAutoEncrypt }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -1206,27 +1206,3 @@ rollingUpdate:
   local actual=$(echo $security_context | jq -r .privileged)
   [ "${actual}" = "true" ]
 }
-
-#--------------------------------------------------------------------
-# client.disableHostNodeID
-
-@test "client/DaemonSet: disableHostNodeID defaults to false" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/client-daemonset.yaml \
-      . | tee /dev/stderr | \
-      yq '.spec.template.spec.containers[0].command | any(contains("disable-host-node-id=false"))' \
-      | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "client/DaemonSet: disableHostNodeID can be set to true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/client-daemonset.yaml \
-      --set 'client.disableHostNodeID=true' \
-      . | tee /dev/stderr | \
-      yq '.spec.template.spec.containers[0].command | any(contains("disable-host-node-id=true"))' \
-      | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}

--- a/values.yaml
+++ b/values.yaml
@@ -699,13 +699,6 @@ client:
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
 
-  # Disable host node ID 
-  # If true, consul clients will not use information from the host to generate a deterministic node ID
-  # and will instead generate a random node ID which will be persisted in the data directory. 
-  # When two VMs are on the same underlying hardware, they can have node IDs that collide. Setting `disableHostNodeID` to true can work around the collision.
-  # Refer to https://www.consul.io/docs/agent/options#_disable_host_node_id for more info. 
-  disableHostNodeID: false
-
   # Resource settings for Client agents.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
   # YAML map.


### PR DESCRIPTION
Don't set `-disable-host-node-id=false` on Consul Clients because it causes Clients to
not be able to join the cluster on certain hypervisor or Kind setups. This flag was
added in 0.30.0 to stop Consul logging an error when a Client pod was force deleted
but this error does not affect the pod restarting so removing the flag will have
no real effect.

Fixes https://github.com/hashicorp/consul-helm/pull/901

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

