### PR TITLE
Update templates to support license autoload.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,8 @@ commands:
                         -enable-enterprise \
                         -enable-multi-cluster \
                         -debug-directory="$TEST_RESULTS/debug" \
-                        -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+                        -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest" \
+                        -consul-image="ashwinvenkatesh/consul@sha256:7a5c5f6fc043bd690a1d27648b0cc3bcac68656e2841c2d862a7666b661ba864"
                   then
                     echo "Tests in ${pkg} failed, aborting early"
                     exit_code=1
@@ -189,9 +190,16 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
+      - run:
+          name: Create enterprise license secret
+          command: |
+            # Create an enterprise license secret in the primary cluster.
+            # This license is set as a CircleCI project env variable.
+            # The license expires 15-Oct-2025.
+            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -221,9 +229,16 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
+      - run:
+          name: Create enterprise license secret
+          command: |
+            # Create an enterprise license secret in the primary cluster.
+            # This license is set as a CircleCI project env variable.
+            # The license expires 15-Oct-2025.
+            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
             # This license is set as a CircleCI project env variable.
             # The license expires 15-Oct-2025.
             kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
+            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
@@ -236,6 +237,7 @@ jobs:
             # This license is set as a CircleCI project env variable.
             # The license expires 15-Oct-2025.
             kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
+            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,7 @@ commands:
                         -enable-enterprise \
                         -enable-multi-cluster \
                         -debug-directory="$TEST_RESULTS/debug" \
-                        -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest" \
-                        -consul-image="ashwinvenkatesh/consul@sha256:7a5c5f6fc043bd690a1d27648b0cc3bcac68656e2841c2d862a7666b661ba864"
+                        -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
                   then
                     echo "Tests in ${pkg} failed, aborting early"
                     exit_code=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,17 +190,9 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -230,17 +222,9 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -286,14 +270,6 @@ jobs:
             echo "export primary_kubeconfig=$primary_kubeconfig" >> $BASH_ENV
             echo "export secondary_kubeconfig=$secondary_kubeconfig" >> $BASH_ENV
 
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
-
       # Restore go module cache if there is one
       - restore_cache:
           keys:
