### PR TITLE
Allow setting annotations on service accounts

### DIFF
--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- with .Values.client.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.client.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.client.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.client.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.client.serviceAccount.annotations }}
+  {{- if .Values.client.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl .Values.client.serviceAccount.annotations . | nindent 4 }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/client-serviceaccount.yaml
+++ b/templates/client-serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.client.serviceAccountAnnotations }}
+  {{- with .Values.client.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,9 +10,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.client.snapshotAgent.serviceAccount.annotations }}
+  {{- if .Values.client.snapshotAgent.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl .Values.client.snapshotAgent.serviceAccount.annotations . | nindent 4 }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.client.snapshotAgent.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.client.snapshotAgent.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.client.snapshotAgent.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.client.snapshotAgent.serviceAccountAnnotations }}
+  {{- with .Values.client.snapshotAgent.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/client-snapshot-agent-serviceaccount.yaml
+++ b/templates/client-snapshot-agent-serviceaccount.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- with .Values.client.snapshotAgent.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.connectInject.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.connectInject.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.connectInject.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/connect-inject-serviceaccount.yaml
+++ b/templates/connect-inject-serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.connectInject.serviceAccount.annotations }}
+  annotations:
+    {{- tpl .Values.connectInject.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/controller-serviceaccount.yaml
+++ b/templates/controller-serviceaccount.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: controller
+  {{- if .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- tpl .Values.controller.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
   {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/templates/controller-serviceaccount.yaml
+++ b/templates/controller-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     component: controller
   {{- if .Values.controller.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.controller.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.controller.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
   {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/ingress-gateways-serviceaccount.yaml
+++ b/templates/ingress-gateways-serviceaccount.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.ingressGateways.enabled }}
 {{- $root := . }}
+{{- $defaults := .Values.ingressGateways.defaults }}
 {{- range .Values.ingressGateways.gateways }}
+{{- $serviceAccount := .serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,9 +15,14 @@ metadata:
     release: {{ $root.Release.Name }}
     component: ingress-gateway
     ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
-  {{- if $root.Values.ingressGateways.serviceAccount.annotations }}
+  {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
   annotations:
-    {{- tpl $root.Values.ingressGateways.serviceAccount.annotations $root | nindent 4 }}
+    {{- if $defaults.serviceAccount.annotations }}
+    {{ tpl $defaults.serviceAccount.annotations $root | nindent 4 | trim }}
+    {{- end }}
+    {{- if $serviceAccount.annotations }}
+    {{ tpl $serviceAccount.annotations $root | nindent 4 | trim }}
+    {{- end }}
   {{- end }}
 {{- with $root.Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/ingress-gateways-serviceaccount.yaml
+++ b/templates/ingress-gateways-serviceaccount.yaml
@@ -13,6 +13,10 @@ metadata:
     release: {{ $root.Release.Name }}
     component: ingress-gateway
     ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+  {{- if $root.Values.ingressGateways.serviceAccount.annotations }}
+  annotations:
+    {{- tpl $root.Values.ingressGateways.serviceAccount.annotations $root | nindent 4 }}
+  {{- end }}
 {{- with $root.Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: mesh-gateway
+  {{- if .Values.meshGateway.serviceAccount.annotations }}
+  annotations:
+    {{- tpl .Values.meshGateway.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/mesh-gateway-serviceaccount.yaml
+++ b/templates/mesh-gateway-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     component: mesh-gateway
   {{- if .Values.meshGateway.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.meshGateway.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.meshGateway.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.server.serviceAccountAnnotations }}
+  {{- with .Values.server.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.server.serviceAccount.annotations }}
+  {{- if .Values.server.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.server.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.server.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- with .Values.server.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.syncCatalog.serviceAccount.annotations }}
+  annotations:
+    {{- tpl .Values.syncCatalog.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/templates/sync-catalog-serviceaccount.yaml
+++ b/templates/sync-catalog-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if .Values.syncCatalog.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.syncCatalog.serviceAccount.annotations . | nindent 4 }}
+    {{ tpl .Values.syncCatalog.serviceAccount.annotations . | nindent 4 | trim }}
   {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/templates/terminating-gateways-serviceaccount.yaml
+++ b/templates/terminating-gateways-serviceaccount.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.terminatingGateways.enabled }}
 {{- $root := . }}
+{{- $defaults := .Values.terminatingGateways.defaults }}
 {{- range .Values.terminatingGateways.gateways }}
+{{- $serviceAccount := .serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,6 +15,15 @@ metadata:
     release: {{ $root.Release.Name }}
     component: terminating-gateway
     terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+  {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
+  annotations:
+    {{- if $defaults.serviceAccount.annotations }}
+    {{ tpl $defaults.serviceAccount.annotations $root | nindent 4 | trim }}
+    {{- end }}
+    {{- if $serviceAccount.annotations }}
+    {{ tpl $serviceAccount.annotations $root | nindent 4 | trim }}
+    {{- end }}
+  {{- end }}
 {{- with $root.Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range . }}

--- a/test/unit/client-serviceaccount.bats
+++ b/test/unit/client-serviceaccount.bats
@@ -67,3 +67,25 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# client.serviceAccountAnnotations
+
+@test "client/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-serviceaccount.yaml \
+      --set "client.serviceAccountAnnotations.foo=bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/client-serviceaccount.bats
+++ b/test/unit/client-serviceaccount.bats
@@ -69,7 +69,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# client.serviceAccountAnnotations
+# client.serviceAccount.annotations
 
 @test "client/ServiceAccount: no annotations by default" {
   cd `chart_dir`
@@ -84,7 +84,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-serviceaccount.yaml \
-      --set "client.serviceAccountAnnotations.foo=bar" \
+      --set "client.serviceAccount.annotations.foo=bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/client-serviceaccount.bats
+++ b/test/unit/client-serviceaccount.bats
@@ -84,7 +84,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-serviceaccount.yaml \
-      --set "client.serviceAccount.annotations.foo=bar" \
+      --set "client.serviceAccount.annotations=foo: bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/client-snapshot-agent-serviceaccount.bats
+++ b/test/unit/client-snapshot-agent-serviceaccount.bats
@@ -59,7 +59,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# client.snapshotAgent.serviceAccountAnnotations
+# client.snapshotAgent.serviceAccount.annotations
 
 @test "client/SnapshotAgentServiceAccount: no annotations by default" {
   cd `chart_dir`
@@ -76,7 +76,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/client-snapshot-agent-serviceaccount.yaml \
       --set 'client.snapshotAgent.enabled=true' \
-      --set "client.snapshotAgent.serviceAccountAnnotations.foo=bar" \
+      --set "client.snapshotAgent.serviceAccount.annotations.foo=bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/client-snapshot-agent-serviceaccount.bats
+++ b/test/unit/client-snapshot-agent-serviceaccount.bats
@@ -57,3 +57,27 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# client.snapshotAgent.serviceAccountAnnotations
+
+@test "client/SnapshotAgentServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-serviceaccount.yaml \
+      --set 'client.snapshotAgent.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/SnapshotAgentServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-snapshot-agent-serviceaccount.yaml \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set "client.snapshotAgent.serviceAccountAnnotations.foo=bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/client-snapshot-agent-serviceaccount.bats
+++ b/test/unit/client-snapshot-agent-serviceaccount.bats
@@ -76,7 +76,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/client-snapshot-agent-serviceaccount.yaml \
       --set 'client.snapshotAgent.enabled=true' \
-      --set "client.snapshotAgent.serviceAccount.annotations.foo=bar" \
+      --set "client.snapshotAgent.serviceAccount.annotations=foo: bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/connect-inject-serviceaccount.bats
+++ b/test/unit/connect-inject-serviceaccount.bats
@@ -48,3 +48,27 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# connectInject.serviceAccount.annotations
+
+@test "connectInject/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set "connectInject.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/controller-serviceaccount.bats
+++ b/test/unit/controller-serviceaccount.bats
@@ -39,3 +39,27 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# controller.serviceAccount.annotations
+
+@test "controller/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-serviceaccount.yaml  \
+      --set 'controller.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "controller/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-serviceaccount.yaml  \
+      --set 'controller.enabled=true' \
+      --set "controller.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -66,3 +66,29 @@ load _helpers
       yq -r '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# ingressGateways.serviceAccount.annotations
+
+@test "ingressGateways/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-serviceaccount.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-serviceaccount.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set "ingressGateways.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/ingress-gateways-serviceaccount.bats
+++ b/test/unit/ingress-gateways-serviceaccount.bats
@@ -83,12 +83,20 @@ load _helpers
 
 @test "ingressGateways/ServiceAccount: annotations when enabled" {
   cd `chart_dir`
-  local actual=$(helm template \
+
+  local object=$(helm template \
       -s templates/ingress-gateways-serviceaccount.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set "ingressGateways.serviceAccount.annotations=foo: bar" \
+      --set "ingressGateways.defaults.serviceAccount.annotations=default: foo" \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set "ingressGateways.gateways[0].serviceAccount.annotations=gateway1: bar" \
       . | tee /dev/stderr |
-      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.annotations.default' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object | yq -r '.[0].metadata.annotations.gateway1' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }

--- a/test/unit/mesh-gateway-serviceaccount.bats
+++ b/test/unit/mesh-gateway-serviceaccount.bats
@@ -42,3 +42,28 @@ load _helpers
   [ "${actual}" = "my-secret2" ]
 }
 
+#--------------------------------------------------------------------
+# meshGateway.serviceAccount.annotations
+
+@test "meshGateway/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-serviceaccount.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-serviceaccount.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set "meshGateway.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -67,3 +67,25 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# server.serviceAccountAnnotations
+
+@test "server/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-serviceaccount.yaml  \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-serviceaccount.yaml  \
+      --set "server.serviceAccountAnnotations.foo=bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -69,7 +69,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# server.serviceAccountAnnotations
+# server.serviceAccount.annotations
 
 @test "server/ServiceAccount: no annotations by default" {
   cd `chart_dir`
@@ -84,7 +84,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-serviceaccount.yaml  \
-      --set "server.serviceAccountAnnotations.foo=bar" \
+      --set "server.serviceAccount.annotations.foo=bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -84,7 +84,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-serviceaccount.yaml  \
-      --set "server.serviceAccount.annotations.foo=bar" \
+      --set "server.serviceAccount.annotations=foo: bar" \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/sync-catalog-serviceaccount.bats
+++ b/test/unit/sync-catalog-serviceaccount.bats
@@ -66,3 +66,27 @@ load _helpers
       yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
   [ "${actual}" = "my-secret2" ]
 }
+
+#--------------------------------------------------------------------
+# syncCatalog.serviceAccount.annotations
+
+@test "syncCatalog/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-serviceaccount.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "syncCatalog/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-serviceaccount.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set "syncCatalog.serviceAccount.annotations=foo: bar" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/terminating-gateways-serviceaccount.bats
+++ b/test/unit/terminating-gateways-serviceaccount.bats
@@ -66,3 +66,37 @@ load _helpers
       yq -r '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+#--------------------------------------------------------------------
+# terminatingGateways.serviceAccount.annotations
+
+@test "terminatingGateways/ServiceAccount: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-serviceaccount.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.metadata.annotations | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/ServiceAccount: annotations when enabled" {
+  cd `chart_dir`
+
+  local object=$(helm template \
+      -s templates/terminating-gateways-serviceaccount.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set "terminatingGateways.defaults.serviceAccount.annotations=default: foo" \
+      --set 'terminatingGateways.gateways[0].name=gateway1' \
+      --set "terminatingGateways.gateways[0].serviceAccount.annotations=gateway1: bar" \
+      . | tee /dev/stderr |
+      yq -s -r '.' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].metadata.annotations.default' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object | yq -r '.[0].metadata.annotations.gateway1' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1787,6 +1787,19 @@ meshGateway:
   # @type: integer
   hostPort: null
 
+  serviceAccount:
+    # This value defines additional annotations for the mesh gateways' service account. This should be formatted as a
+    # multi-line string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
   # Resource settings for mesh gateway pods.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
   # YAML map.

--- a/values.yaml
+++ b/values.yaml
@@ -1416,6 +1416,19 @@ connectInject:
   # Log verbosity level. One of "debug", "info", "warn", or "error".
   logLevel: info
 
+  serviceAccount:
+    # This value defines additional annotations for the client service account. This should be formatted as a multi-line
+    # string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
   # Resource settings for connect inject pods.
   # @recurse: false
   # @type: map

--- a/values.yaml
+++ b/values.yaml
@@ -371,8 +371,9 @@ server:
   # by setting the `server.extraConfig` value.
   connect: true
 
-  # A map of annotations to add to the server service account
-  serviceAccountAnnotations: {}
+  serviceAccount:
+    # A map of annotations to add to the server service account 
+    annotations: {}
 
   # The resource requests (CPU, memory, etc.)
   # for each of the server agents. This should be a YAML map corresponding to a Kubernetes
@@ -702,8 +703,9 @@ client:
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
 
-  # A map of annotations to add to the client service account
-  serviceAccountAnnotations: {}
+  serviceAccount:
+    # A map of annotations to add to the client service account 
+    annotations: {}
 
   # Resource settings for Client agents.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
@@ -910,8 +912,9 @@ client:
       # The key of the Kubernetes secret.
       secretKey: null
 
-    # A map of annotations to add to the snapshot agent service account
-    serviceAccountAnnotations: {}
+    serviceAccount:
+      # A map of annotations to add to the snapshot agent service account 
+      annotations: {}
 
     # Resource settings for snapshot agent pods.
     # @recurse: false

--- a/values.yaml
+++ b/values.yaml
@@ -1886,19 +1886,6 @@ ingressGateways:
   # and `client.enabled=true`.
   enabled: false
 
-  serviceAccount:
-    # This value defines additional annotations for the ingress gateways' service account. This should be formatted as a
-    # multi-line string.
-    #
-    # ```yaml
-    # annotations: |
-    #   "sample/annotation1": "foo"
-    #   "sample/annotation2": "bar"
-    # ```
-    #
-    # @type: string
-    annotations: null
-
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
   # will override the default values provided here. Annotations will
@@ -1945,6 +1932,19 @@ ingressGateways:
       # Optional YAML string that will be appended to the Service spec.
       # @type: string
       additionalSpec: null
+
+    serviceAccount:
+      # This value defines additional annotations for the ingress gateways' service account. This should be formatted 
+      # as a multi-line string.
+      #
+      # ```yaml
+      # annotations: |
+      #   "sample/annotation1": "foo"
+      #   "sample/annotation2": "bar"
+      # ```
+      #
+      # @type: string
+      annotations: null
 
     # Resource limits for all ingress gateway pods
     # @recurse: false

--- a/values.yaml
+++ b/values.yaml
@@ -713,7 +713,6 @@ client:
   exposeGossipPorts: false
 
   serviceAccount:
-    serviceAccount:
     # This value defines additional annotations for the client service account. This should be formatted as a multi-line
     # string.
     #

--- a/values.yaml
+++ b/values.yaml
@@ -1615,6 +1615,19 @@ controller:
   # Log verbosity level. One of "debug", "info", "warn", or "error".
   logLevel: info
 
+  serviceAccount:
+    # This value defines additional annotations for the client service account. This should be formatted as a multi-line
+    # string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
   # Resource settings for controller pods.
   # @recurse: false
   # @type: map

--- a/values.yaml
+++ b/values.yaml
@@ -372,8 +372,17 @@ server:
   connect: true
 
   serviceAccount:
-    # A map of annotations to add to the server service account 
-    annotations: {}
+    # This value defines additional annotations for the server service account. This should be formatted as a multi-line
+    # string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
 
   # The resource requests (CPU, memory, etc.)
   # for each of the server agents. This should be a YAML map corresponding to a Kubernetes
@@ -704,8 +713,18 @@ client:
   exposeGossipPorts: false
 
   serviceAccount:
-    # A map of annotations to add to the client service account 
-    annotations: {}
+    serviceAccount:
+    # This value defines additional annotations for the client service account. This should be formatted as a multi-line
+    # string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
 
   # Resource settings for Client agents.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
@@ -913,8 +932,17 @@ client:
       secretKey: null
 
     serviceAccount:
-      # A map of annotations to add to the snapshot agent service account 
-      annotations: {}
+      # This value defines additional annotations for the snapshot agent service account. This should be formatted as a 
+      # multi-line string.
+      #
+      # ```yaml
+      # annotations: |
+      #   "sample/annotation1": "foo"
+      #   "sample/annotation2": "bar"
+      # ```
+      #
+      # @type: string
+      annotations: null
 
     # Resource settings for snapshot agent pods.
     # @recurse: false

--- a/values.yaml
+++ b/values.yaml
@@ -1417,8 +1417,8 @@ connectInject:
   logLevel: info
 
   serviceAccount:
-    # This value defines additional annotations for the client service account. This should be formatted as a multi-line
-    # string.
+    # This value defines additional annotations for the injector service account. This should be formatted as a 
+    # multi-line string.
     #
     # ```yaml
     # annotations: |
@@ -1616,8 +1616,8 @@ controller:
   logLevel: info
 
   serviceAccount:
-    # This value defines additional annotations for the client service account. This should be formatted as a multi-line
-    # string.
+    # This value defines additional annotations for the controller service account. This should be formatted as a 
+    # multi-line string.
     #
     # ```yaml
     # annotations: |
@@ -1859,6 +1859,19 @@ ingressGateways:
   # Enable ingress gateway deployment. Requires `connectInject.enabled=true`
   # and `client.enabled=true`.
   enabled: false
+
+  serviceAccount:
+    # This value defines additional annotations for the ingress gateways' service account. This should be formatted as a
+    # multi-line string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
 
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list

--- a/values.yaml
+++ b/values.yaml
@@ -907,6 +907,9 @@ client:
       # The key of the Kubernetes secret.
       secretKey: null
 
+    # A map of annotations to add to the snapshot agent service account
+    serviceAccountAnnotations: {}
+
     # Resource settings for snapshot agent pods.
     # @recurse: false
     # @type: map

--- a/values.yaml
+++ b/values.yaml
@@ -1297,6 +1297,19 @@ syncCatalog:
   # @type: string
   tolerations: null
 
+  serviceAccount:
+    # This value defines additional annotations for the mesh gateways' service account. This should be formatted as a
+    # multi-line string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
   # Resource settings for sync catalog pods.
   # @recurse: false
   # @type: map

--- a/values.yaml
+++ b/values.yaml
@@ -699,6 +699,9 @@ client:
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
 
+  # A map of annotations to add to the client service account
+  serviceAccountAnnotations: {}
+
   # Resource settings for Client agents.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
   # YAML map.

--- a/values.yaml
+++ b/values.yaml
@@ -371,6 +371,9 @@ server:
   # by setting the `server.extraConfig` value.
   connect: true
 
+  # A map of annotations to add to the server service account
+  serviceAccountAnnotations: {}
+
   # The resource requests (CPU, memory, etc.)
   # for each of the server agents. This should be a YAML map corresponding to a Kubernetes
   # ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#resourcerequirements-v1-core)

--- a/values.yaml
+++ b/values.yaml
@@ -2118,6 +2118,19 @@ terminatingGateways:
     # @type: string
     annotations: null
 
+    serviceAccount:
+      # This value defines additional annotations for the terminating gateways' service account. This should be 
+      # formatted as a multi-line string.
+      #
+      # ```yaml
+      # annotations: |
+      #   "sample/annotation1": "foo"
+      #   "sample/annotation2": "bar"
+      # ```
+      #
+      # @type: string
+      annotations: null
+
     # [Enterprise Only] `consulNamespace` defines the Consul namespace to register
     # the gateway into. Requires `global.enableConsulNamespaces` to be true and
     # Consul Enterprise v1.7+ with a valid Consul Enterprise license.


### PR DESCRIPTION
Fixes #235.

Changes proposed in this PR:
This is a redux of #236

- Added values for service account annotations
- These values expect a multi-line YAML string of the annotations map

How I've tested this PR:
- Unit tests and some test renders

How I expect reviewers to test this PR:
- Same

Checklist:
- [x] Bats tests added