### PR TITLE
create an acl replication token whenever federation is enabled

### DIFF
--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -195,7 +195,7 @@ spec:
                 -create-client-token=false \
                 {{- end }}
 
-                {{- if (or .Values.global.federation.enabled .Values.global.acls.createReplicationToken) }}
+                {{- if (or .Values.global.acls.createReplicationToken (and .Values.global.federation.enabled (and .Values.connectInject.enabled (and .Values.global.tls.enabled .Values.meshGateway.enabled)))) }}
                 -create-acl-replication-token=true \
                 {{- end }}
 

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -195,7 +195,7 @@ spec:
                 -create-client-token=false \
                 {{- end }}
 
-                {{- if .Values.global.acls.createReplicationToken }}
+                {{- if (or .Values.global.federation.enabled .Values.global.acls.createReplicationToken) }}
                 -create-acl-replication-token=true \
                 {{- end }}
 

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1019,6 +1019,19 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/Job: -create-acl-replication-token is true when federation is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.createReplicationToken=false' \
+      --set 'global.federation.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-create-acl-replication-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+
 #--------------------------------------------------------------------
 # global.acls.replicationToken
 

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1024,6 +1024,9 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.acls.createReplicationToken=false' \
       --set 'global.federation.enabled=true' \
       . | tee /dev/stderr |


### PR DESCRIPTION
Changes proposed in this PR:
- add `-create-acl-replication-token=true` to server-acl-init whenever federation is enabled so that we can use it in consul-k8s to know when federation is enabled.

How I've tested this PR:
unit tests + acceptance tests

How I expect reviewers to test this PR:
code review + unit test

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

