### PR TITLE
Run mesh gateway tests without disabling transparent proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,6 +634,11 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
+      - acceptance-openshift
+      - acceptance-gke-1-17
+      - acceptance-eks-1-18
+      - acceptance-aks-1-19
+      - acceptance-kind-1-21
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ commands:
                         -enable-enterprise \
                         -enable-multi-cluster \
                         -debug-directory="$TEST_RESULTS/debug" \
-                        -consul-k8s-image=<< parameters.consul-k8s-image >>
+                        -consul-k8s-image=<< parameters.consul-k8s-image >> \
+                        -consul-image="gcr.io/nitya-293720/consul-dev:ent-fix"
                   then
                     echo "Tests in ${pkg} failed, aborting early"
                     exit_code=1
@@ -82,22 +83,6 @@ commands:
                 gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
                 exit $exit_code
 
-      - unless:
-          condition: << parameters.failfast >>
-          steps:
-            - run:
-                name: Run acceptance tests
-                working_directory: test/acceptance/tests
-                no_output_timeout: 2h
-                command: |
-                  pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-                  echo "Running $pkgs"
-                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h \
-                      << parameters.additional-flags >> \
-                      -enable-multi-cluster \
-                      -enable-enterprise \
-                      -debug-directory="$TEST_RESULTS/debug" \
-                      -consul-k8s-image=<< parameters.consul-k8s-image >>
 jobs:
   unit-helm:
     docker:
@@ -195,7 +180,6 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          failfast: false
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
@@ -227,7 +211,6 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          failfast: false
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results
@@ -634,11 +617,11 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - acceptance-openshift
-      - acceptance-gke-1-17
-      - acceptance-eks-1-18
-      - acceptance-aks-1-19
-      - acceptance-kind-1-21
+#      - acceptance-openshift
+#      - acceptance-gke-1-17
+#      - acceptance-eks-1-18
+#      - acceptance-aks-1-19
+#      - acceptance-kind-1-21
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
                 echo $pkgs
                 for pkg in $pkgs
                 do
-                  if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
+                  if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h \
                         << parameters.additional-flags >> \
                         -enable-enterprise \
                         -enable-multi-cluster \
@@ -92,7 +92,7 @@ commands:
                 command: |
                   pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
                   echo "Running $pkgs"
-                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
+                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h \
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
                       -enable-enterprise \
@@ -195,7 +195,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          failfast: true
+          failfast: false
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
@@ -227,7 +227,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          failfast: true
+          failfast: false
           additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,23 @@ commands:
                 gotestsum --raw-command --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- cat jsonfile*
                 exit $exit_code
 
+      - unless:
+          condition: << parameters.failfast >>
+          steps:
+            - run:
+                name: Run acceptance tests
+                working_directory: test/acceptance/tests
+                no_output_timeout: 2h
+                command: |
+                  pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+                  echo "Running $pkgs"
+                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h \
+                      << parameters.additional-flags >> \
+                      -enable-multi-cluster \
+                      -enable-enterprise \
+                      -debug-directory="$TEST_RESULTS/debug" \
+                      -consul-k8s-image=<< parameters.consul-k8s-image >> \
+                      -consul-image="gcr.io/nitya-293720/consul-dev:ent-fix"
 jobs:
   unit-helm:
     docker:

--- a/templates/crd-ingressgateways.yaml
+++ b/templates/crd-ingressgateways.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: ingressgateways.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: IngressGateway is the Schema for the ingressgateways API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,31 +56,58 @@ spec:
             description: IngressGatewaySpec defines the desired state of IngressGateway
             properties:
               listeners:
-                description: Listeners declares what ports the ingress gateway should listen on, and what services to associated to those ports.
+                description: Listeners declares what ports the ingress gateway should
+                  listen on, and what services to associated to those ports.
                 items:
-                  description: IngressListener manages the configuration for a listener on a specific port.
+                  description: IngressListener manages the configuration for a listener
+                    on a specific port.
                   properties:
                     port:
-                      description: Port declares the port on which the ingress gateway should listen for traffic.
+                      description: Port declares the port on which the ingress gateway
+                        should listen for traffic.
                       type: integer
                     protocol:
-                      description: 'Protocol declares what type of traffic this listener is expected to receive. Depending on the protocol, a listener might support multiplexing services over a single port, or additional discovery chain features. The current supported values are: (tcp | http | http2 | grpc).'
+                      description: 'Protocol declares what type of traffic this listener
+                        is expected to receive. Depending on the protocol, a listener
+                        might support multiplexing services over a single port, or
+                        additional discovery chain features. The current supported
+                        values are: (tcp | http | http2 | grpc).'
                       type: string
                     services:
-                      description: "Services declares the set of services to which the listener forwards traffic. \n For \"tcp\" protocol listeners, only a single service is allowed. For \"http\" listeners, multiple services can be declared."
+                      description: "Services declares the set of services to which
+                        the listener forwards traffic. \n For \"tcp\" protocol listeners,
+                        only a single service is allowed. For \"http\" listeners,
+                        multiple services can be declared."
                       items:
-                        description: IngressService manages configuration for services that are exposed to ingress traffic.
+                        description: IngressService manages configuration for services
+                          that are exposed to ingress traffic.
                         properties:
                           hosts:
-                            description: "Hosts is a list of hostnames which should be associated to this service on the defined listener. Only allowed on layer 7 protocols, this will be used to route traffic to the service by matching the Host header of the HTTP request. \n If a host is provided for a service that also has a wildcard specifier defined, the host will override the wildcard-specifier-provided \"<service-name>.*\" domain for that listener. \n This cannot be specified when using the wildcard specifier, \"*\", or when using a \"tcp\" listener."
+                            description: "Hosts is a list of hostnames which should
+                              be associated to this service on the defined listener.
+                              Only allowed on layer 7 protocols, this will be used
+                              to route traffic to the service by matching the Host
+                              header of the HTTP request. \n If a host is provided
+                              for a service that also has a wildcard specifier defined,
+                              the host will override the wildcard-specifier-provided
+                              \"<service-name>.*\" domain for that listener. \n This
+                              cannot be specified when using the wildcard specifier,
+                              \"*\", or when using a \"tcp\" listener."
                             items:
                               type: string
                             type: array
                           name:
-                            description: "Name declares the service to which traffic should be forwarded. \n This can either be a specific service, or the wildcard specifier, \"*\". If the wildcard specifier is provided, the listener must be of \"http\" protocol and means that the listener will forward traffic to all services. \n A name can be specified on multiple listeners, and will be exposed on both of the listeners."
+                            description: "Name declares the service to which traffic
+                              should be forwarded. \n This can either be a specific
+                              service, or the wildcard specifier, \"*\". If the wildcard
+                              specifier is provided, the listener must be of \"http\"
+                              protocol and means that the listener will forward traffic
+                              to all services. \n A name can be specified on multiple
+                              listeners, and will be exposed on both of the listeners."
                             type: string
                           namespace:
-                            description: Namespace is the namespace where the service is located. Namespacing is a Consul Enterprise feature.
+                            description: Namespace is the namespace where the service
+                              is located. Namespacing is a Consul Enterprise feature.
                             type: string
                         type: object
                       type: array
@@ -86,7 +117,8 @@ spec:
                 description: TLS holds the TLS configuration for this gateway.
                 properties:
                   enabled:
-                    description: Indicates that TLS should be enabled for this gateway service.
+                    description: Indicates that TLS should be enabled for this gateway
+                      service.
                     type: boolean
                 required:
                 - enabled
