### PR TITLE
Add federation flag to server-acl-init-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+        default: "kschoche/consul-k8s-dev-fed"
     steps:
       - when:
           condition: << parameters.failfast >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "kschoche/consul-k8s-dev-fed"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
     steps:
       - when:
           condition: << parameters.failfast >>

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -199,6 +199,10 @@ spec:
                 -create-acl-replication-token=true \
                 {{- end }}
 
+                {{- if .Values.global.federation.enabled }}
+                -federation=true \
+                {{- end }}
+
                 {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
                 -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
                 {{- else if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1431,3 +1431,19 @@ load _helpers
       yq '.spec.template.spec.containers[0].command | any(contains("create-controller-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.federation.enabled
+@test "serverACLInit/Job: ensure federation is passed when federation is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.federation.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-federation"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1434,6 +1434,7 @@ load _helpers
 
 #--------------------------------------------------------------------
 # global.federation.enabled
+
 @test "serverACLInit/Job: ensure federation is passed when federation is enabled" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
Changes proposed in this PR:
- Add a new flag `-federation` to server-acl-init-job so so that we know there are multiple datacenters being federated even when there is no acl replication being configured, such as with HCP.

How I've tested this PR:
Acceptance tests pass
Unit tests

How I expect reviewers to test this PR:
Code review, possibly HCS pointing at a consul-k8s build from (https://github.com/hashicorp/consul-k8s/pull/531)

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

