### PR TITLE
Allow user to explicitely set advertise address for Consul server

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -121,6 +121,9 @@ spec:
           image: "{{ default .Values.global.image .Values.server.image }}"
           env:
             - name: ADVERTISE_IP
+              {{- if .Values.server.advertiseAddr }}
+              value: {{ .Values.server.advertiseAddr }}
+              {{- else }}
               valueFrom:
                 fieldRef:
                   {{- if .Values.server.exposeGossipAndRPCPorts }}
@@ -132,6 +135,7 @@ spec:
                   {{- else }}
                   fieldPath: status.podIP
                   {{- end }}
+              {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -232,6 +232,21 @@ load _helpers
   [ "${actual}" = '[{"name":"ADVERTISE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}]' ]
 
 }
+#--------------------------------------------------------------------
+# advertiseAddr
+
+@test "server/StatefulSet: advertiseAddr can be explicitely set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.advertiseAddr=1.2.3.4' \
+      . | tee /dev/stderr )
+
+  # Test that ADVERTISE_IP is being set to advertiseAddr
+  local actual=$(echo "$object" |
+    yq -r -c '.spec.template.spec.containers[0].env | map(select(.name == "ADVERTISE_IP"))' | tee /dev/stderr)
+  [ "${actual}" = '[{"name": "ADVERTISE_IP", "value": "1.2.3.4"}]' ]
+}
 
 #--------------------------------------------------------------------
 # serflan

--- a/values.yaml
+++ b/values.yaml
@@ -332,6 +332,7 @@ server:
   # set `server.ports.serflan.port` to a port not being used on the host. Since
   # `client.exposeGossipPorts` uses the hostPort 8301,
   # `server.ports.serflan.port` must be set to something other than 8301.
+  # Has no effect when then `server.advertiseAddr` is set.
   exposeGossipAndRPCPorts: false
 
   # Configures ports for the consul servers.
@@ -347,6 +348,12 @@ server:
     # the consul server Pods.
     serflan:
       port: 8301
+
+  # The address the consul server(s) will advertise to other agents.
+  # If unset, the advertise address will default to the Pod IP
+  # (see `server.exposeGossipAndRPCPorts`).
+  # @type: string
+  advertiseAddr: null
 
   # This defines the disk size for configuring the
   # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the


### PR DESCRIPTION
*Problem description*
By default, the Helm chart only allows choosing between the PodIP
and HostIP for the advertise address that is passed to Consul.
In certain configuration it is necessary to specify a different IP
(NAT, VMs etc.). Since the environment key "ADVERTISE_IP" is already
set by the Helm chart, the user can no longer simply overwrite this.
(Kubernetes will complain that `valueRef` cannot be used when `value` is
specified)

*Changes proposed in this PR:*
Thus, this patch introduces an explicit option for this configuration
setting.

*How I've tested this PR:*
I locally deployed the Helm chart with these changes. I also added a testcase for it.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

