### PR TITLE
Enable Openshift for connect injector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 IMPROVEMENTS:
 * Connect: Allow overwriting Kubernetes HTTP probes when running with transparent proxy enabled.
   [[GH-953](https://github.com/hashicorp/consul-helm/pull/953)]
+* Connect: Enable OpenShift for the connect-injector so that we can support running with transparent
+  proxy enabled. [[GH-972](https://github.com/hashicorp/consul-helm/pull/972)]
 
 BUG FIXES:
 * OpenShift: support `server.exposeGossipAndRPCPorts`. [[GH-932](https://github.com/hashicorp/consul-helm/issues/932)]

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -95,6 +95,9 @@ spec:
                 {{- else }}
                 -default-enable-transparent-proxy=false \
                 {{- end }}
+                {{- if .Values.global.openshift.enabled }}
+                -enable-openshift \
+                {{- end }}
                 {{- if .Values.connectInject.transparentProxy.defaultOverwriteProbes }}
                 -transparent-proxy-default-overwrite-probes=true \
                 {{- else }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -1421,3 +1421,29 @@ EOF
 
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# openshift
+
+@test "connectInject/Deployment: openshift is is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-openshift"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: -enable-openshift is set when global.openshift.enabled is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-openshift"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
Companion to hashicorp/consul-k8s#521 and hashicorp/consul-k8s#524
Changes proposed in this PR:
- Pass `-enable-openshift` flag to connect injector when openshift is enabled globally

How I've tested this PR:
Deployed manually on openshift with the image built from hashicorp/consul-k8s#524 (`ishustava/consul-k8s-dev:05-25-2021-0bc1f55`)

First, I need to allow Envoy to run as the specific user and the init contianer to run with elevated privileges:

```
oc adm policy add-scc-to-user anyuid -z default
oc adm policy add-scc-to-user privileged -z default
```
This will allow any pod with the default service account to run as any user and have elevated privileges to run iptables.

Deployed static-server and static-client with:

```
---
apiVersion: v1
kind: Service
metadata:
  name: static-server
spec:
  type: LoadBalancer
  selector:
    app: static-server
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-server
  template:
    metadata:
      name: static-server
      labels:
        app: static-server
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
    spec:
      containers:
        - name: static-server
          image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
          args:
            - -text="hello world"
            - -listen=:8080
          ports:
            - containerPort: 8080
              name: http
      terminationGracePeriodSeconds: 0 # so deletion is quick
```

```
apiVersion: v1
kind: Service
metadata:
  name: static-client
spec:
  selector:
    app: static-client
  ports:
    - port: 80
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-client
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-client
  template:
    metadata:
      name: static-client
      labels:
        app: static-client
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
    spec:
      containers:
        - name: static-client
          image: docker.mirror.hashicorp.services/curlimages/curl:latest
          command: [ "/bin/sh", "-c", "--" ]
          args: [ "while true; do sleep 30; done;" ]
```

```
$ kubectl exec deploy/static-client -- curl -s static-server
Defaulting container name to static-client.
Use 'kubectl describe pod/static-client-dc7497cb4-5dzkl -n consul' to see all of the containers in this pod.
"hello world"
```

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