@@ -95,16 +127,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -121,7 +157,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-meshes.yaml
+++ b/templates/crd-meshes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: meshes.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: Mesh is the Schema for the mesh API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,26 +56,35 @@ spec:
             description: MeshSpec defines the desired state of Mesh
             properties:
               transparentProxy:
-                description: TransparentProxyMeshConfig controls configuration specific to proxies in "transparent" mode. Added in v1.10.0.
+                description: TransparentProxyMeshConfig controls configuration specific
+                  to proxies in "transparent" mode. Added in v1.10.0.
                 properties:
-                  catalogDestinationsOnly:
-                    description: CatalogDestinationsOnly determines whether sidecar proxies operating in "transparent" mode can proxy traffic to IP addresses not registered in Consul's catalog. If enabled, traffic will only be proxied to upstreams with service registrations in the catalog.
+                  meshDestinationsOnly:
+                    description: MeshDestinationsOnly determines whether sidecar proxies
+                      operating in "transparent" mode can proxy traffic to IP addresses
+                      not registered in Consul's catalog. If enabled, traffic will
+                      only be proxied to upstreams with service registrations in the
+                      catalog.
                     type: boolean
                 type: object
             type: object
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -88,7 +101,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-proxydefaults.yaml
+++ b/templates/crd-proxydefaults.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: proxydefaults.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ProxyDefaults is the Schema for the proxydefaults API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,65 +56,99 @@ spec:
             description: ProxyDefaultsSpec defines the desired state of ProxyDefaults
             properties:
               config:
-                description: Config is an arbitrary map of configuration values used by Connect proxies. Any values that your proxy allows can be configured globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
+                description: Config is an arbitrary map of configuration values used
+                  by Connect proxies. Any values that your proxy allows can be configured
+                  globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               expose:
-                description: Expose controls the default expose path configuration for Envoy.
+                description: Expose controls the default expose path configuration
+                  for Envoy.
                 properties:
                   checks:
-                    description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
+                    description: Checks defines whether paths associated with Consul
+                      checks will be exposed. This flag triggers exposing all HTTP
+                      and GRPC check paths registered for the service.
                     type: boolean
                   paths:
                     description: Paths is the list of paths exposed through the proxy.
                     items:
                       properties:
                         listenerPort:
-                          description: ListenerPort defines the port of the proxy's listener for exposed paths.
+                          description: ListenerPort defines the port of the proxy's
+                            listener for exposed paths.
                           type: integer
                         localPathPort:
-                          description: LocalPathPort is the port that the service is listening on for the given path.
+                          description: LocalPathPort is the port that the service
+                            is listening on for the given path.
                           type: integer
                         path:
-                          description: Path is the path to expose through the proxy, ie. "/metrics".
+                          description: Path is the path to expose through the proxy,
+                            ie. "/metrics".
                           type: string
                         protocol:
-                          description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
+                          description: Protocol describes the upstream's service protocol.
+                            Valid values are "http" and "http2", defaults to "http".
                           type: string
                       type: object
                     type: array
                 type: object
               meshGateway:
-                description: MeshGateway controls the default mesh gateway configuration for this service.
+                description: MeshGateway controls the default mesh gateway configuration
+                  for this service.
                 properties:
                   mode:
-                    description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                    description: Mode is the mode that should be used for the upstream
+                      connection. One of none, local, or remote.
                     type: string
                 type: object
               mode:
-                description: 'Mode can be one of "direct" or "transparent". "transparent" represents that inbound and outbound application traffic is being captured and redirected through the proxy. This mode does not enable the traffic redirection itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected. "direct" represents that the proxy''s listeners must be dialed directly by the local application and other proxies. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
+                description: 'Mode can be one of "direct" or "transparent". "transparent"
+                  represents that inbound and outbound application traffic is being
+                  captured and redirected through the proxy. This mode does not enable
+                  the traffic redirection itself. Instead it signals Consul to configure
+                  Envoy as if traffic is already being redirected. "direct" represents
+                  that the proxy''s listeners must be dialed directly by the local
+                  application and other proxies. Note: This cannot be set using the
+                  CRD and should be set using annotations on the services that are
+                  part of the mesh.'
                 type: string
               transparentProxy:
-                description: 'TransparentProxy controls configuration specific to proxies in transparent mode. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
+                description: 'TransparentProxy controls configuration specific to
+                  proxies in transparent mode. Note: This cannot be set using the
+                  CRD and should be set using annotations on the services that are
+                  part of the mesh.'
                 properties:
+                  dialedDirectly:
+                    description: DialedDirectly indicates whether transparent proxies
+                      can dial this proxy instance directly. The discovery chain is
+                      not considered when dialing a service instance directly. This
+                      setting is useful when addressing stateful services, such as
+                      a database cluster with a leader node.
+                    type: boolean
                   outboundListenerPort:
-                    description: The port of the listener where outbound application traffic is being redirected to.
+                    description: OutboundListenerPort is the port of the listener
+                      where outbound application traffic is being redirected to.
                     type: integer
                 type: object
             type: object
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -127,7 +165,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-servicedefaults.yaml
+++ b/templates/crd-servicedefaults.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: servicedefaults.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ServiceDefaults is the Schema for the servicedefaults API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,161 +56,267 @@ spec:
             description: ServiceDefaultsSpec defines the desired state of ServiceDefaults
             properties:
               expose:
-                description: Expose controls the default expose path configuration for Envoy.
+                description: Expose controls the default expose path configuration
+                  for Envoy.
                 properties:
                   checks:
-                    description: Checks defines whether paths associated with Consul checks will be exposed. This flag triggers exposing all HTTP and GRPC check paths registered for the service.
+                    description: Checks defines whether paths associated with Consul
+                      checks will be exposed. This flag triggers exposing all HTTP
+                      and GRPC check paths registered for the service.
                     type: boolean
                   paths:
                     description: Paths is the list of paths exposed through the proxy.
                     items:
                       properties:
                         listenerPort:
-                          description: ListenerPort defines the port of the proxy's listener for exposed paths.
+                          description: ListenerPort defines the port of the proxy's
+                            listener for exposed paths.
                           type: integer
                         localPathPort:
-                          description: LocalPathPort is the port that the service is listening on for the given path.
+                          description: LocalPathPort is the port that the service
+                            is listening on for the given path.
                           type: integer
                         path:
-                          description: Path is the path to expose through the proxy, ie. "/metrics".
+                          description: Path is the path to expose through the proxy,
+                            ie. "/metrics".
                           type: string
                         protocol:
-                          description: Protocol describes the upstream's service protocol. Valid values are "http" and "http2", defaults to "http".
+                          description: Protocol describes the upstream's service protocol.
+                            Valid values are "http" and "http2", defaults to "http".
                           type: string
                       type: object
                     type: array
                 type: object
               externalSNI:
-                description: ExternalSNI is an optional setting that allows for the TLS SNI value to be changed to a non-connect value when federating with an external system.
+                description: ExternalSNI is an optional setting that allows for the
+                  TLS SNI value to be changed to a non-connect value when federating
+                  with an external system.
                 type: string
               meshGateway:
-                description: MeshGateway controls the default mesh gateway configuration for this service.
+                description: MeshGateway controls the default mesh gateway configuration
+                  for this service.
                 properties:
                   mode:
-                    description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                    description: Mode is the mode that should be used for the upstream
+                      connection. One of none, local, or remote.
                     type: string
                 type: object
               mode:
