### PR TITLE
Update type of connectTimeout and TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+BUG FIXES:
+* CRDs: Update the type of connectTimeout and TTL in ServiceResolver and ServiceRouter from int64 to string.
+  This allows a user to set these values as a duration string on the resource ex '5s'.
+
 ## 0.32.0-beta3 (May 27, 2021)
 KNOWN ISSUES:
 * This beta release does not work when Pod Security Policies are enabled. This will be fixed in the upcoming release.

--- a/templates/crd-serviceresolvers.yaml
+++ b/templates/crd-serviceresolvers.yaml
@@ -53,8 +53,7 @@ spec:
             properties:
               connectTimeout:
                 description: ConnectTimeout is the timeout for establishing new network connections to this service.
-                format: int64
-                type: integer
+                type: string
               defaultSubset:
                 description: DefaultSubset is the subset to use when no explicit subset is requested. If empty the unnamed subset is used.
                 type: string
@@ -96,8 +95,7 @@ spec:
                               type: boolean
                             ttl:
                               description: TTL is the ttl for generated cookies. Cannot be specified for session cookies.
-                              format: int64
-                              type: integer
+                              type: string
                           type: object
                         field:
                           description: Field is the attribute type to hash on. Must be one of "header", "cookie", or "query_parameter". Cannot be specified along with sourceIP.

--- a/templates/crd-servicerouters.yaml
+++ b/templates/crd-servicerouters.yaml
@@ -70,8 +70,7 @@ spec:
                           type: string
                         requestTimeout:
                           description: RequestTimeout is the total amount of time permitted for the entire downstream request (and retries) to be processed.
-                          format: int64
-                          type: integer
+                          type: string
                         retryOnConnectFailure:
                           description: RetryOnConnectFailure allows for connection failure errors to trigger a retry.
                           type: boolean


### PR DESCRIPTION
Update duration types from int64 to string to allow users to set the duration as `5s` for example.

How I've tested this PR: Created a resource with the following fields
```
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceResolver
metadata:
  name: resolver
spec:
  redirect:
    service: bar
  connectTimeout: 5s
  loadBalancer:
    policy: policy
    hashPolicies:
    - cookieConfig:
        ttl: 3s
```
It gets applied successfully. The config does not sync with consul but that is because the loadBalancer config here has some error with the hashPolicy but the type are correct.

How I expect reviewers to test this PR: Reference https://github.com/hashicorp/consul-k8s/pull/529 and check changelog.


Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

