### PR TITLE
Cleanup acceptance tests leftover resources on Azure and GCP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,9 +351,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-18:
     environment:
@@ -469,9 +469,9 @@ jobs:
           command: |
             terraform destroy -auto-approve
           when: always
-      - slack/status:
-          fail_only: true
-          failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-21:
     environment:
@@ -612,6 +612,20 @@ jobs:
           fail_only: true
           failure_message: "Failed to trigger an update to the helm charts index. Check the logs at: ${CIRCLE_BUILD_URL}"
 
+  cleanup-azure-resources:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+    steps:
+      - run:
+          name: cleanup leftover resources
+          command: |
+            az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" > /dev/null
+            resource_groups=$(az group list -o json  | jq -r '.[] | select(.name | test("^consul-k8s-\\d+$")) | .name')
+            for group in $resource_groups; do
+              echo "Deleting $group resource group"
+              az group delete -n $group --yes
+            done
+
 workflows:
   version: 2
   test:
@@ -634,6 +648,12 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
+      - acceptance-openshift
+      - acceptance-aks-1-19
+      - cleanup-azure-resources:
+          requires:
+            - acceptance-aks-1-19
+            - acceptance-openshift
   nightly-acceptance-tests:
     triggers:
       - schedule:
@@ -648,6 +668,10 @@ workflows:
       - acceptance-eks-1-18
       - acceptance-aks-1-19
       - acceptance-kind-1-21
+      - cleanup-azure-resources:
+          requires:
+            - acceptance-aks-1-19
+            - acceptance-openshift
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,6 +663,7 @@ workflows:
             - unit-helm
             - unit-acceptance-framework
       - cleanup-gcp-resources
+      - cleanup-azure-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,9 +351,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-18:
     environment:
@@ -469,9 +469,9 @@ jobs:
           command: |
             terraform destroy -auto-approve
           when: always
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-21:
     environment:
@@ -626,6 +626,20 @@ jobs:
               az group delete -n $group --yes
             done
 
+  cleanup-gcp-resources:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+    steps:
+      - run:
+          name: cleanup leftover resources
+          command: |
+            echo "${GOOGLE_CREDENTIALS}" | gcloud auth activate-service-account --key-file=-
+            clusters=$(gcloud container clusters list --zone us-central1-a --project ${CLOUDSDK_CORE_PROJECT} --format json  | jq -r '.[] | select(.name | test("^consul-k8s-\\d+$")) | .name')
+            for cluster in $clusters; do
+              echo "Deleting $cluster GKE cluster"
+              gcloud container clusters delete $cluster --zone us-central1-a --project ${CLOUDSDK_CORE_PROJECT} --quiet
+            done
+
 workflows:
   version: 2
   test:
@@ -648,12 +662,7 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - acceptance-openshift
-      - acceptance-aks-1-19
-      - cleanup-azure-resources:
-          requires:
-            - acceptance-aks-1-19
-            - acceptance-openshift
+      - cleanup-gcp-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:
@@ -672,6 +681,9 @@ workflows:
           requires:
             - acceptance-aks-1-19
             - acceptance-openshift
+      - cleanup-gcp-resources:
+          requires:
+            - acceptance-gke-1-17
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,18 +671,19 @@ workflows:
               only:
                 - master
     jobs:
-      - acceptance-openshift
-      - acceptance-gke-1-17
+      - cleanup-gcp-resources
+      - cleanup-azure-resources
+      - acceptance-openshift:
+          requires:
+          - cleanup-azure-resources
+      - acceptance-gke-1-17:
+          requires:
+            - cleanup-gcp-resources
       - acceptance-eks-1-18
-      - acceptance-aks-1-19
+      - acceptance-aks-1-19:
+          requires:
+            - cleanup-azure-resources
       - acceptance-kind-1-21
-      - cleanup-azure-resources:
-          requires:
-            - acceptance-aks-1-19
-            - acceptance-openshift
-      - cleanup-gcp-resources:
-          requires:
-            - acceptance-gke-1-17
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,8 +662,6 @@ workflows:
           requires:
             - unit-helm
             - unit-acceptance-framework
-      - cleanup-gcp-resources
-      - cleanup-azure-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:


### PR DESCRIPTION
Changes proposed in this PR:
- Cleanup leftover resources on Azure and GCP:
   - On azure, since all resources are scoped to a resource group, we can just delete the resource groups that are created by tests, and azure will recursively delete any resources belonging to that group as well.
   - On GCP, we only need to delete the GKE clusters since no additional resources are created.
- Successful job on Azure: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3200/workflows/8b17310d-27fb-4069-9a5b-7800c66442b2/jobs/13607
- Successful job on GCP: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3199/workflows/b7ae9323-243c-4532-bab8-1e4af8a834de/jobs/13600

How I've tested this PR:
Ran these jobs in CI

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

