### PR TITLE
Add namespace read support to the connect-inject clusterrole so we can read namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+IMPROVEMENTS:
+* Connect: Add namespaces get/list/watch to the connect-inject clusterrole to support the ability to fetch namespace labels which can enable/disable tproxy for an entire namespace. [[GH-942](https://github.com/hashicorp/consul-helm/pull/942)]
+
 FEATURES:
 * CRDs: Update ServiceDefaults with Mode, TransparentProxy and UpstreamConfigs fields. Note: Mode and TransparentProxy should not be set
   using this CRD but via annotations. [[GH-925](https://github.com/hashicorp/consul-helm/pull/925)], [[GH-914](https://github.com/hashicorp/consul-helm/pull/914)]

--- a/templates/connect-inject-clusterrole.yaml
+++ b/templates/connect-inject-clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "namespaces"]
   verbs:
   - "get"
   - "list"


### PR DESCRIPTION
Add namespace read support to the clusterrole so we can read namespaces in the endpoints controller and webhook.

Changes proposed in this PR:
- Add namespaces get to the connect-inject clusterrole. The webhook handler and the endpoints controller both read namespaces now to fetch metadata related to tproxy labels.

How I've tested this PR:
manually tested alongside https://github.com/hashicorp/consul-k8s/pull/510 and verified that it resolves the following error: 
```
Error from server: error when creating "svc.yaml": admission webhook "kyle-consul-consul-connect-injector.consul.hashicorp.com" denied the request: error getting namespace metadata for container: namespaces "default" is forbidden: User "system:serviceaccount:default:kyle-consul-consul-connect-injector-webhook-svc-account" cannot get resource "namespaces" in API group "" in the namespace "default"
```
How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

