### PR TITLE
Provide deployment info to webhook cert manager pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * Allow setting annotations on service accounts for: server, client, client
   snapshot agent, connect inject, controller, ingressGateways, meshGateway,
   syncCatalog, and terminatingGateways. [[GH-964](https://github.com/hashicorp/consul-helm/pull/964)]
+* Delete secrets created by webhook-cert-manager when the deployment is deleted. [[GH-987](https://github.com/hashicorp/consul-helm/pull/987)]
 
 BUG FIXES:
 * CRDs: Update the type of connectTimeout and TTL in ServiceResolver and ServiceRouter from int64 to string.

--- a/templates/webhook-cert-manager-clusterrole.yaml
+++ b/templates/webhook-cert-manager-clusterrole.yaml
@@ -31,6 +31,14 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - {{ template "consul.fullname" . }}-webhook-cert-manager
+  verbs:
+  - get
 {{- if .Values.global.enablePodSecurityPolicies }}
 - apiGroups:
   - policy

--- a/templates/webhook-cert-manager-deployment.yaml
+++ b/templates/webhook-cert-manager-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -36,7 +37,9 @@ spec:
         - "-ec"
         - |
           consul-k8s webhook-cert-manager \
-            -config-file=/bootstrap/config/webhook-config.json
+            -config-file=/bootstrap/config/webhook-config.json \
+            -deployment-name={{ template "consul.fullname" . }}-webhook-cert-manager \
+            -deployment-namespace={{ .Release.Namespace }}
         image: {{ .Values.global.imageK8S }}
         name: webhook-cert-manager
         resources:

--- a/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/test/unit/webhook-cert-manager-clusterrole.bats
@@ -50,6 +50,6 @@ load _helpers
       --set 'controller.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
-      yq -r '.rules[2].resources[0]' | tee /dev/stderr)
+      yq -r '.rules[3].resources[0]' | tee /dev/stderr)
   [ "${actual}" = "podsecuritypolicies" ]
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Pass `-deployment-name` and `-deployment-namespace` to webhook cert manager. This allows the cert-manager to set the deployment as the owner of the secrets it creates.

How I've tested this PR: Manually with a helm install and uninstall. The secrets get deleted post install. Additionally, performing a helm upgrade on a previous helm install adds an OwnerReference to the secret which should allow people upgrade to this version of the chart to have their secrets owned by the deployment.

How I expect reviewers to test this PR: Repeat above steps.


Checklist:
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

