### PR TITLE
Support adding enterprise license as an ENV VAR and not a secret

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,17 +190,9 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -230,17 +222,9 @@ jobs:
           paths:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc1
-            kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}" --context=kind-dc2
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -286,14 +270,6 @@ jobs:
             echo "export primary_kubeconfig=$primary_kubeconfig" >> $BASH_ENV
             echo "export secondary_kubeconfig=$secondary_kubeconfig" >> $BASH_ENV
 
-      - run:
-          name: Create enterprise license secret
-          command: |
-            # Create an enterprise license secret in the primary cluster.
-            # This license is set as a CircleCI project env variable.
-            # The license expires 15-Oct-2025.
-            KUBECONFIG=$primary_kubeconfig kubectl create secret generic ent-license --from-literal=key="${CONSUL_ENT_LICENSE}"
-
       # Restore go module cache if there is one
       - restore_cache:
           keys:
@@ -302,7 +278,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enterprise-license-secret-name=ent-license -enterprise-license-secret-key=key -enable-transparent-proxy
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
 
       - store_test_results:
           path: /tmp/test-results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Below is the list of available flags:
 -debug-directory
     The directory where to write debug information about failed test runs, such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.
 -enable-enterprise
-    If true, the test suite will run tests for enterprise features. Note that some features may require setting the enterprise license flags below.
+    If true, the test suite will run tests for enterprise features. Note that some features may require setting the enterprise license flag below or the env var CONSUL_ENT_LICENSE.
 -enable-multi-cluster
     If true, the tests that require multiple Kubernetes clusters will be run. At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.
 -enable-openshift
@@ -99,10 +99,8 @@ Below is the list of available flags:
 -enable-transparent-proxy
     If true, the test suite will run tests with transparent proxy enabled.
     This applies only to tests that enable connectInject.
