### PR TITLE
Bump envoy to 1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+IMPROVEMENTS:
+* Updated the default envoy image to `envoyproxy/envoy-alpine:v1.18.2`.
+
 ## 0.32.0-beta2 (May 6, 2021)
 
 IMPROVEMENTS:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,12 +18,14 @@ annotations:
     - name: consul-k8s
       image: hashicorp/consul-k8s:0.26.0-beta2
     - name: envoy
-      image: envoyproxy/envoy-alpine:v1.16.0
+      image: envoyproxy/envoy-alpine:v1.18.2
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
-    - name: Consul Homepage
-      url: https://www.consul.io
     - name: Documentation
       url: https://www.consul.io/docs/k8s
-    - name: Chart GitHub Repository
+    - name: hashicorp/consul-helm
       url: https://github.com/hashicorp/consul-helm
+    - name: hashicorp/consul
+      url: https://github.com/hashicorp/consul
+    - name: hashicorp/consul-k8s
+      url: https://github.com/hashicorp/consul-k8s

--- a/test/unit/ingress-gateways-deployment.bats
+++ b/test/unit/ingress-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.16.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.2" ]
 }
 
 @test "ingressGateways/Deployment: envoy image can be set using the global value" {

--- a/test/unit/mesh-gateway-deployment.bats
+++ b/test/unit/mesh-gateway-deployment.bats
@@ -335,7 +335,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.16.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.2" ]
 }
 
 @test "meshGateway/Deployment: setting meshGateway.imageEnvoy fails" {

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.16.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.2" ]
 }
 
 @test "terminatingGateways/Deployment: envoy image can be set using the global value" {

--- a/values.yaml
+++ b/values.yaml
@@ -272,7 +272,7 @@ global:
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   # @default: envoyproxy/envoy-alpine:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy-alpine:v1.16.0"
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.18.2"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Also modify some of our ArtifactHub links

Changes proposed in this PR:
- Bump envoy to 1.18.2 since that's supported in Consul 1.10
- Tweak our artifacthub links
  - Change `Chart GitHub Repository` to `hashicorp/consul-helm`
  - It looks like they take everything under `sources` and put the link titles as `Source` but if the same link is titled under `artifacthub.io/links` then they use that title so I'm adding the names as `hashicorp/<release name>`.

Here's what it looks like now:
![image](https://user-images.githubusercontent.com/1034429/117503385-b7fef900-af35-11eb-8d7a-5dac13f55741.png)

https://artifacthub.io/packages/helm/hashicorp/consul

How I've tested this PR: I haven't.

How I expect reviewers to test this PR: Acceptance tests.


Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