@@ -302,7 +278,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key -enable-transparent-proxy
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
 
       - store_test_results:
           path: /tmp/test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,29 @@ IMPROVEMENTS:
 * Connect: Allow overwriting Kubernetes HTTP probes when running with transparent proxy enabled.
   [[GH-953](https://github.com/hashicorp/consul-helm/pull/953)]
 
+FEATURES:
+* License Autoloading [Enterprise]: Consul Enterprise 1.10+ now requires the enterprise license for Consul to be provided as a Kubernetes secret. Once created, the secret can be
+  configured in the helm chart with the following values:
+```yaml
+server:
+  enterpriseLicense:
+    secretName: <name-of-kubernetes-secret>
+    secretKey: <name-of-key-whose-value-is-the-license>
+```
+
 BUG FIXES:
 * OpenShift: support `server.exposeGossipAndRPCPorts`. [[GH-932](https://github.com/hashicorp/consul-helm/issues/932)]
+
+BREAKING CHANGES:
+* [Enterprise] For versions of Consul Enterprise <1.10, if the license was provided as a Kubernetes secret, the key `server.enterpriseLicense.enableLicenseAutoload` needs to explicitly
+  set to false in order for the license job to run.
+```yaml
+server:
+  enterpriseLicense:
+    secretName: <name-of-kubernetes-secret>
+    secretKey: <name-of-key-whose-value-is-the-license>
+    enableLicenseAutoload: false
+```
 
 ## 0.32.0-beta2 (May 6, 2021)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Below is the list of available flags:
 -debug-directory
     The directory where to write debug information about failed test runs, such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
 -enable-enterprise
-    If true, the test suite will run tests for enterprise features. Note that some features may require setting the enterprise license flags below.
+    If true, the test suite will run tests for enterprise features. Note that some features may require setting the enterprise license flag below or the env var CONSUL_ENT_LICENSE.
 -enable-multi-cluster
     If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -enable-openshift
@@ -99,10 +99,8 @@ Below is the list of available flags:
 -enable-transparent-proxy
     If true, the test suite will run tests with transparent proxy enabled.
     This applies only to tests that enable connectInject.
--enterprise-license-secret-name
-    The name of the Kubernetes secret containing the enterprise license.
--enterprise-license-secret-key
-    The key of the Kubernetes secret containing the enterprise license.
+-enterprise-license
+    The enterprise license for Consul.
 -kubeconfig string
     The path to a kubeconfig file. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
 -kubecontext string

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -127,6 +127,12 @@ spec:
         {{- if .Values.global.acls.manageSystemACLs }}
         - name: aclconfig
           emptyDir: {}
+        {{- else }}
+        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        - name: consul-license
+          secret:
+            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+        {{- end }}
         {{- end }}
       containers:
         - name: consul
@@ -164,6 +170,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.gossipEncryption.secretName }}
                   key: {{ .Values.global.gossipEncryption.secretKey }}
+            {{- end }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
+            - name: CONSUL_LICENSE_PATH
+              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
@@ -271,6 +281,12 @@ spec:
             {{- if .Values.global.acls.manageSystemACLs }}
             - name: aclconfig
               mountPath: /consul/aclconfig
+            {{- else }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            - name: consul-license
+              mountPath: /consul/license
+              readOnly: true
+            {{- end }}
             {{- end }}
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -128,7 +128,7 @@ spec:
         - name: aclconfig
           emptyDir: {}
         {{- else }}
-        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
@@ -171,7 +171,7 @@ spec:
                   name: {{ .Values.global.gossipEncryption.secretName }}
                   key: {{ .Values.global.gossipEncryption.secretKey }}
             {{- end }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}
@@ -282,7 +282,7 @@ spec:
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- else }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
       volumes:
         {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
         - name: snapshot-config
@@ -50,6 +50,12 @@ spec:
         {{- if .Values.global.acls.manageSystemACLs }}
         - name: aclconfig
           emptyDir: {}
+        {{- else }}
+        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        - name: consul-license
+          secret:
+            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+        {{- end }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
         {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
@@ -94,6 +100,11 @@ spec:
                 secretKeyRef:
                   name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
+            {{- else }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            - name: CONSUL_LICENSE_PATH
+              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
+            {{- end }}
             {{- end}}
           command:
             - "/bin/sh"
@@ -111,7 +122,7 @@ spec:
                 {{- if .Values.global.acls.manageSystemACLs }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
-          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) ) }}
+          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
           volumeMounts:
             {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
             - name: snapshot-config
@@ -121,6 +132,12 @@ spec:
             {{- if .Values.global.acls.manageSystemACLs }}
             - name: aclconfig
               mountPath: /consul/aclconfig
+            {{- else }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            - name: consul-license
+              mountPath: /consul/license
+              readOnly: true
+            {{- end }}
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt}}

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
       volumes:
         {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
         - name: snapshot-config
@@ -51,7 +51,7 @@ spec:
         - name: aclconfig
           emptyDir: {}
         {{- else }}
-        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
@@ -101,7 +101,7 @@ spec:
                   name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
             {{- else }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}
@@ -122,7 +122,7 @@ spec:
                 {{- if .Values.global.acls.manageSystemACLs }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
-          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
           volumeMounts:
             {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
             - name: snapshot-config
@@ -133,7 +133,7 @@ spec:
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- else }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+{{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/templates/enterprise-license-job.yaml
+++ b/templates/enterprise-license-job.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/templates/enterprise-license-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/templates/enterprise-license-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/enterprise-license-role.yaml
+++ b/templates/enterprise-license-role.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/enterprise-license-role.yaml
+++ b/templates/enterprise-license-role.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/enterprise-license-rolebinding.yaml
+++ b/templates/enterprise-license-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/templates/enterprise-license-rolebinding.yaml
+++ b/templates/enterprise-license-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/enterprise-license-serviceaccount.yaml
+++ b/templates/enterprise-license-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-  {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -97,6 +97,11 @@ spec:
           secret:
             secretName: {{ template "consul.fullname" . }}-server-cert
         {{- end }}
+        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        - name: consul-license
+          secret:
+            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+        {{- end }}
         {{- range .Values.server.extraVolumes }}
         - name: userconfig-{{ .name }}
           {{ .type }}:
@@ -152,6 +157,10 @@ spec:
               value: https://localhost:8501
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
+            {{- end }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            - name: CONSUL_LICENSE_PATH
+              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}
             {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
             - name: ACL_REPLICATION_TOKEN
@@ -236,6 +245,11 @@ spec:
               readOnly: true
             - name: consul-server-cert
               mountPath: /consul/tls/server
+              readOnly: true
+            {{- end }}
+            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            - name: consul-license
+              mountPath: /consul/license
               readOnly: true
             {{- end }}
             {{- range .Values.server.extraVolumes }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           secret:
             secretName: {{ template "consul.fullname" . }}-server-cert
         {{- end }}
-        {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
@@ -158,7 +158,7 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}
@@ -247,7 +247,7 @@ spec:
               mountPath: /consul/tls/server
               readOnly: true
             {{- end }}
-            {{- if (and (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -13,7 +13,11 @@ import (
 
 // HelmChartPath is the path to the helm chart.
 // Note: this will need to be changed if this file is moved.
-const HelmChartPath = "../../../.."
+const (
+	HelmChartPath     = "../../../.."
+	LicenseSecretName = "license"
+	LicenseSecretKey  = "key"
+)
 
 // TestConfig holds configuration for the test suite.
 type TestConfig struct {
@@ -26,9 +30,8 @@ type TestConfig struct {
 	SecondaryKubeContext   string
 	SecondaryKubeNamespace string
 
-	EnableEnterprise            bool
-	EnterpriseLicenseSecretName string
-	EnterpriseLicenseSecretKey  string
+	EnableEnterprise  bool
+	EnterpriseLicense string
 
 	EnableOpenshift bool
 
@@ -62,9 +65,9 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 		setIfNotEmpty(helmValues, "global.image", entImage)
 	}
 
-	if t.EnterpriseLicenseSecretName != "" && t.EnterpriseLicenseSecretKey != "" {
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretName", t.EnterpriseLicenseSecretName)
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretKey", t.EnterpriseLicenseSecretKey)
+	if t.EnterpriseLicense != "" {
+		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretName", LicenseSecretName)
+		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretKey", LicenseSecretKey)
 	}
 
 	if t.EnableOpenshift {

--- a/test/acceptance/framework/config/config_test.go
+++ b/test/acceptance/framework/config/config_test.go
@@ -58,28 +58,18 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 		{
 			"sets ent license secret",
 			TestConfig{
-				EnterpriseLicenseSecretName: "ent-license",
-				EnterpriseLicenseSecretKey:  "key",
+				EnterpriseLicense: "ent-license",
 			},
 			map[string]string{
-				"server.enterpriseLicense.secretName":           "ent-license",
+				"server.enterpriseLicense.secretName":           "license",
 				"server.enterpriseLicense.secretKey":            "key",
 				"connectInject.transparentProxy.defaultEnabled": "false",
 			},
 		},
 		{
-			"doesn't set ent license secret when only secret name is set",
+			"doesn't set ent license if license is empty",
 			TestConfig{
-				EnterpriseLicenseSecretName: "ent-license",
-			},
-			map[string]string{
-				"connectInject.transparentProxy.defaultEnabled": "false",
-			},
-		},
-		{
-			"doesn't set ent license secret when only secret key is set",
-			TestConfig{
-				EnterpriseLicenseSecretKey: "key",
+				EnterpriseLicense: "",
 			},
 			map[string]string{
 				"connectInject.transparentProxy.defaultEnabled": "false",

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"errors"
 	"flag"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/config"
@@ -18,9 +19,8 @@ type TestFlags struct {
 	flagSecondaryKubecontext string
 	flagSecondaryNamespace   string
 
-	flagEnableEnterprise            bool
-	flagEnterpriseLicenseSecretName string
-	flagEnterpriseLicenseSecretKey  string
+	flagEnableEnterprise  bool
+	flagEnterpriseLicense string
 
 	flagEnableOpenshift bool
 
@@ -69,10 +69,6 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagEnableEnterprise, "enable-enterprise", false,
 		"If true, the test suite will run tests for enterprise features. "+
 			"Note that some features may require setting the enterprise license flags below.")
-	flag.StringVar(&t.flagEnterpriseLicenseSecretName, "enterprise-license-secret-name", "",
-		"The name of the Kubernetes secret containing the enterprise license.")
-	flag.StringVar(&t.flagEnterpriseLicenseSecretKey, "enterprise-license-secret-key", "",
-		"The key of the Kubernetes secret containing the enterprise license.")
 
 	flag.BoolVar(&t.flagEnableOpenshift, "enable-openshift", false,
 		"If true, the tests will automatically add Openshift Helm value for each Helm install.")
@@ -93,6 +89,8 @@ func (t *TestFlags) init() {
 
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
+
+	t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
 }
 
 func (t *TestFlags) Validate() error {
@@ -102,12 +100,9 @@ func (t *TestFlags) Validate() error {
 		}
 	}
 
-	onlyEntSecretNameSet := t.flagEnterpriseLicenseSecretName != "" && t.flagEnterpriseLicenseSecretKey == ""
-	onlyEntSecretKeySet := t.flagEnterpriseLicenseSecretName == "" && t.flagEnterpriseLicenseSecretKey != ""
-	if onlyEntSecretNameSet || onlyEntSecretKeySet {
-		return errors.New("both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one")
+	if t.flagEnableEnterprise && t.flagEnterpriseLicense == "" {
+		return errors.New("-enable-enterprise provided without setting env var CONSUL_ENT_LICENSE with consul license")
 	}
-
 	return nil
 }
 
@@ -124,9 +119,8 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		SecondaryKubeContext:   t.flagSecondaryKubecontext,
 		SecondaryKubeNamespace: t.flagSecondaryNamespace,
 
-		EnableEnterprise:            t.flagEnableEnterprise,
-		EnterpriseLicenseSecretName: t.flagEnterpriseLicenseSecretName,
-		EnterpriseLicenseSecretKey:  t.flagEnterpriseLicenseSecretKey,
+		EnableEnterprise:  t.flagEnableEnterprise,
+		EnterpriseLicense: t.flagEnterpriseLicense,
 
 		EnableOpenshift: t.flagEnableOpenshift,
 

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -68,7 +68,9 @@ func (t *TestFlags) init() {
 
 	flag.BoolVar(&t.flagEnableEnterprise, "enable-enterprise", false,
 		"If true, the test suite will run tests for enterprise features. "+
-			"Note that some features may require setting the enterprise license flags below.")
+			"Note that some features may require setting the enterprise license flag below or the env var CONSUL_ENT_LICENSE")
+	flag.StringVar(&t.flagEnterpriseLicense, "enterprise-license", "",
+		"The enterprise license for Consul.")
 
 	flag.BoolVar(&t.flagEnableOpenshift, "enable-openshift", false,
 		"If true, the tests will automatically add Openshift Helm value for each Helm install.")
@@ -90,7 +92,9 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
 
-	t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
+	if t.flagEnterpriseLicense == "" {
+		t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
+	}
 }
 
 func (t *TestFlags) Validate() error {

--- a/test/acceptance/framework/flags/flags_test.go
+++ b/test/acceptance/framework/flags/flags_test.go
@@ -11,8 +11,9 @@ func TestFlags_validate(t *testing.T) {
 		flagEnableMultiCluster   bool
 		flagSecondaryKubeconfig  string
 		flagSecondaryKubecontext string
-		flagEntLicenseSecretName string
-		flagEntLicenseSecretKey  string
+
+		flagEnableEnt  bool
+		flagEntLicense string
 	}
 	tests := []struct {
 		name       string
@@ -81,26 +82,18 @@ func TestFlags_validate(t *testing.T) {
 			"",
 		},
 		{
-			"enterprise license: error when only -enterprise-license-secret-name is provided",
+			"enterprise license: error when only -enable-enterprise is true but env CONSUL_ENT_LICENSE is not provided",
 			fields{
-				flagEntLicenseSecretName: "secret",
+				flagEnableEnt: true,
 			},
 			true,
-			"both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one",
+			"-enable-enterprise provided without setting env var CONSUL_ENT_LICENSE with consul license",
 		},
 		{
-			"enterprise license: error when only -enterprise-license-secret-key is provided",
+			"enterprise license: no error when both -enable-enterprise and env CONSUL_ENT_LICENSE are provided",
 			fields{
-				flagEntLicenseSecretKey: "key",
-			},
-			true,
-			"both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one",
-		},
-		{
-			"enterprise license: no error when both -enterprise-license-secret-name and -enterprise-license-secret-key are provided",
-			fields{
-				flagEntLicenseSecretName: "secret",
-				flagEntLicenseSecretKey:  "key",
+				flagEnableEnt:  true,
+				flagEntLicense: "license",
 			},
 			false,
 			"",
@@ -109,11 +102,11 @@ func TestFlags_validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tf := &TestFlags{
-				flagEnableMultiCluster:          tt.fields.flagEnableMultiCluster,
-				flagSecondaryKubeconfig:         tt.fields.flagSecondaryKubeconfig,
-				flagSecondaryKubecontext:        tt.fields.flagSecondaryKubecontext,
-				flagEnterpriseLicenseSecretName: tt.fields.flagEntLicenseSecretName,
-				flagEnterpriseLicenseSecretKey:  tt.fields.flagEntLicenseSecretKey,
+				flagEnableMultiCluster:   tt.fields.flagEnableMultiCluster,
+				flagSecondaryKubeconfig:  tt.fields.flagSecondaryKubeconfig,
+				flagSecondaryKubecontext: tt.fields.flagSecondaryKubecontext,
+				flagEnableEnterprise:     tt.fields.flagEnableEnt,
+				flagEnterpriseLicense:    tt.fields.flagEntLicense,
 			}
 			err := tf.Validate()
 			if tt.wantErr {

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -84,11 +84,6 @@ func TestMeshGatewayDefault(t *testing.T) {
 		"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 		"server.extraVolumes[0].items[0].path": "config.json",
 
-		// Enterprise license job will fail if it runs in the secondary DC,
-		// so we're explicitly setting these values to empty to avoid that.
-		"server.enterpriseLicense.secretName": "",
-		"server.enterpriseLicense.secretKey":  "",
-
 		"connectInject.enabled": "true",
 		// Temporarily disable tproxy regardless of the global setting.
 		// This should be removed once multi-cluster is working with explicit upstreams.
@@ -223,11 +218,6 @@ func TestMeshGatewaySecure(t *testing.T) {
 				"server.extraVolumes[0].load":          "true",
 				"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
 				"server.extraVolumes[0].items[0].path": "config.json",
-
-				// Enterprise license job will fail if it runs in the secondary DC,
-				// so we're explicitly setting these values to empty to avoid that.
-				"server.enterpriseLicense.secretName": "",
-				"server.enterpriseLicense.secretKey":  "",
 
 				"connectInject.enabled": "true",
 				// Temporarily disable tproxy regardless of the global setting.

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -380,3 +380,81 @@ exec /bin/consul snapshot agent \'
 
   [ "${actual}" = "${exp}" ]
 }
+
+#--------------------------------------------------------------------
+# license-autoload
+
+@test "client/SnapshotAgentDeployment: adds volume for license secret when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"consul-license","secret":{"secretName":"foo"}}' ]
+}
+
+@test "client/SnapshotAgentDeployment: adds volume mount for license secret when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"consul-license","mountPath":"/consul/license","readOnly":true}' ]
+}
+
+@test "client/SnapshotAgentDeployment: adds env var for license path when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
+}
+
+@test "client/SnapshotAgentDeployment: does not add license secret volume if manageSystemACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = "" ]
+}
+
+@test "client/SnapshotAgentDeployment: does not add license secret volume mount if manageSystemACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = "" ]
+}
+
+@test "client/SnapshotAgentDeployment: does not add license env if manageSystemACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
+      [ "${actual}" = "" ]
+}

--- a/test/unit/enterprise-license-job.bats
+++ b/test/unit/enterprise-license-job.bats
@@ -9,6 +9,15 @@ load _helpers
       .
 }
 
+@test "server/EnterpriseLicense: disabled if autoload is true (default) {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/enterprise-license-job.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      .
+}
+
 @test "server/EnterpriseLicense: disabled when servers are disabled" {
   cd `chart_dir`
   assert_empty helm template \
@@ -16,6 +25,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,6 +34,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -32,15 +43,17 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
-@test "server/EnterpriseLicense: enabled when secretName and secretKey is provided" {
+@test "server/EnterpriseLicense: enabled when secretName, secretKey is provided and autoload is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -55,6 +68,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
@@ -67,6 +81,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
@@ -89,6 +104,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes | length' | tee /dev/stderr)
@@ -101,6 +117,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes | length' | tee /dev/stderr)
@@ -113,6 +130,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
@@ -125,6 +143,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
@@ -137,6 +156,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
@@ -149,6 +169,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
@@ -161,6 +182,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
@@ -173,6 +195,7 @@ load _helpers
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.caCert.secretName=foo-ca-cert' \
       --set 'global.tls.caCert.secretKey=key' \

--- a/test/unit/enterprise-license-podsecuritypolicy.bats
+++ b/test/unit/enterprise-license-podsecuritypolicy.bats
@@ -9,6 +9,16 @@ load _helpers
       .
 }
 
+@test "enterpriseLicense/PodSecurityPolicy: disabled if autoload is true (default)" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/enterprise-license-podsecuritypolicy.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      .
+}
+
 @test "enterpriseLicense/PodSecurityPolicy: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   assert_empty helm template \
@@ -16,6 +26,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,6 +35,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -32,6 +44,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -41,6 +54,7 @@ load _helpers
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=false' \
       .
 }
@@ -51,6 +65,7 @@ load _helpers
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/enterprise-license-role.bats
+++ b/test/unit/enterprise-license-role.bats
@@ -9,6 +9,15 @@ load _helpers
       .
 }
 
+@test "enterpriseLicense/Role: disabled if autoload is true (default)" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/enterprise-license-role.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      .
+}
+
 @test "enterpriseLicense/Role: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   assert_empty helm template \
@@ -16,6 +25,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,6 +34,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -32,6 +43,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -41,6 +53,7 @@ load _helpers
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -52,6 +65,7 @@ load _helpers
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq '.rules | length' | tee /dev/stderr)
   [ "${actual}" = "0" ]
@@ -66,6 +80,7 @@ load _helpers
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resourceNames[0] == "RELEASE-NAME-consul-enterprise-license-acl-token")) | length' | tee /dev/stderr)
@@ -82,6 +97,7 @@ load _helpers
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)

--- a/test/unit/enterprise-license-rolebinding.bats
+++ b/test/unit/enterprise-license-rolebinding.bats
@@ -9,6 +9,15 @@ load _helpers
       .
 }
 
+@test "enterpriseLicense/RoleBinding: disabled if autoload is true (default)" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/enterprise-license-rolebinding.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      .
+}
+
 @test "enterpriseLicense/RoleBinding: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   assert_empty helm template \
@@ -16,6 +25,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,6 +34,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -32,15 +43,17 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
-@test "enterpriseLicense/RoleBinding: enabled when ent license defined" {
+@test "enterpriseLicense/RoleBinding: enabled when ent license defined and autoload disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/enterprise-license-serviceaccount.bats
+++ b/test/unit/enterprise-license-serviceaccount.bats
@@ -9,6 +9,15 @@ load _helpers
       .
 }
 
+@test "enterpriseLicense/ServiceAccount: disabled if autoload is true (default)" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/enterprise-license-serviceaccount.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      .
+}
+
 @test "enterpriseLicense/ServiceAccount: disabled with server=false, ent secret defined" {
   cd `chart_dir`
   assert_empty helm template \
@@ -16,6 +25,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,6 +34,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -32,6 +43,7 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -41,6 +53,7 @@ load _helpers
       -s templates/enterprise-license-serviceaccount.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -55,6 +68,7 @@ load _helpers
       -s templates/enterprise-license-serviceaccount.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.imagePullSecrets[0].name=my-secret' \
       --set 'global.imagePullSecrets[1].name=my-secret2' \
       . | tee /dev/stderr)

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1210,3 +1210,39 @@ load _helpers
   [ "$status" -eq 1 ]
   [[ "$output" =~ "server.bootstrapExpect cannot be less than server.replicas" ]]
 }
+
+#--------------------------------------------------------------------
+# license-autoload
+
+@test "server/StatefulSet: adds volume for license secret when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"consul-license","secret":{"secretName":"foo"}}' ]
+}
+
+@test "server/StatefulSet: adds volume mount for license secret when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"consul-license","mountPath":"/consul/license","readOnly":true}' ]
+}
+
+@test "server/StatefulSet: adds env var for license path when enterprise license secret name and key are provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -325,6 +325,8 @@ server:
     secretName: null
     # The key within the Kubernetes secret that holds the enterprise license.
     secretKey: null
+    # Manages license autoload. Supported in Consul 1.10+
+    enableLicenseAutoload: true
 
   # Exposes the servers' gossip and RPC ports as hostPorts. To enable a client
   # agent outside of the k8s cluster to join the datacenter, you would need to

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.5.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.10.0-beta2"
+  image: "hashicorp/consul:1.10.0-beta3"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s Docker image.


### PR DESCRIPTION
Changes proposed in this PR:
- Make updates required to support license auto loading.
- Ensure backwards compatibility for consul versions where license job is required to run.

TODO:
- Update acceptance tests to use autoLoad for consul 1.10+ (separate PR) 

How I've tested this PR:
- Run the acceptance tests with a Consul License set as a secret and autoloading enabled with ACLs enabled and disabled.

How I expect reviewers to test this PR:
- Code review
- Status of CI pipeline


Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

