### PR TITLE
Allow overwriting kubernetes http probes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="hashicorp/consul-enterprise:1.10.0-ent-beta2" \
-                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+                    -consul-k8s-image="ishustava/consul-k8s-dev:05-14-2021-d7662f1"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                     -secondary-kubecontext="kind-dc2" \
                     -debug-directory="$TEST_RESULTS/debug" \
                     -consul-image="hashicorp/consul-enterprise:1.10.0-ent-beta2" \
-                    -consul-k8s-image="ishustava/consul-k8s-dev:05-14-2021-d7662f1"
+                    -consul-k8s-image="docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
               then
                 echo "Tests in ${pkg} failed, aborting early"
                 exit_code=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+IMPROVEMENTS:
+* Connect: Allow overwriting Kubernetes HTTP probes when running with transparent proxy enabled.
+  [[GH-953](https://github.com/hashicorp/consul-helm/pull/953)]
 
 BUG FIXES:
 * OpenShift: support `server.exposeGossipAndRPCPorts`. [[GH-932](https://github.com/hashicorp/consul-helm/issues/932)]

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -91,9 +91,14 @@ spec:
                 -release-namespace="{{ .Release.Namespace }}" \
                 -listen=:8080 \
                 {{- if .Values.connectInject.transparentProxy.defaultEnabled }}
-                -enable-transparent-proxy=true \
+                -default-enable-transparent-proxy=true \
                 {{- else }}
-                -enable-transparent-proxy=false \
+                -default-enable-transparent-proxy=false \
+                {{- end }}
+                {{- if .Values.connectInject.transparentProxy.defaultOverwriteProbes }}
+                -transparent-proxy-default-overwrite-probes=true \
+                {{- else }}
+                -transparent-proxy-default-overwrite-probes=false \
                 {{- end }}
                 {{- if .Values.connectInject.logLevel }}
                 -log-level={{ .Values.connectInject.logLevel }} \

--- a/test/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
+++ b/test/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
@@ -17,6 +17,12 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
           readinessProbe:
             exec:
               command: ['sh', '-c', 'test ! -f /tmp/unhealthy']

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -1387,7 +1387,7 @@ EOF
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: can be disabled by setting connectInject.transparentProxy.defaultEnabled=false" {
+@test "connectInject/Deployment: transparent proxy can be disabled by setting connectInject.transparentProxy.defaultEnabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/connect-inject-deployment.yaml  \
@@ -1395,6 +1395,29 @@ EOF
       --set 'connectInject.transparentProxy.defaultEnabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-enable-transparent-proxy=false"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: overwrite probes is enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-transparent-proxy-default-overwrite-probes=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: overwrite probes can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultOverwriteProbes=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-transparent-proxy-default-overwrite-probes=false"))' | tee /dev/stderr)
 
   [ "${actual}" = "true" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1314,6 +1314,14 @@ connectInject:
     # This value is overridable via the "consul.hashicorp.com/transparent-proxy" pod annotation.
     defaultEnabled: true
 
+    # If true, we will overwrite Kubernetes HTTP probes of the pod to point to the Envoy proxy instead.
+    # This setting is recommended because with traffic being enforced to go through the Envoy proxy,
+    # the probes on the pod will fail because kube-proxy doesn't have the right certificates
+    # to talk to Envoy.
+    # This value is also overridable via the "consul.hashicorp.com/transparent-proxy-overwrite-probes" annotation.
+    # Note: This value has no effect if transparent proxy is disabled on the pod.
+    defaultOverwriteProbes: true
+
   # Configures metrics for Consul Connect services. All values are overridable
   # via annotations on a per-pod basis.
   metrics:


### PR DESCRIPTION
This is a companion to hashicorp/consul-k8s#517

Changes proposed in this PR:
- Add a new Helm value to allow overwriting k8s http probes globally.
- Add HTTP liveness probe to the static-server fixture for connect inject tests to test this. 

How I've tested this PR:
Ran the test with tproxy enabled and without the changes in consul-k8s and saw that it fails, then ran it again with `ishustava/consul-k8s-dev:05-14-2021-d7662f1` and the tests passed.

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