-                description: 'Mode can be one of "direct" or "transparent". "transparent" represents that inbound and outbound application traffic is being captured and redirected through the proxy. This mode does not enable the traffic redirection itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected. "direct" represents that the proxy''s listeners must be dialed directly by the local application and other proxies. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
+                description: 'Mode can be one of "direct" or "transparent". "transparent"
+                  represents that inbound and outbound application traffic is being
+                  captured and redirected through the proxy. This mode does not enable
+                  the traffic redirection itself. Instead it signals Consul to configure
+                  Envoy as if traffic is already being redirected. "direct" represents
+                  that the proxy''s listeners must be dialed directly by the local
+                  application and other proxies. Note: This cannot be set using the
+                  CRD and should be set using annotations on the services that are
+                  part of the mesh.'
                 type: string
               protocol:
-                description: Protocol sets the protocol of the service. This is used by Connect proxies for things like observability features and to unlock usage of the service-splitter and service-router config entries for a service.
+                description: Protocol sets the protocol of the service. This is used
+                  by Connect proxies for things like observability features and to
+                  unlock usage of the service-splitter and service-router config entries
+                  for a service.
                 type: string
               transparentProxy:
-                description: 'TransparentProxy controls configuration specific to proxies in transparent mode. Note: This cannot be set using the CRD and should be set using annotations on the services that are part of the mesh.'
+                description: 'TransparentProxy controls configuration specific to
+                  proxies in transparent mode. Note: This cannot be set using the
+                  CRD and should be set using annotations on the services that are
+                  part of the mesh.'
                 properties:
+                  dialedDirectly:
+                    description: DialedDirectly indicates whether transparent proxies
+                      can dial this proxy instance directly. The discovery chain is
+                      not considered when dialing a service instance directly. This
+                      setting is useful when addressing stateful services, such as
+                      a database cluster with a leader node.
+                    type: boolean
                   outboundListenerPort:
-                    description: The port of the listener where outbound application traffic is being redirected to.
+                    description: OutboundListenerPort is the port of the listener
+                      where outbound application traffic is being redirected to.
                     type: integer
                 type: object
               upstreamConfig:
-                description: UpstreamConfig controls default configuration settings that apply across all upstreams, and per-upstream configuration overrides. Note that per-upstream configuration applies across all federated datacenters to the pairing of source and upstream destination services.
+                description: UpstreamConfig controls default configuration settings
+                  that apply across all upstreams, and per-upstream configuration
+                  overrides. Note that per-upstream configuration applies across all
+                  federated datacenters to the pairing of source and upstream destination
+                  services.
                 properties:
                   defaults:
-                    description: Defaults contains default configuration for all upstreams of a given service. The name field must be empty.
+                    description: Defaults contains default configuration for all upstreams
+                      of a given service. The name field must be empty.
                     properties:
                       connectTimeoutMs:
-                        description: ConnectTimeoutMs is the number of milliseconds to timeout making a new connection to this upstream. Defaults to 5000 (5 seconds) if not set.
+                        description: ConnectTimeoutMs is the number of milliseconds
+                          to timeout making a new connection to this upstream. Defaults
+                          to 5000 (5 seconds) if not set.
                         type: integer
                       envoyClusterJSON:
