### PR TITLE
Bump kube versions in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,9 +299,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-19:
     environment:
@@ -354,9 +354,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-18:
     environment:
@@ -420,9 +420,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -498,9 +498,9 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "Acceptance tests against Kind with Kubernetes v1.21 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.21 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   go-fmt-and-vet-helm-gen:
     executor: go
@@ -630,10 +630,6 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - acceptance-gke-1-17
-      - acceptance-eks-1-18
-      - acceptance-aks-1-19
-      - acceptance-kind-1-21
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.19.4"
+          version: "v1.20.7"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
@@ -208,7 +208,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.19.4"
+          version: "v1.20.7"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
@@ -229,7 +229,7 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
 
-  acceptance-gke-1-16:
+  acceptance-gke-1-17:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -299,11 +299,11 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-1-18:
+  acceptance-aks-1-19:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -354,11 +354,11 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-1-17:
+  acceptance-eks-1-18:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -420,9 +420,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -469,7 +469,7 @@ jobs:
           fail_only: true
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-kind-1-20:
+  acceptance-kind-1-21:
     environment:
       - TEST_RESULTS: /tmp/test-results
     machine:
@@ -479,7 +479,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.20.2"
+          version: "v1.21.1"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
@@ -498,9 +498,9 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-      - slack/status:
-          fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.20 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "Acceptance tests against Kind with Kubernetes v1.21 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   go-fmt-and-vet-helm-gen:
     executor: go
@@ -630,6 +630,10 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
+      - acceptance-gke-1-17
+      - acceptance-eks-1-18
+      - acceptance-aks-1-19
+      - acceptance-kind-1-21
   nightly-acceptance-tests:
     triggers:
       - schedule:
@@ -640,10 +644,10 @@ workflows:
                 - master
     jobs:
       # - acceptance-openshift >> disabled because OpenShift 4.4 was too flaky. Can possibly re-enable when latest OpenShift version is released.
-      - acceptance-gke-1-16
-      - acceptance-eks-1-17
-      - acceptance-aks-1-18
-      - acceptance-kind-1-20
+      - acceptance-gke-1-17
+      - acceptance-eks-1-18
+      - acceptance-aks-1-19
+      - acceptance-kind-1-21
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
           command: |
             go get gotest.tools/gotestsum
 
-            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
             chmod +x ./kind
             sudo mv ./kind /usr/local/bin/kind
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use Consul with Kubernetes, please see the
 
 ## Prerequisites
   * **Helm 3.0+** (Helm 2 is not supported)
-  * **Kubernetes 1.16+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.17+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/test/terraform/aks/main.tf
+++ b/test/terraform/aks/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default[count.index].location
   resource_group_name = azurerm_resource_group.default[count.index].name
   dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.18.14"
+  kubernetes_version  = "1.19.9"
 
   default_node_pool {
     name            = "default"

--- a/test/terraform/eks/main.tf
+++ b/test/terraform/eks/main.tf
@@ -54,7 +54,7 @@ module "eks" {
   version = "12.2.0"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.17"
+  cluster_version = "1.18"
   subnets         = module.vpc[count.index].private_subnets
 
   vpc_id = module.vpc[count.index].vpc_id

--- a/test/terraform/gke/main.tf
+++ b/test/terraform/gke/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.16."
+  version_prefix = "1.17."
 }
 
 resource "google_container_cluster" "cluster" {


### PR DESCRIPTION
Changes proposed in this PR:
- GKE no longer supports 1.16 and so we're moving all acceptance tests up by one version.

How I've tested this PR:
[acceptance tests](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3050/workflows/7895c053-530b-4b47-b532-8a4c8bb89d98)

How I expect reviewers to test this PR:
- code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

