### PR TITLE
Add support for recursor flag

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -257,6 +257,9 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+                {{- range $value := .Values.global.recursors }}
+                -recursor={{ quote $value }} \
+                {{- end }}
                 -domain={{ .Values.global.domain }}
           volumeMounts:
             - name: data

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -233,6 +233,9 @@ spec:
                 -retry-join="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:{{ $serverSerfLANPort }}" \
                 {{- end }}
                 -serf-lan-port={{ .Values.server.ports.serflan.port }} \
+                {{- range $value := .Values.global.recursors }}
+                -recursor={{ quote $value }} \
+                {{- end }}
                 -server
           volumeMounts:
             - name: data-{{ .Release.Namespace }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -1282,7 +1282,7 @@ rollingUpdate:
 #--------------------------------------------------------------------
 # recursors
 
-@test "server/DaemonSet: -recursor can be set by global.recursors" {
+@test "client/DaemonSet: -recursor can be set by global.recursors" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/client-daemonset.yaml  \

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -1278,3 +1278,16 @@ rollingUpdate:
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = "" ]
 }
+
+#--------------------------------------------------------------------
+# recursors
+
+@test "server/DaemonSet: -recursor can be set by global.recursors" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.recursors[0]=1.2.3.4' \
+      . | tee /dev/stderr |
+      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("-recursor=\"1.2.3.4\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1246,3 +1246,14 @@ load _helpers
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
 }
+
+
+@test "server/StatefulSet: -recursor can be set by global.recursors" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.recursors[0]=1.2.3.4' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].command | join(" ") | contains("-recursor=\"1.2.3.4\"")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -91,6 +91,13 @@ global:
     # encryption key.
     secretKey: ""
 
+  # A list of addresses of upstream DNS servers that are used to recursively resolve queries.
+  # These values are given as `-recursor` flag to consul server and client
+  # See (https://www.consul.io/docs/agent/options#_recursor).
+  # If this is `null` (default), then the clients can only resolve queries inside of consul domain.
+  # @type: array<string>
+  recursors: null
+
   # Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.
   # Requires Consul v1.4.1+ and consul-k8s v0.16.2+
@@ -127,13 +134,6 @@ global:
     # If true, the Helm chart will configure Consul to disable the HTTP port on
     # both clients and servers and to only accept HTTPS connections.
     httpsOnly: true
-
-    # A list of addresses of upstream DNS servers that are used to recursively resolve queries.
-    # These values are given as `-recursor` flag to consul server and client
-    # See (https://www.consul.io/docs/agent/options#_recursor).
-    # If this is `null` (default), then the clients can only resolve queries inside of consul domain.
-    # @type: array<string>
-    recursors: null
 
     # A Kubernetes secret containing the certificate of the CA to use for
     # TLS communication within the Consul cluster. If you have generated the CA yourself

--- a/values.yaml
+++ b/values.yaml
@@ -96,7 +96,7 @@ global:
   # See (https://www.consul.io/docs/agent/options#_recursor).
   # If this is `null` (default), then the clients can only resolve queries inside of consul domain.
   # @type: array<string>
-  recursors: null
+  recursors: []
 
   # Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.

--- a/values.yaml
+++ b/values.yaml
@@ -128,6 +128,13 @@ global:
     # both clients and servers and to only accept HTTPS connections.
     httpsOnly: true
 
+    # A list of addresses of upstream DNS servers that are used to recursively resolve queries.
+    # These values are given as `-recursor` flag to consul server and client
+    # See (https://www.consul.io/docs/agent/options#_recursor).
+    # If this is `null` (default), then the clients can only resolve queries inside of consul domain.
+    # @type: array<string>
+    recursors: null
+
     # A Kubernetes secret containing the certificate of the CA to use for
     # TLS communication within the Consul cluster. If you have generated the CA yourself
     # with the consul CLI, you could use the following command to create the secret
@@ -933,7 +940,7 @@ client:
       secretKey: null
 
     serviceAccount:
-      # This value defines additional annotations for the snapshot agent service account. This should be formatted as a 
+      # This value defines additional annotations for the snapshot agent service account. This should be formatted as a
       # multi-line string.
       #
       # ```yaml
@@ -1432,7 +1439,7 @@ connectInject:
   logLevel: info
 
   serviceAccount:
-    # This value defines additional annotations for the injector service account. This should be formatted as a 
+    # This value defines additional annotations for the injector service account. This should be formatted as a
     # multi-line string.
     #
     # ```yaml
@@ -1631,7 +1638,7 @@ controller:
   logLevel: info
 
   serviceAccount:
-    # This value defines additional annotations for the controller service account. This should be formatted as a 
+    # This value defines additional annotations for the controller service account. This should be formatted as a
     # multi-line string.
     #
     # ```yaml
@@ -1936,7 +1943,7 @@ ingressGateways:
       additionalSpec: null
 
     serviceAccount:
-      # This value defines additional annotations for the ingress gateways' service account. This should be formatted 
+      # This value defines additional annotations for the ingress gateways' service account. This should be formatted
       # as a multi-line string.
       #
       # ```yaml
@@ -2121,7 +2128,7 @@ terminatingGateways:
     annotations: null
 
     serviceAccount:
-      # This value defines additional annotations for the terminating gateways' service account. This should be 
+      # This value defines additional annotations for the terminating gateways' service account. This should be
       # formatted as a multi-line string.
       #
       # ```yaml

--- a/values.yaml
+++ b/values.yaml
@@ -91,10 +91,10 @@ global:
     # encryption key.
     secretKey: ""
 
-  # A list of addresses of upstream DNS servers that are used to recursively resolve queries.
-  # These values are given as `-recursor` flag to consul server and client
-  # See (https://www.consul.io/docs/agent/options#_recursor).
-  # If this is `null` (default), then the clients can only resolve queries inside of consul domain.
+  # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
+  # These values are given as `-recursor` flags to Consul servers and clients.
+  # See https://www.consul.io/docs/agent/options#_recursor for more details.
+  # If this is an empty array (the default), then Consul DNS will only resolve queries for the Consul top level domain (by default `.consul`).
   # @type: array<string>
   recursors: []
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/consul-helm/issues/984

Changes proposed in this PR:
- Add support for `-recursor` flag (https://www.consul.io/docs/agent/options#_recursor)

How I've tested this PR: Yes, provided in next section.

How I expect reviewers to test this PR:

1. Default value should not change any manifests. i.e.

```
global:
    recursors: null
```
 
 2. Setting a list of IP addresses, will provide the flag to server and clients, and user should be able to resolve queries recursively.
 
 ```
 global:
    recursors:
    - 8.8.8.8
    - 1.1.1.1
 ```
 
Looking up a domain outside of consul domain in agents, and servers should return IP address:
```
$ kubectl exec consul-74tmn --  nslookup google.com localhost:8600
Server:         localhost:8600
Address:        [::1]:8600

Name:   google.com
Address: 142.251.37.14

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:400e:808::200e
```

```
$ kubectl exec consul-server-0 -- nslookup google.com localhost:8600
Server:         localhost:8600
Address:        [::1]:8600

Name:   google.com
Address: 142.251.37.14

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:400e:808::200e
```

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