-                        description: 'EnvoyClusterJSON is a complete override ("escape hatch") for the upstream''s cluster. The Connect client TLS certificate and context will be injected overriding any TLS settings present. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                        description: 'EnvoyClusterJSON is a complete override ("escape
+                          hatch") for the upstream''s cluster. The Connect client
+                          TLS certificate and context will be injected overriding
+                          any TLS settings present. Note: This escape hatch is NOT
+                          compatible with the discovery chain and will be ignored
+                          if a discovery chain is active.'
                         type: string
                       envoyListenerJSON:
-                        description: 'EnvoyListenerJSON is a complete override ("escape hatch") for the upstream''s listener. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                        description: 'EnvoyListenerJSON is a complete override ("escape
+                          hatch") for the upstream''s listener. Note: This escape
+                          hatch is NOT compatible with the discovery chain and will
+                          be ignored if a discovery chain is active.'
                         type: string
                       limits:
-                        description: Limits are the set of limits that are applied to the proxy for a specific upstream of a service instance.
+                        description: Limits are the set of limits that are applied
+                          to the proxy for a specific upstream of a service instance.
                         properties:
                           maxConcurrentRequests:
-                            description: MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed to the upstream cluster at a point in time. This is mostly applicable to HTTP/2 clusters since all HTTP/1.1 requests are limited by MaxConnections.
+                            description: MaxConcurrentRequests is the maximum number
+                              of in-flight requests that will be allowed to the upstream
+                              cluster at a point in time. This is mostly applicable
+                              to HTTP/2 clusters since all HTTP/1.1 requests are limited
+                              by MaxConnections.
                             type: integer
                           maxConnections:
-                            description: MaxConnections is the maximum number of connections the local proxy can make to the upstream service.
+                            description: MaxConnections is the maximum number of connections
+                              the local proxy can make to the upstream service.
                             type: integer
                           maxPendingRequests:
-                            description: MaxPendingRequests is the maximum number of requests that will be queued waiting for an available connection. This is mostly applicable to HTTP/1.1 clusters since all HTTP/2 requests are streamed over a single connection.
+                            description: MaxPendingRequests is the maximum number
+                              of requests that will be queued waiting for an available
+                              connection. This is mostly applicable to HTTP/1.1 clusters
+                              since all HTTP/2 requests are streamed over a single
+                              connection.
                             type: integer
                         type: object
                       meshGateway:
-                        description: MeshGatewayConfig controls how Mesh Gateways are configured and used.
+                        description: MeshGatewayConfig controls how Mesh Gateways
+                          are configured and used.
                         properties:
                           mode:
-                            description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                            description: Mode is the mode that should be used for
+                              the upstream connection. One of none, local, or remote.
                             type: string
                         type: object
                       name:
-                        description: Name is only accepted within a service-defaults config entry.
+                        description: Name is only accepted within a service-defaults
+                          config entry.
                         type: string
                       namespace:
-                        description: Namespace is only accepted within a service-defaults config entry.
+                        description: Namespace is only accepted within a service-defaults
+                          config entry.
                         type: string
                       passiveHealthCheck:
-                        description: PassiveHealthCheck configuration determines how upstream proxy instances will be monitored for removal from the load balancing pool.
+                        description: PassiveHealthCheck configuration determines how
+                          upstream proxy instances will be monitored for removal from
+                          the load balancing pool.
                         properties:
                           interval:
-                            description: Interval between health check analysis sweeps. Each sweep may remove hosts or return hosts to the pool.
+                            description: Interval between health check analysis sweeps.
+                              Each sweep may remove hosts or return hosts to the pool.
                             type: string
                           maxFailures:
-                            description: MaxFailures is the count of consecutive failures that results in a host being removed from the pool.
+                            description: MaxFailures is the count of consecutive failures
+                              that results in a host being removed from the pool.
                             format: int32
                             type: integer
                         type: object
                       protocol:
-                        description: Protocol describes the upstream's service protocol. Valid values are "tcp", "http" and "grpc". Anything else is treated as tcp. This enables protocol aware features like per-request metrics and connection pooling, tracing, routing etc.
+                        description: Protocol describes the upstream's service protocol.
+                          Valid values are "tcp", "http" and "grpc". Anything else
+                          is treated as tcp. This enables protocol aware features
+                          like per-request metrics and connection pooling, tracing,
+                          routing etc.
                         type: string
                     type: object
                   overrides:
-                    description: Overrides is a slice of per-service configuration. The name field is required.
+                    description: Overrides is a slice of per-service configuration.
+                      The name field is required.
                     items:
                       properties:
                         connectTimeoutMs:
-                          description: ConnectTimeoutMs is the number of milliseconds to timeout making a new connection to this upstream. Defaults to 5000 (5 seconds) if not set.
+                          description: ConnectTimeoutMs is the number of milliseconds
+                            to timeout making a new connection to this upstream. Defaults
+                            to 5000 (5 seconds) if not set.
                           type: integer
                         envoyClusterJSON:
-                          description: 'EnvoyClusterJSON is a complete override ("escape hatch") for the upstream''s cluster. The Connect client TLS certificate and context will be injected overriding any TLS settings present. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                          description: 'EnvoyClusterJSON is a complete override ("escape
+                            hatch") for the upstream''s cluster. The Connect client
+                            TLS certificate and context will be injected overriding
+                            any TLS settings present. Note: This escape hatch is NOT
+                            compatible with the discovery chain and will be ignored
+                            if a discovery chain is active.'
                           type: string
                         envoyListenerJSON:
-                          description: 'EnvoyListenerJSON is a complete override ("escape hatch") for the upstream''s listener. Note: This escape hatch is NOT compatible with the discovery chain and will be ignored if a discovery chain is active.'
+                          description: 'EnvoyListenerJSON is a complete override ("escape
+                            hatch") for the upstream''s listener. Note: This escape
+                            hatch is NOT compatible with the discovery chain and will
+                            be ignored if a discovery chain is active.'
                           type: string
                         limits:
-                          description: Limits are the set of limits that are applied to the proxy for a specific upstream of a service instance.
+                          description: Limits are the set of limits that are applied
+                            to the proxy for a specific upstream of a service instance.
                           properties:
                             maxConcurrentRequests:
-                              description: MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed to the upstream cluster at a point in time. This is mostly applicable to HTTP/2 clusters since all HTTP/1.1 requests are limited by MaxConnections.
+                              description: MaxConcurrentRequests is the maximum number
+                                of in-flight requests that will be allowed to the
+                                upstream cluster at a point in time. This is mostly
+                                applicable to HTTP/2 clusters since all HTTP/1.1 requests
+                                are limited by MaxConnections.
                               type: integer
                             maxConnections:
-                              description: MaxConnections is the maximum number of connections the local proxy can make to the upstream service.
+                              description: MaxConnections is the maximum number of
+                                connections the local proxy can make to the upstream
+                                service.
                               type: integer
                             maxPendingRequests:
-                              description: MaxPendingRequests is the maximum number of requests that will be queued waiting for an available connection. This is mostly applicable to HTTP/1.1 clusters since all HTTP/2 requests are streamed over a single connection.
+                              description: MaxPendingRequests is the maximum number
+                                of requests that will be queued waiting for an available
+                                connection. This is mostly applicable to HTTP/1.1
+                                clusters since all HTTP/2 requests are streamed over
+                                a single connection.
                               type: integer
                           type: object
                         meshGateway:
-                          description: MeshGatewayConfig controls how Mesh Gateways are configured and used.
+                          description: MeshGatewayConfig controls how Mesh Gateways
+                            are configured and used.
                           properties:
                             mode:
-                              description: Mode is the mode that should be used for the upstream connection. One of none, local, or remote.
+                              description: Mode is the mode that should be used for
+                                the upstream connection. One of none, local, or remote.
                               type: string
                           type: object
                         name:
-                          description: Name is only accepted within a service-defaults config entry.
+                          description: Name is only accepted within a service-defaults
+                            config entry.
                           type: string
                         namespace:
-                          description: Namespace is only accepted within a service-defaults config entry.
+                          description: Namespace is only accepted within a service-defaults
+                            config entry.
                           type: string
                         passiveHealthCheck:
-                          description: PassiveHealthCheck configuration determines how upstream proxy instances will be monitored for removal from the load balancing pool.
+                          description: PassiveHealthCheck configuration determines
+                            how upstream proxy instances will be monitored for removal
+                            from the load balancing pool.
                           properties:
                             interval:
-                              description: Interval between health check analysis sweeps. Each sweep may remove hosts or return hosts to the pool.
+                              description: Interval between health check analysis
+                                sweeps. Each sweep may remove hosts or return hosts
+                                to the pool.
                               type: string
                             maxFailures:
-                              description: MaxFailures is the count of consecutive failures that results in a host being removed from the pool.
+                              description: MaxFailures is the count of consecutive
+                                failures that results in a host being removed from
+                                the pool.
                               format: int32
                               type: integer
                           type: object
                         protocol:
-                          description: Protocol describes the upstream's service protocol. Valid values are "tcp", "http" and "grpc". Anything else is treated as tcp. This enables protocol aware features like per-request metrics and connection pooling, tracing, routing etc.
+                          description: Protocol describes the upstream's service protocol.
+                            Valid values are "tcp", "http" and "grpc". Anything else
+                            is treated as tcp. This enables protocol aware features
+                            like per-request metrics and connection pooling, tracing,
+                            routing etc.
                           type: string
                       type: object
                     type: array
@@ -215,16 +325,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -241,7 +355,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-serviceintentions.yaml
+++ b/templates/crd-serviceintentions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: serviceintentions.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ServiceIntentions is the Schema for the serviceintentions API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,81 +56,123 @@ spec:
             description: ServiceIntentionsSpec defines the desired state of ServiceIntentions
             properties:
               destination:
-                description: Destination is the intention destination that will have the authorization granted to.
+                description: Destination is the intention destination that will have
+                  the authorization granted to.
                 properties:
                   name:
-                    description: Name is the destination of all intentions defined in this config entry. This may be set to the wildcard character (*) to match all services that don't otherwise have intentions defined.
+                    description: Name is the destination of all intentions defined
+                      in this config entry. This may be set to the wildcard character
+                      (*) to match all services that don't otherwise have intentions
+                      defined.
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace the config entry will apply to. This may be set to the wildcard character (*) to match all services in all namespaces that don't otherwise have intentions defined.
+                    description: Namespace specifies the namespace the config entry
+                      will apply to. This may be set to the wildcard character (*)
+                      to match all services in all namespaces that don't otherwise
+                      have intentions defined.
                     type: string
                 type: object
               sources:
-                description: Sources is the list of all intention sources and the authorization granted to those sources. The order of this list does not matter, but out of convenience Consul will always store this reverse sorted by intention precedence, as that is the order that they will be evaluated at enforcement time.
+                description: Sources is the list of all intention sources and the
+                  authorization granted to those sources. The order of this list does
+                  not matter, but out of convenience Consul will always store this
+                  reverse sorted by intention precedence, as that is the order that
+                  they will be evaluated at enforcement time.
                 items:
                   properties:
                     action:
-                      description: Action is required for an L4 intention, and should be set to one of "allow" or "deny" for the action that should be taken if this intention matches a request.
+                      description: Action is required for an L4 intention, and should
+                        be set to one of "allow" or "deny" for the action that should
+                        be taken if this intention matches a request.
                       type: string
                     description:
-                      description: Description for the intention. This is not used by Consul, but is presented in API responses to assist tooling.
+                      description: Description for the intention. This is not used
+                        by Consul, but is presented in API responses to assist tooling.
                       type: string
                     name:
-                      description: Name is the source of the intention. This is the name of a Consul service. The service doesn't need to be registered.
+                      description: Name is the source of the intention. This is the
+                        name of a Consul service. The service doesn't need to be registered.
                       type: string
                     namespace:
                       description: Namespace is the namespace for the Name parameter.
                       type: string
                     permissions:
-                      description: Permissions is the list of all additional L7 attributes that extend the intention match criteria. Permission precedence is applied top to bottom. For any given request the first permission to match in the list is terminal and stops further evaluation. As with L4 intentions, traffic that fails to match any of the provided permissions in this intention will be subject to the default intention behavior is defined by the default ACL policy. This should be omitted for an L4 intention as it is mutually exclusive with the Action field.
+                      description: Permissions is the list of all additional L7 attributes
+                        that extend the intention match criteria. Permission precedence
+                        is applied top to bottom. For any given request the first
+                        permission to match in the list is terminal and stops further
+                        evaluation. As with L4 intentions, traffic that fails to match
+                        any of the provided permissions in this intention will be
+                        subject to the default intention behavior is defined by the
+                        default ACL policy. This should be omitted for an L4 intention
+                        as it is mutually exclusive with the Action field.
                       items:
                         properties:
                           action:
-                            description: Action is one of "allow" or "deny" for the action that should be taken if this permission matches a request.
+                            description: Action is one of "allow" or "deny" for the
+                              action that should be taken if this permission matches
+                              a request.
                             type: string
                           http:
-                            description: HTTP is a set of HTTP-specific authorization criteria.
+                            description: HTTP is a set of HTTP-specific authorization
+                              criteria.
                             properties:
                               header:
-                                description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
+                                description: Header is a set of criteria that can
+                                  match on HTTP request headers. If more than one
+                                  is configured all must match for the overall match
+                                  to apply.
                                 items:
                                   properties:
                                     exact:
-                                      description: Exact matches if the header with the given name is this value.
+                                      description: Exact matches if the header with
+                                        the given name is this value.
                                       type: string
                                     invert:
-                                      description: Invert inverts the logic of the match.
+                                      description: Invert inverts the logic of the
+                                        match.
                                       type: boolean
                                     name:
-                                      description: Name is the name of the header to match.
+                                      description: Name is the name of the header
+                                        to match.
                                       type: string
                                     prefix:
-                                      description: Prefix matches if the header with the given name has this prefix.
+                                      description: Prefix matches if the header with
+                                        the given name has this prefix.
                                       type: string
                                     present:
-                                      description: Present matches if the header with the given name is present with any value.
+                                      description: Present matches if the header with
+                                        the given name is present with any value.
                                       type: boolean
                                     regex:
-                                      description: Regex matches if the header with the given name matches this pattern.
+                                      description: Regex matches if the header with
+                                        the given name matches this pattern.
                                       type: string
                                     suffix:
-                                      description: Suffix matches if the header with the given name has this suffix.
+                                      description: Suffix matches if the header with
+                                        the given name has this suffix.
                                       type: string
                                   type: object
                                 type: array
                               methods:
-                                description: Methods is a list of HTTP methods for which this match applies. If unspecified all HTTP methods are matched. If provided the names must be a valid method.
+                                description: Methods is a list of HTTP methods for
+                                  which this match applies. If unspecified all HTTP
+                                  methods are matched. If provided the names must
+                                  be a valid method.
                                 items:
                                   type: string
                                 type: array
                               pathExact:
-                                description: PathExact is the exact path to match on the HTTP request path.
+                                description: PathExact is the exact path to match
+                                  on the HTTP request path.
                                 type: string
                               pathPrefix:
-                                description: PathPrefix is the path prefix to match on the HTTP request path.
+                                description: PathPrefix is the path prefix to match
+                                  on the HTTP request path.
                                 type: string
                               pathRegex:
-                                description: PathRegex is the regular expression to match on the HTTP request path.
+                                description: PathRegex is the regular expression to
+                                  match on the HTTP request path.
                                 type: string
                             type: object
                         type: object
@@ -137,16 +183,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -163,7 +213,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-serviceresolvers.yaml
+++ b/templates/crd-serviceresolvers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: serviceresolvers.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ServiceResolver is the Schema for the serviceresolvers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,131 +56,190 @@ spec:
             description: ServiceResolverSpec defines the desired state of ServiceResolver
             properties:
               connectTimeout:
-                description: ConnectTimeout is the timeout for establishing new network connections to this service.
+                description: ConnectTimeout is the timeout for establishing new network
+                  connections to this service.
                 type: string
               defaultSubset:
-                description: DefaultSubset is the subset to use when no explicit subset is requested. If empty the unnamed subset is used.
+                description: DefaultSubset is the subset to use when no explicit subset
+                  is requested. If empty the unnamed subset is used.
                 type: string
               failover:
                 additionalProperties:
                   properties:
                     datacenters:
-                      description: Datacenters is a fixed list of datacenters to try during failover.
+                      description: Datacenters is a fixed list of datacenters to try
+                        during failover.
                       items:
                         type: string
                       type: array
                     namespace:
-                      description: Namespace is the namespace to resolve the requested service from to form the failover group of instances. If empty the current namespace is used.
+                      description: Namespace is the namespace to resolve the requested
+                        service from to form the failover group of instances. If empty
+                        the current namespace is used.
                       type: string
                     service:
-                      description: Service is the service to resolve instead of the default as the failover group of instances during failover.
+                      description: Service is the service to resolve instead of the
+                        default as the failover group of instances during failover.
                       type: string
                     serviceSubset:
-                      description: ServiceSubset is the named subset of the requested service to resolve as the failover group of instances. If empty the default subset for the requested service is used.
+                      description: ServiceSubset is the named subset of the requested
+                        service to resolve as the failover group of instances. If
+                        empty the default subset for the requested service is used.
                       type: string
                   type: object
-                description: Failover controls when and how to reroute traffic to an alternate pool of service instances. The map is keyed by the service subset it applies to and the special string "*" is a wildcard that applies to any subset not otherwise specified here.
+                description: Failover controls when and how to reroute traffic to
+                  an alternate pool of service instances. The map is keyed by the
+                  service subset it applies to and the special string "*" is a wildcard
+                  that applies to any subset not otherwise specified here.
                 type: object
               loadBalancer:
-                description: LoadBalancer determines the load balancing policy and configuration for services issuing requests to this upstream service.
+                description: LoadBalancer determines the load balancing policy and
+                  configuration for services issuing requests to this upstream service.
                 properties:
                   hashPolicies:
-                    description: HashPolicies is a list of hash policies to use for hashing load balancing algorithms. Hash policies are evaluated individually and combined such that identical lists result in the same hash. If no hash policies are present, or none are successfully evaluated, then a random backend host will be selected.
+                    description: HashPolicies is a list of hash policies to use for
+                      hashing load balancing algorithms. Hash policies are evaluated
+                      individually and combined such that identical lists result in
+                      the same hash. If no hash policies are present, or none are
+                      successfully evaluated, then a random backend host will be selected.
                     items:
                       properties:
                         cookieConfig:
-                          description: CookieConfig contains configuration for the "cookie" hash policy type.
+                          description: CookieConfig contains configuration for the
+                            "cookie" hash policy type.
                           properties:
                             path:
                               description: Path is the path to set for the cookie.
                               type: string
                             session:
-                              description: Session determines whether to generate a session cookie with no expiration.
+                              description: Session determines whether to generate
+                                a session cookie with no expiration.
                               type: boolean
                             ttl:
-                              description: TTL is the ttl for generated cookies. Cannot be specified for session cookies.
+                              description: TTL is the ttl for generated cookies. Cannot
+                                be specified for session cookies.
                               type: string
                           type: object
                         field:
-                          description: Field is the attribute type to hash on. Must be one of "header", "cookie", or "query_parameter". Cannot be specified along with sourceIP.
+                          description: Field is the attribute type to hash on. Must
+                            be one of "header", "cookie", or "query_parameter". Cannot
+                            be specified along with sourceIP.
                           type: string
                         fieldValue:
-                          description: FieldValue is the value to hash. ie. header name, cookie name, URL query parameter name Cannot be specified along with sourceIP.
+                          description: FieldValue is the value to hash. ie. header
+                            name, cookie name, URL query parameter name Cannot be
+                            specified along with sourceIP.
                           type: string
                         sourceIP:
-                          description: SourceIP determines whether the hash should be of the source IP rather than of a field and field value. Cannot be specified along with field or fieldValue.
+                          description: SourceIP determines whether the hash should
+                            be of the source IP rather than of a field and field value.
+                            Cannot be specified along with field or fieldValue.
                           type: boolean
                         terminal:
-                          description: Terminal will short circuit the computation of the hash when multiple hash policies are present. If a hash is computed when a Terminal policy is evaluated, then that hash will be used and subsequent hash policies will be ignored.
+                          description: Terminal will short circuit the computation
+                            of the hash when multiple hash policies are present. If
+                            a hash is computed when a Terminal policy is evaluated,
+                            then that hash will be used and subsequent hash policies
+                            will be ignored.
                           type: boolean
                       type: object
                     type: array
                   leastRequestConfig:
-                    description: LeastRequestConfig contains configuration for the "leastRequest" policy type.
+                    description: LeastRequestConfig contains configuration for the
+                      "leastRequest" policy type.
                     properties:
                       choiceCount:
-                        description: ChoiceCount determines the number of random healthy hosts from which to select the one with the least requests.
+                        description: ChoiceCount determines the number of random healthy
+                          hosts from which to select the one with the least requests.
                         format: int32
                         type: integer
                     type: object
                   policy:
-                    description: Policy is the load balancing policy used to select a host.
+                    description: Policy is the load balancing policy used to select
+                      a host.
                     type: string
                   ringHashConfig:
-                    description: RingHashConfig contains configuration for the "ringHash" policy type.
+                    description: RingHashConfig contains configuration for the "ringHash"
+                      policy type.
                     properties:
                       maximumRingSize:
-                        description: MaximumRingSize determines the maximum number of entries in the hash ring.
+                        description: MaximumRingSize determines the maximum number
+                          of entries in the hash ring.
                         format: int64
                         type: integer
                       minimumRingSize:
-                        description: MinimumRingSize determines the minimum number of entries in the hash ring.
+                        description: MinimumRingSize determines the minimum number
+                          of entries in the hash ring.
                         format: int64
                         type: integer
                     type: object
                 type: object
               redirect:
-                description: Redirect when configured, all attempts to resolve the service this resolver defines will be substituted for the supplied redirect EXCEPT when the redirect has already been applied. When substituting the supplied redirect, all other fields besides Kind, Name, and Redirect will be ignored.
+                description: Redirect when configured, all attempts to resolve the
+                  service this resolver defines will be substituted for the supplied
+                  redirect EXCEPT when the redirect has already been applied. When
+                  substituting the supplied redirect, all other fields besides Kind,
+                  Name, and Redirect will be ignored.
                 properties:
                   datacenter:
-                    description: Datacenter is the datacenter to resolve the service from instead of the current one.
+                    description: Datacenter is the datacenter to resolve the service
+                      from instead of the current one.
                     type: string
                   namespace:
-                    description: Namespace is the namespace to resolve the service from instead of the current one.
+                    description: Namespace is the namespace to resolve the service
+                      from instead of the current one.
                     type: string
                   service:
-                    description: Service is a service to resolve instead of the current service.
+                    description: Service is a service to resolve instead of the current
+                      service.
                     type: string
                   serviceSubset:
-                    description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset If empty the default subset is used.
+                    description: ServiceSubset is a named subset of the given service
+                      to resolve instead of one defined as that service's DefaultSubset
+                      If empty the default subset is used.
                     type: string
                 type: object
               subsets:
                 additionalProperties:
                   properties:
                     filter:
-                      description: Filter is the filter expression to be used for selecting instances of the requested service. If empty all healthy instances are returned. This expression can filter on the same selectors as the Health API endpoint.
+                      description: Filter is the filter expression to be used for
+                        selecting instances of the requested service. If empty all
+                        healthy instances are returned. This expression can filter
+                        on the same selectors as the Health API endpoint.
                       type: string
                     onlyPassing:
-                      description: OnlyPassing specifies the behavior of the resolver's health check interpretation. If this is set to false, instances with checks in the passing as well as the warning states will be considered healthy. If this is set to true, only instances with checks in the passing state will be considered healthy.
+                      description: OnlyPassing specifies the behavior of the resolver's
+                        health check interpretation. If this is set to false, instances
+                        with checks in the passing as well as the warning states will
+                        be considered healthy. If this is set to true, only instances
+                        with checks in the passing state will be considered healthy.
                       type: boolean
                   type: object
-                description: Subsets is map of subset name to subset definition for all usable named subsets of this service. The map key is the name of the subset and all names must be valid DNS subdomain elements. This may be empty, in which case only the unnamed default subset will be usable.
+                description: Subsets is map of subset name to subset definition for
+                  all usable named subsets of this service. The map key is the name
+                  of the subset and all names must be valid DNS subdomain elements.
+                  This may be empty, in which case only the unnamed default subset
+                  will be usable.
                 type: object
             type: object
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -193,7 +256,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-servicerouters.yaml
+++ b/templates/crd-servicerouters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: servicerouters.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ServiceRouter is the Schema for the servicerouters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,105 +56,145 @@ spec:
             description: ServiceRouterSpec defines the desired state of ServiceRouter
             properties:
               routes:
-                description: Routes are the list of routes to consider when processing L7 requests. The first route to match in the list is terminal and stops further evaluation. Traffic that fails to match any of the provided routes will be routed to the default service.
+                description: Routes are the list of routes to consider when processing
+                  L7 requests. The first route to match in the list is terminal and
+                  stops further evaluation. Traffic that fails to match any of the
+                  provided routes will be routed to the default service.
                 items:
                   properties:
                     destination:
-                      description: Destination controls how to proxy the matching request(s) to a service.
+                      description: Destination controls how to proxy the matching
+                        request(s) to a service.
                       properties:
                         namespace:
-                          description: Namespace is the Consul namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
+                          description: Namespace is the Consul namespace to resolve
+                            the service from instead of the current namespace. If
+                            empty the current namespace is assumed.
                           type: string
                         numRetries:
-                          description: NumRetries is the number of times to retry the request when a retryable result occurs
+                          description: NumRetries is the number of times to retry
+                            the request when a retryable result occurs
                           format: int32
                           type: integer
                         prefixRewrite:
-                          description: PrefixRewrite defines how to rewrite the HTTP request path before proxying it to its final destination. This requires that either match.http.pathPrefix or match.http.pathExact be configured on this route.
+                          description: PrefixRewrite defines how to rewrite the HTTP
+                            request path before proxying it to its final destination.
+                            This requires that either match.http.pathPrefix or match.http.pathExact
+                            be configured on this route.
                           type: string
                         requestTimeout:
-                          description: RequestTimeout is the total amount of time permitted for the entire downstream request (and retries) to be processed.
+                          description: RequestTimeout is the total amount of time
+                            permitted for the entire downstream request (and retries)
+                            to be processed.
                           type: string
                         retryOnConnectFailure:
-                          description: RetryOnConnectFailure allows for connection failure errors to trigger a retry.
+                          description: RetryOnConnectFailure allows for connection
+                            failure errors to trigger a retry.
                           type: boolean
                         retryOnStatusCodes:
-                          description: RetryOnStatusCodes is a flat list of http response status codes that are eligible for retry.
+                          description: RetryOnStatusCodes is a flat list of http response
+                            status codes that are eligible for retry.
                           items:
                             format: int32
                             type: integer
                           type: array
                         service:
-                          description: Service is the service to resolve instead of the default service. If empty then the default service name is used.
+                          description: Service is the service to resolve instead of
+                            the default service. If empty then the default service
+                            name is used.
                           type: string
                         serviceSubset:
-                          description: ServiceSubset is a named subset of the given service to resolve instead of the one defined as that service's DefaultSubset. If empty, the default subset is used.
+                          description: ServiceSubset is a named subset of the given
+                            service to resolve instead of the one defined as that
+                            service's DefaultSubset. If empty, the default subset
+                            is used.
                           type: string
                       type: object
                     match:
-                      description: Match is a set of criteria that can match incoming L7 requests. If empty or omitted it acts as a catch-all.
+                      description: Match is a set of criteria that can match incoming
+                        L7 requests. If empty or omitted it acts as a catch-all.
                       properties:
                         http:
                           description: HTTP is a set of http-specific match criteria.
                           properties:
                             header:
-                              description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
+                              description: Header is a set of criteria that can match
+                                on HTTP request headers. If more than one is configured
+                                all must match for the overall match to apply.
                               items:
                                 properties:
                                   exact:
-                                    description: Exact will match if the header with the given name is this value.
+                                    description: Exact will match if the header with
+                                      the given name is this value.
                                     type: string
                                   invert:
                                     description: Invert inverts the logic of the match.
                                     type: boolean
                                   name:
-                                    description: Name is the name of the header to match.
+                                    description: Name is the name of the header to
+                                      match.
                                     type: string
                                   prefix:
-                                    description: Prefix will match if the header with the given name has this prefix.
+                                    description: Prefix will match if the header with
+                                      the given name has this prefix.
                                     type: string
                                   present:
-                                    description: Present will match if the header with the given name is present with any value.
+                                    description: Present will match if the header
+                                      with the given name is present with any value.
                                     type: boolean
                                   regex:
-                                    description: Regex will match if the header with the given name matches this pattern.
+                                    description: Regex will match if the header with
+                                      the given name matches this pattern.
                                     type: string
                                   suffix:
-                                    description: Suffix will match if the header with the given name has this suffix.
+                                    description: Suffix will match if the header with
+                                      the given name has this suffix.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             methods:
-                              description: Methods is a list of HTTP methods for which this match applies. If unspecified all http methods are matched.
+                              description: Methods is a list of HTTP methods for which
+                                this match applies. If unspecified all http methods
+                                are matched.
                               items:
                                 type: string
                               type: array
                             pathExact:
-                              description: PathExact is an exact path to match on the HTTP request path.
+                              description: PathExact is an exact path to match on
+                                the HTTP request path.
                               type: string
                             pathPrefix:
-                              description: PathPrefix is a path prefix to match on the HTTP request path.
+                              description: PathPrefix is a path prefix to match on
+                                the HTTP request path.
                               type: string
                             pathRegex:
-                              description: PathRegex is a regular expression to match on the HTTP request path.
+                              description: PathRegex is a regular expression to match
+                                on the HTTP request path.
                               type: string
                             queryParam:
-                              description: QueryParam is a set of criteria that can match on HTTP query parameters. If more than one is configured all must match for the overall match to apply.
+                              description: QueryParam is a set of criteria that can
+                                match on HTTP query parameters. If more than one is
+                                configured all must match for the overall match to
+                                apply.
                               items:
                                 properties:
                                   exact:
-                                    description: Exact will match if the query parameter with the given name is this value.
+                                    description: Exact will match if the query parameter
+                                      with the given name is this value.
                                     type: string
                                   name:
-                                    description: Name is the name of the query parameter to match on.
+                                    description: Name is the name of the query parameter
+                                      to match on.
                                     type: string
                                   present:
-                                    description: Present will match if the query parameter with the given name is present with any value.
+                                    description: Present will match if the query parameter
+                                      with the given name is present with any value.
                                     type: boolean
                                   regex:
-                                    description: Regex will match if the query parameter with the given name matches this pattern.
+                                    description: Regex will match if the query parameter
+                                      with the given name matches this pattern.
                                     type: string
                                 required:
                                 - name
@@ -164,16 +208,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -190,7 +238,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-servicesplitters.yaml
+++ b/templates/crd-servicesplitters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: servicesplitters.consul.hashicorp.com
   labels:
@@ -41,10 +41,14 @@ spec:
         description: ServiceSplitter is the Schema for the servicesplitters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,20 +56,29 @@ spec:
             description: ServiceSplitterSpec defines the desired state of ServiceSplitter
             properties:
               splits:
-                description: Splits defines how much traffic to send to which set of service instances during a traffic split. The sum of weights across all splits must add up to 100.
+                description: Splits defines how much traffic to send to which set
+                  of service instances during a traffic split. The sum of weights
+                  across all splits must add up to 100.
                 items:
                   properties:
                     namespace:
-                      description: The namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.
+                      description: The namespace to resolve the service from instead
+                        of the current namespace. If empty the current namespace is
+                        assumed.
                       type: string
                     service:
-                      description: Service is the service to resolve instead of the default.
+                      description: Service is the service to resolve instead of the
+                        default.
                       type: string
                     serviceSubset:
-                      description: ServiceSubset is a named subset of the given service to resolve instead of one defined as that service's DefaultSubset. If empty the default subset is used.
+                      description: ServiceSubset is a named subset of the given service
+                        to resolve instead of one defined as that service's DefaultSubset.
+                        If empty the default subset is used.
                       type: string
                     weight:
-                      description: Weight is a value between 0 and 100 reflecting what portion of traffic should be directed to this split. The smallest representable weight is 1/10000 or .01%.
+                      description: Weight is a value between 0 and 100 reflecting
+                        what portion of traffic should be directed to this split.
+                        The smallest representable weight is 1/10000 or .01%.
                       type: number
                   type: object
                 type: array
@@ -73,16 +86,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -99,7 +116,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/templates/crd-terminatinggateways.yaml
+++ b/templates/crd-terminatinggateways.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: terminatinggateways.consul.hashicorp.com
   labels:
@@ -38,13 +38,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TerminatingGateway is the Schema for the terminatinggateways API
+        description: TerminatingGateway is the Schema for the terminatinggateways
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -52,27 +57,36 @@ spec:
             description: TerminatingGatewaySpec defines the desired state of TerminatingGateway
             properties:
               services:
-                description: Services is a list of service names represented by the terminating gateway.
+                description: Services is a list of service names represented by the
+                  terminating gateway.
                 items:
-                  description: A LinkedService is a service represented by a terminating gateway
+                  description: A LinkedService is a service represented by a terminating
+                    gateway
                   properties:
                     caFile:
-                      description: CAFile is the optional path to a CA certificate to use for TLS connections from the gateway to the linked service.
+                      description: CAFile is the optional path to a CA certificate
+                        to use for TLS connections from the gateway to the linked
+                        service.
                       type: string
                     certFile:
-                      description: CertFile is the optional path to a client certificate to use for TLS connections from the gateway to the linked service.
+                      description: CertFile is the optional path to a client certificate
+                        to use for TLS connections from the gateway to the linked
+                        service.
                       type: string
                     keyFile:
-                      description: KeyFile is the optional path to a private key to use for TLS connections from the gateway to the linked service.
+                      description: KeyFile is the optional path to a private key to
+                        use for TLS connections from the gateway to the linked service.
                       type: string
                     name:
-                      description: Name is the name of the service, as defined in Consul's catalog.
+                      description: Name is the name of the service, as defined in
+                        Consul's catalog.
                       type: string
                     namespace:
                       description: The namespace the service is registered in.
                       type: string
                     sni:
-                      description: SNI is the optional name to specify during the TLS handshake with a linked service.
+                      description: SNI is the optional name to specify during the
+                        TLS handshake with a linked service.
                       type: string
                   type: object
                 type: array
@@ -80,16 +94,20 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions indicate the latest available observations of a resource's current state.
+                description: Conditions indicate the latest available observations
+                  of a resource's current state.
                 items:
-                  description: 'Conditions define a readiness condition for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  description: 'Conditions define a readiness condition for a Consul
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -106,7 +124,8 @@ spec:
                   type: object
                 type: array
               lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully synced with Consul.
+                description: LastSyncedTime is the last time the resource successfully
+                  synced with Consul.
                 format: date-time
                 type: string
             type: object

--- a/test/acceptance/go.mod
+++ b/test/acceptance/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/gruntwork-io/terratest v0.31.2
-	github.com/hashicorp/consul/api v1.4.1-0.20210504212756-347f3d212843
+	github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad
 	github.com/hashicorp/consul/sdk v0.7.0
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/test/acceptance/go.sum
+++ b/test/acceptance/go.sum
@@ -225,8 +225,8 @@ github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arn
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.31.2 h1:xvYHA80MUq5kx670dM18HInewOrrQrAN+XbVVtytUHg=
 github.com/gruntwork-io/terratest v0.31.2/go.mod h1:EEgJie28gX/4AD71IFqgMj6e99KP5mi81hEtzmDjxTo=
-github.com/hashicorp/consul/api v1.4.1-0.20210504212756-347f3d212843 h1:KrwvodQtuOqcAscposKbpRBxNsjRvWb2EE28WBNcH7E=
-github.com/hashicorp/consul/api v1.4.1-0.20210504212756-347f3d212843/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
+github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad h1:nynVR0qTR2vUCY8j0PqwcyjhlkwcLov/mnNiDQoBRjw=
+github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
 github.com/hashicorp/consul/sdk v0.7.0 h1:H6R9d008jDcHPQPAqPNuydAshJ4v5/8URdFnUvK/+sc=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/test/acceptance/tests/controller/controller_namespaces_test.go
+++ b/test/acceptance/tests/controller/controller_namespaces_test.go
@@ -158,7 +158,7 @@ func TestControllerNamespaces(t *testing.T) {
 					require.NoError(r, err)
 					meshEntry, ok := entry.(*api.MeshConfigEntry)
 					require.True(r, ok, "could not cast to MeshConfigEntry")
-					require.True(r, meshEntry.TransparentProxy.CatalogDestinationsOnly)
+					require.True(r, meshEntry.TransparentProxy.MeshDestinationsOnly)
 
 					// service-router
 					entry, _, err = consulClient.ConfigEntries().Get(api.ServiceRouter, "router", queryOpts)
@@ -221,7 +221,7 @@ func TestControllerNamespaces(t *testing.T) {
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
 				logger.Log(t, "patching mesh custom resource")
-				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "mesh", "mesh", "-p", fmt.Sprintf(`{"spec":{"transparentProxy":{"catalogDestinationsOnly": %t}}}`, false), "--type=merge")
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "-n", KubeNS, "mesh", "mesh", "-p", fmt.Sprintf(`{"spec":{"transparentProxy":{"meshDestinationsOnly": %t}}}`, false), "--type=merge")
 
 				logger.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
@@ -269,7 +269,7 @@ func TestControllerNamespaces(t *testing.T) {
 					require.NoError(r, err)
 					meshEntry, ok := entry.(*api.MeshConfigEntry)
 					require.True(r, ok, "could not cast to MeshConfigEntry")
-					require.False(r, meshEntry.TransparentProxy.CatalogDestinationsOnly)
+					require.False(r, meshEntry.TransparentProxy.MeshDestinationsOnly)
 
 					// service-router
 					entry, _, err = consulClient.ConfigEntries().Get(api.ServiceRouter, "router", queryOpts)

--- a/test/acceptance/tests/controller/controller_test.go
+++ b/test/acceptance/tests/controller/controller_test.go
@@ -106,7 +106,7 @@ func TestController(t *testing.T) {
 					require.NoError(r, err)
 					meshConfigEntry, ok := entry.(*api.MeshConfigEntry)
 					require.True(r, ok, "could not cast to MeshConfigEntry")
-					require.True(r, meshConfigEntry.TransparentProxy.CatalogDestinationsOnly)
+					require.True(r, meshConfigEntry.TransparentProxy.MeshDestinationsOnly)
 
 					// service-router
 					entry, _, err = consulClient.ConfigEntries().Get(api.ServiceRouter, "router", nil)
@@ -170,7 +170,7 @@ func TestController(t *testing.T) {
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "proxydefaults", "global", "-p", fmt.Sprintf(`{"spec":{"meshGateway":{"mode": "%s"}}}`, patchMeshGatewayMode), "--type=merge")
 
 				logger.Log(t, "patching mesh custom resource")
-				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "mesh", "mesh", "-p", fmt.Sprintf(`{"spec":{"transparentProxy":{"catalogDestinationsOnly": %t}}}`, false), "--type=merge")
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "mesh", "mesh", "-p", fmt.Sprintf(`{"spec":{"transparentProxy":{"meshDestinationsOnly": %t}}}`, false), "--type=merge")
 
 				logger.Log(t, "patching service-router custom resource")
 				patchPathPrefix := "/baz"
@@ -218,7 +218,7 @@ func TestController(t *testing.T) {
 					require.NoError(r, err)
 					meshEntry, ok := entry.(*api.MeshConfigEntry)
 					require.True(r, ok, "could not cast to MeshConfigEntry")
-					require.False(r, meshEntry.TransparentProxy.CatalogDestinationsOnly)
+					require.False(r, meshEntry.TransparentProxy.MeshDestinationsOnly)
 
 					// service-router
 					entry, _, err = consulClient.ConfigEntries().Get(api.ServiceRouter, "router", nil)

--- a/test/acceptance/tests/fixtures/crds/mesh.yaml
+++ b/test/acceptance/tests/fixtures/crds/mesh.yaml
@@ -4,4 +4,4 @@ metadata:
   name: mesh
 spec:
   transparentProxy:
-    catalogDestinationsOnly: true
+    meshDestinationsOnly: true

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -36,10 +36,7 @@ func TestMeshGatewayDefault(t *testing.T) {
 		"global.federation.createFederationSecret": "true",
 
 		"connectInject.enabled": "true",
-		// Temporarily disable tproxy regardless of the global setting.
-		// This should be removed once multi-cluster is working with explicit upstreams.
-		"connectInject.transparentProxy.defaultEnabled": "false",
-		"controller.enabled":                            "true",
+		"controller.enabled":    "true",
 
 		"meshGateway.enabled":  "true",
 		"meshGateway.replicas": "1",
@@ -85,9 +82,6 @@ func TestMeshGatewayDefault(t *testing.T) {
 		"server.extraVolumes[0].items[0].path": "config.json",
 
 		"connectInject.enabled": "true",
-		// Temporarily disable tproxy regardless of the global setting.
-		// This should be removed once multi-cluster is working with explicit upstreams.
-		"connectInject.transparentProxy.defaultEnabled": "false",
 
 		"meshGateway.enabled":  "true",
 		"meshGateway.replicas": "1",


### PR DESCRIPTION
Mesh gateway tests no longer explicitly disable transparent proxy.


