### PR TITLE
Fixes #932

### DIFF
--- a/templates/server-role.yaml
+++ b/templates/server-role.yaml
@@ -17,6 +17,14 @@ rules:
   - {{ template "consul.fullname" . }}-server
   verbs:
   - use
+{{- if (and .Values.global.openshift.enabled .Values.server.exposeGossipAndRPCPorts ) }}
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames:
+  - {{ template "consul.fullname" . }}-server
+  verbs:
+  - use
+{{- end}}
 {{- else }}
 rules: []
 {{- end }}

--- a/templates/server-securitycontextconstraints.yaml
+++ b/templates/server-securitycontextconstraints.yaml
@@ -1,0 +1,46 @@
+{{- if (and .Values.global.openshift.enabled .Values.server.exposeGossipAndRPCPorts (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ template "consul.fullname" . }}-server
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/description: {{ template "consul.fullname" . }}-server are the security context constraints required
+      to run the consul server.
+allowHostPorts: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostPID: false
+allowHostNetwork: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{- end -}}


### PR DESCRIPTION
Changes proposed in this PR:
- New security context constraint for consul-server allowing only hostPort when appropriate
- Add this security context constraint to server role when appropriate

How I've tested this PR:

Helm template alters aoutput as expected when turning on and off the relevant values.
The chart deploys all as expected in out openshift environment when .Values.server.exposeGossipAndRPCPorts