--enterprise-license-secret-name
-    The name of the Kubernetes secret containing the enterprise license.
--enterprise-license-secret-key
-    The key of the Kubernetes secret containing the enterprise license.
+-enterprise-license
+    The enterprise license for Consul.
 -kubeconfig string
     The path to a kubeconfig file. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
 -kubecontext string

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -13,7 +13,11 @@ import (
 
 // HelmChartPath is the path to the helm chart.
 // Note: this will need to be changed if this file is moved.
-const HelmChartPath = "../../../.."
+const (
+	HelmChartPath     = "../../../.."
+	LicenseSecretName = "license"
+	LicenseSecretKey  = "key"
+)
 
 // TestConfig holds configuration for the test suite.
 type TestConfig struct {
@@ -26,9 +30,8 @@ type TestConfig struct {
 	SecondaryKubeContext   string
 	SecondaryKubeNamespace string
 
-	EnableEnterprise            bool
-	EnterpriseLicenseSecretName string
-	EnterpriseLicenseSecretKey  string
+	EnableEnterprise  bool
+	EnterpriseLicense string
 
 	EnableOpenshift bool
 
@@ -62,9 +65,9 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 		setIfNotEmpty(helmValues, "global.image", entImage)
 	}
 
-	if t.EnterpriseLicenseSecretName != "" && t.EnterpriseLicenseSecretKey != "" {
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretName", t.EnterpriseLicenseSecretName)
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretKey", t.EnterpriseLicenseSecretKey)
+	if t.EnterpriseLicense != "" {
+		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretName", LicenseSecretName)
+		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretKey", LicenseSecretKey)
 	}
 
 	if t.EnableOpenshift {

--- a/test/acceptance/framework/config/config_test.go
+++ b/test/acceptance/framework/config/config_test.go
@@ -58,28 +58,18 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 		{
 			"sets ent license secret",
 			TestConfig{
-				EnterpriseLicenseSecretName: "ent-license",
-				EnterpriseLicenseSecretKey:  "key",
+				EnterpriseLicense: "ent-license",
 			},
 			map[string]string{
-				"server.enterpriseLicense.secretName":           "ent-license",
+				"server.enterpriseLicense.secretName":           "license",
 				"server.enterpriseLicense.secretKey":            "key",
 				"connectInject.transparentProxy.defaultEnabled": "false",
 			},
 		},
 		{
-			"doesn't set ent license secret when only secret name is set",
+			"doesn't set ent license if license is empty",
 			TestConfig{
-				EnterpriseLicenseSecretName: "ent-license",
-			},
-			map[string]string{
-				"connectInject.transparentProxy.defaultEnabled": "false",
-			},
-		},
-		{
-			"doesn't set ent license secret when only secret key is set",
-			TestConfig{
-				EnterpriseLicenseSecretKey: "key",
+				EnterpriseLicense: "",
 			},
 			map[string]string{
 				"connectInject.transparentProxy.defaultEnabled": "false",

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"errors"
 	"flag"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/consul-helm/test/acceptance/framework/config"
@@ -18,9 +19,8 @@ type TestFlags struct {
 	flagSecondaryKubecontext string
 	flagSecondaryNamespace   string
 
-	flagEnableEnterprise            bool
-	flagEnterpriseLicenseSecretName string
-	flagEnterpriseLicenseSecretKey  string
+	flagEnableEnterprise  bool
+	flagEnterpriseLicense string
 
 	flagEnableOpenshift bool
 
@@ -69,10 +69,6 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagEnableEnterprise, "enable-enterprise", false,
 		"If true, the test suite will run tests for enterprise features. "+
 			"Note that some features may require setting the enterprise license flags below.")
-	flag.StringVar(&t.flagEnterpriseLicenseSecretName, "enterprise-license-secret-name", "",
-		"The name of the Kubernetes secret containing the enterprise license.")
-	flag.StringVar(&t.flagEnterpriseLicenseSecretKey, "enterprise-license-secret-key", "",
-		"The key of the Kubernetes secret containing the enterprise license.")
 
 	flag.BoolVar(&t.flagEnableOpenshift, "enable-openshift", false,
 		"If true, the tests will automatically add Openshift Helm value for each Helm install.")
@@ -93,6 +89,8 @@ func (t *TestFlags) init() {
 
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
+
+	t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
 }
 
 func (t *TestFlags) Validate() error {
@@ -102,12 +100,9 @@ func (t *TestFlags) Validate() error {
 		}
 	}
 
-	onlyEntSecretNameSet := t.flagEnterpriseLicenseSecretName != "" && t.flagEnterpriseLicenseSecretKey == ""
-	onlyEntSecretKeySet := t.flagEnterpriseLicenseSecretName == "" && t.flagEnterpriseLicenseSecretKey != ""
-	if onlyEntSecretNameSet || onlyEntSecretKeySet {
-		return errors.New("both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one")
+	if t.flagEnableEnterprise && t.flagEnterpriseLicense == "" {
+		return errors.New("-enable-enterprise provided without setting env var CONSUL_ENT_LICENSE with consul license")
 	}
-
 	return nil
 }
 
@@ -124,9 +119,8 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		SecondaryKubeContext:   t.flagSecondaryKubecontext,
 		SecondaryKubeNamespace: t.flagSecondaryNamespace,
 
-		EnableEnterprise:            t.flagEnableEnterprise,
-		EnterpriseLicenseSecretName: t.flagEnterpriseLicenseSecretName,
-		EnterpriseLicenseSecretKey:  t.flagEnterpriseLicenseSecretKey,
+		EnableEnterprise:  t.flagEnableEnterprise,
+		EnterpriseLicense: t.flagEnterpriseLicense,
 
 		EnableOpenshift: t.flagEnableOpenshift,
 

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -68,7 +68,9 @@ func (t *TestFlags) init() {
 
 	flag.BoolVar(&t.flagEnableEnterprise, "enable-enterprise", false,
 		"If true, the test suite will run tests for enterprise features. "+
-			"Note that some features may require setting the enterprise license flags below.")
+			"Note that some features may require setting the enterprise license flag below or the env var CONSUL_ENT_LICENSE")
+	flag.StringVar(&t.flagEnterpriseLicense, "enterprise-license", "",
+		"The enterprise license for Consul.")
 
 	flag.BoolVar(&t.flagEnableOpenshift, "enable-openshift", false,
 		"If true, the tests will automatically add Openshift Helm value for each Helm install.")
@@ -90,7 +92,9 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
 
-	t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
+	if t.flagEnterpriseLicense == "" {
+		t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
+	}
 }
 
 func (t *TestFlags) Validate() error {

--- a/test/acceptance/framework/flags/flags_test.go
+++ b/test/acceptance/framework/flags/flags_test.go
@@ -11,8 +11,9 @@ func TestFlags_validate(t *testing.T) {
 		flagEnableMultiCluster   bool
 		flagSecondaryKubeconfig  string
 		flagSecondaryKubecontext string
-		flagEntLicenseSecretName string
-		flagEntLicenseSecretKey  string
+
+		flagEnableEnt  bool
+		flagEntLicense string
 	}
 	tests := []struct {
 		name       string
@@ -81,26 +82,18 @@ func TestFlags_validate(t *testing.T) {
 			"",
 		},
 		{
-			"enterprise license: error when only -enterprise-license-secret-name is provided",
+			"enterprise license: error when only -enable-enterprise is true but env CONSUL_ENT_LICENSE is not provided",
 			fields{
-				flagEntLicenseSecretName: "secret",
+				flagEnableEnt: true,
 			},
 			true,
-			"both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one",
+			"-enable-enterprise provided without setting env var CONSUL_ENT_LICENSE with consul license",
 		},
 		{
-			"enterprise license: error when only -enterprise-license-secret-key is provided",
+			"enterprise license: no error when both -enable-enterprise and env CONSUL_ENT_LICENSE are provided",
 			fields{
-				flagEntLicenseSecretKey: "key",
-			},
-			true,
-			"both of -enterprise-license-secret-name and -enterprise-license-secret-name flags must be provided; not just one",
-		},
-		{
-			"enterprise license: no error when both -enterprise-license-secret-name and -enterprise-license-secret-key are provided",
-			fields{
-				flagEntLicenseSecretName: "secret",
-				flagEntLicenseSecretKey:  "key",
+				flagEnableEnt:  true,
+				flagEntLicense: "license",
 			},
 			false,
 			"",
@@ -109,11 +102,11 @@ func TestFlags_validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tf := &TestFlags{
-				flagEnableMultiCluster:          tt.fields.flagEnableMultiCluster,
-				flagSecondaryKubeconfig:         tt.fields.flagSecondaryKubeconfig,
-				flagSecondaryKubecontext:        tt.fields.flagSecondaryKubecontext,
-				flagEnterpriseLicenseSecretName: tt.fields.flagEntLicenseSecretName,
-				flagEnterpriseLicenseSecretKey:  tt.fields.flagEntLicenseSecretKey,
+				flagEnableMultiCluster:   tt.fields.flagEnableMultiCluster,
+				flagSecondaryKubeconfig:  tt.fields.flagSecondaryKubeconfig,
+				flagSecondaryKubecontext: tt.fields.flagSecondaryKubecontext,
+				flagEnableEnterprise:     tt.fields.flagEnableEnt,
+				flagEnterpriseLicense:    tt.fields.flagEntLicense,
 			}
 			err := tf.Validate()
 			if tt.wantErr {


### PR DESCRIPTION
Changes proposed in this PR:
- Use the environment variable for the Consul License to create a license secret which the helm chart will autoload.
- This creates a kubernetes secret in each cluster where a helm install is performed. It also deprecates the flags for license-secret-name and license-secret-key for the acceptance tests.
- The tests now rely on the existence of the the env var CONSUL_ENT_LICENSE and if present, creates a secret with the value of the env var, and then updates the helm config with the secret name and secret key.

How I've tested this PR:
Ran acceptance tests against CI

How I expect reviewers to test this PR:
Code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

