### PR TITLE
acceptance-tests: check pod status and conditions in WaitForAllPodsToBeReady instead of container statutes

### DIFF
--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -128,19 +128,19 @@ func KubernetesContextFromOptions(t *testing.T, options *terratestk8s.KubectlOpt
 
 // IsReady returns true if pod is ready.
 func IsReady(pod corev1.Pod) bool {
-	if len(pod.Status.ContainerStatuses) == 0 {
+	if pod.Status.Phase == corev1.PodPending {
 		return false
 	}
 
-	for _, contStatus := range pod.Status.InitContainerStatuses {
-		if !contStatus.Ready {
-			return false
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			if cond.Status == corev1.ConditionTrue {
+				return true
+			} else {
+				return false
+			}
 		}
 	}
-	for _, contStatus := range pod.Status.ContainerStatuses {
-		if !contStatus.Ready {
-			return false
-		}
-	}
-	return true
+
+	return false
 }

--- a/test/acceptance/framework/k8s/debug.go
+++ b/test/acceptance/framework/k8s/debug.go
@@ -22,12 +22,12 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 	t.Helper()
 
 	if t.Failed() {
-		// Create k8s client from kubectl options
+		// Create k8s client from kubectl options.
 		client := helpers.KubernetesClientFromOptions(t, kubectlOptions)
 
 		contextName := helpers.KubernetesContextFromOptions(t, kubectlOptions)
 
-		// Create a directory for the test
+		// Create a directory for the test.
 		testDebugDirectory := filepath.Join(debugDirectory, t.Name(), contextName)
 		require.NoError(t, os.MkdirAll(testDebugDirectory, 0755))
 

--- a/test/acceptance/tests/metrics/metrics_test.go
+++ b/test/acceptance/tests/metrics/metrics_test.go
@@ -32,8 +32,9 @@ func TestComponentMetrics(t *testing.T) {
 		"connectInject.enabled": "true",
 		"controller.enabled":    "true",
 
-		"meshGateway.enabled":  "true",
-		"meshGateway.replicas": "1",
+		"meshGateway.enabled":      "true",
+		"meshGateway.replicas":     "1",
+		"meshGateway.service.type": "ClusterIP",
 
 		"ingressGateways.enabled":              "true",
 		"ingressGateways.gateways[0].name":     "ingress-gateway",
@@ -49,11 +50,6 @@ func TestComponentMetrics(t *testing.T) {
 		"ingressGateways.defaults.resources.requests.cpu":     "50m",
 		"terminatingGateways.defaults.resources.requests.cpu": "50m",
 		"meshGateway.resources.requests.cpu":                  "50m",
-	}
-
-	if cfg.UseKind {
-		helmValues["meshGateway.service.type"] = "NodePort"
-		helmValues["meshGateway.service.nodePort"] = "30000"
 	}
 
 	releaseName := helpers.RandomName()


### PR DESCRIPTION
Sometimes, it seems like `WaitForAllPodsToBeReady` exits before the pods are actually ready. For example, in [this test's artifacts](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3006/workflows/9ae2156b-f41f-40d2-af61-5b3e9b31e35a/jobs/12114/artifacts), we can see that ingress and mesh gateway pods are not ready yet but in the output of the test it shows that `WaitForAllPodsToBeReady` exited after 1sec. I think it's because previously, we were only checking container statutes, and there are transition states where the status of the container may be Ready, but the pod itself is not yet ready.

Changes proposed in this PR:
- Check the pod phase and status instead of individual containers
- Also, use clusterIP service in the component metrics test for the mesh gateway instead of the load balancer (default) since we don't need mesh gw to be reachable in this test and some clouds take a long time to provision a load balancer.

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

