### PR TITLE
Make all Consul client ports customizable

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics) }}
         "prometheus.io/scrape": "true"
         "prometheus.io/path": "/v1/agent/metrics"
-        "prometheus.io/port": "8500"
+        "prometheus.io/port": "{{ .Values.client.ports.http.port }}"
         {{- end }}
     spec:
     {{- if .Values.client.affinity }}
@@ -177,7 +177,7 @@ spec:
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://localhost:8501
+              value: https://localhost:{{ .Values.client.ports.https.port }}
             {{- if .Values.global.tls.enableAutoEncrypt }}
             - name: CONSUL_HTTP_SSL_VERIFY
               value: "false"
@@ -185,6 +185,9 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
+            {{- else }}
+            - name: CONSUL_HTTP_ADDR
+              value: http://localhost:{{ .Values.client.ports.http.port }}
             {{- end }}
             {{- include "consul.extraEnvironmentVars" .Values.client | nindent 12 }}
           command:
@@ -218,13 +221,16 @@ spec:
                 -hcl='verify_server_hostname = true' \
                 {{- end }}
                 {{- end }}
-                -hcl='ports { https = 8501 }' \
+                -hcl='ports { https = {{ .Values.client.ports.https.port }} }' \
                 {{- if .Values.global.tls.httpsOnly }}
                 -hcl='ports { http = -1 }' \
                 {{- end }}
                 {{- end }}
+                {{- if (not (and .Values.global.tls.enabled .Values.global.tls.httpsOnly)) }}
+                -hcl='ports { http = {{ .Values.client.ports.http.port }} }' \
+                {{- end }}
                 {{- if .Values.client.grpc }}
-                -hcl='ports { grpc = 8502 }' \
+                -hcl='ports { grpc = {{ .Values.client.ports.grpc.port }} }' \
                 {{- end }}
                 {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics) }}
                 -hcl='telemetry { prometheus_retention_time = "{{ .Values.global.metrics.agentMetricsRetentionTime }}" }' \
@@ -294,34 +300,34 @@ spec:
             {{- end }}
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
-            - containerPort: 8500
-              hostPort: 8500
+            - containerPort: {{ .Values.client.ports.http.port }}
+              hostPort: {{ .Values.client.ports.http.port }}
               name: http
             {{- end }}
             {{- if .Values.global.tls.enabled }}
-            - containerPort: 8501
-              hostPort: 8501
+            - containerPort: {{ .Values.client.ports.https.port }}
+              hostPort: {{ .Values.client.ports.https.port }}
               name: https
             {{- end }}
-            - containerPort: 8502
-              hostPort: 8502
+            - containerPort: {{ .Values.client.ports.grpc.port }}
+              hostPort: {{ .Values.client.ports.grpc.port }}
               name: grpc
-            - containerPort: 8301
+            - containerPort: {{ .Values.client.ports.serflanTcp.port }}
               {{- if .Values.client.exposeGossipPorts }}
-              hostPort: 8301
+              hostPort: {{ .Values.client.ports.serflanTcp.port }}
               {{- end }}
               protocol: "TCP"
               name: serflan-tcp
-            - containerPort: 8301
+            - containerPort: {{ .Values.client.ports.serflanUdp.port }}
               {{- if .Values.client.exposeGossipPorts }}
-              hostPort: 8301
+              hostPort: {{ .Values.client.ports.serflanUdp.port }}
               {{- end }}
               protocol: "UDP"
               name: serflan-udp
-            - containerPort: 8600
+            - containerPort: {{ .Values.client.ports.dnsTcp.port }}
               name: dns-tcp
               protocol: "TCP"
-            - containerPort: 8600
+            - containerPort: {{ .Values.client.ports.dnsUdp.port }}
               name: dns-udp
               protocol: "UDP"
           readinessProbe:
@@ -335,9 +341,9 @@ spec:
                   {{- if .Values.global.tls.enabled }}
                   curl \
                     -k \
-                    https://127.0.0.1:8501/v1/status/leader \
+                    https://127.0.0.1:{{ .Values.client.ports.https.port }}/v1/status/leader \
                   {{- else }}
-                  curl http://127.0.0.1:8500/v1/status/leader \
+                  curl http://127.0.0.1:{{ .Values.client.ports.http.port }}/v1/status/leader \
                   {{- end }}
                   2>/dev/null | grep -E '".+"'
           {{- if .Values.client.resources }}

--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -34,22 +34,22 @@ spec:
   hostPorts:
   {{- if (not (and .Values.global.tls.enabled .Values.global.tls.httpsOnly)) }}
   # HTTP Port
-  - min: 8500
-    max: 8500
+  - min: {{ .Values.client.ports.http.port }}
+    max: {{ .Values.client.ports.http.port }}
   {{- end }}
   {{- if .Values.global.tls.enabled }}
   # HTTPS port
-  - min: 8501
-    max: 8501
+  - min: {{ .Values.client.ports.https.port }}
+    max: {{ .Values.client.ports.https.port }}
   {{- end }}
   {{- if .Values.client.grpc }}
   # gRPC Port
-  - min: 8502
-    max: 8502
+  - min: {{ .Values.client.ports.grpc.port }}
+    max: {{ .Values.client.ports.grpc.port }}
   {{- end }}
   {{- if .Values.client.exposeGossipPorts }}
-  - min: 8301
-    max: 8301
+  - min: {{ .Values.client.ports.serflanTcp.port }}
+    max: {{ .Values.client.ports.serflanTcp.port }}
   {{- end }}
   hostIPC: false
   hostPID: false

--- a/templates/client-snapshot-agent-deployment.yaml
+++ b/templates/client-snapshot-agent-deployment.yaml
@@ -87,12 +87,12 @@ spec:
                   fieldPath: status.hostIP
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
             {{- end }}
             {{- if .Values.global.acls.manageSystemACLs }}
             - name: CONSUL_HTTP_TOKEN

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -72,9 +72,9 @@ spec:
             {{- end }}
             - name: CONSUL_HTTP_ADDR
               {{- if .Values.global.tls.enabled }}
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
               {{- else }}
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
               {{- end }}
           command:
             - "/bin/sh"

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -104,9 +104,9 @@ spec:
         {{- end }}
         - name: CONSUL_HTTP_ADDR
           {{- if .Values.global.tls.enabled }}
-          value: https://$(HOST_IP):8501
+          value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
           {{- else }}
-          value: http://$(HOST_IP):8500
+          value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
           {{- end }}
         image: {{ .Values.global.imageK8S }}
         name: controller

--- a/templates/create-federation-secret-job.yaml
+++ b/templates/create-federation-secret-job.yaml
@@ -87,7 +87,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               {{- if .Values.global.tls.enableAutoEncrypt }}
               value: /consul/tls/client/ca/tls.crt

--- a/templates/ingress-gateways-deployment.yaml
+++ b/templates/ingress-gateways-deployment.yaml
@@ -143,12 +143,12 @@ spec:
                   fieldPath: metadata.name
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             {{- end }}
           command:
             - "/bin/sh"
@@ -319,16 +319,16 @@ spec:
             {{- end}}
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_GRPC_ADDR
-              value: https://$(HOST_IP):8502
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.grpc.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             - name: CONSUL_GRPC_ADDR
-              value: $(HOST_IP):8502
+              value: $(HOST_IP):{{ $root.Values.client.ports.grpc.port }}
             {{- end }}
           command:
             - /consul-bin/consul
@@ -411,12 +411,12 @@ spec:
                   fieldPath: status.podIP
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             {{- end }}
           command:
             - consul-k8s

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -120,12 +120,12 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
             {{- end }}
           command:
             - "/bin/sh"
@@ -279,16 +279,16 @@ spec:
             {{- end}}
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             - name: CONSUL_GRPC_ADDR
-              value: https://$(HOST_IP):8502
+              value: https://$(HOST_IP):{{ .Values.client.ports.grpc.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
             - name: CONSUL_GRPC_ADDR
-              value: $(HOST_IP):8502
+              value: $(HOST_IP):{{ .Values.client.ports.grpc.port }}
             {{- end }}
           command:
             - /consul-bin/consul
@@ -357,12 +357,12 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
             {{- end }}
           command:
             - consul-k8s

--- a/templates/sync-catalog-deployment.yaml
+++ b/templates/sync-catalog-deployment.yaml
@@ -82,7 +82,7 @@ spec:
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.client.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
             {{- else }}
             - name: CONSUL_HTTP_ADDR
               value: https://{{ template "consul.fullname" . }}-server:8501
@@ -92,7 +92,7 @@ spec:
             {{- else }}
             {{- if .Values.client.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
             {{- else }}
             - name: CONSUL_HTTP_ADDR
               value: http://{{ template "consul.fullname" . }}-server:8500

--- a/templates/terminating-gateways-deployment.yaml
+++ b/templates/terminating-gateways-deployment.yaml
@@ -157,12 +157,12 @@ spec:
                   fieldPath: metadata.name
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             {{- end }}
           command:
             - "/bin/sh"
@@ -270,16 +270,16 @@ spec:
             {{- end}}
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_GRPC_ADDR
-              value: https://$(HOST_IP):8502
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.grpc.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             - name: CONSUL_GRPC_ADDR
-              value: $(HOST_IP):8502
+              value: $(HOST_IP):{{ $root.Values.client.ports.grpc.port }}
             {{- end }}
           command:
             - /consul-bin/consul
@@ -357,12 +357,12 @@ spec:
                   fieldPath: status.podIP
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
+              value: https://$(HOST_IP):{{ $root.Values.client.ports.https.port }}
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- else }}
             - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
+              value: http://$(HOST_IP):{{ $root.Values.client.ports.http.port }}
             {{- end }}
           command:
             - consul-k8s

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -44,12 +44,12 @@ spec:
               fieldPath: status.hostIP
         {{- if .Values.global.tls.enabled }}
         - name: CONSUL_HTTP_ADDR
-          value: https://$(HOST_IP):8501
+          value: https://$(HOST_IP):{{ .Values.client.ports.https.port }}
         - name: CONSUL_CACERT
           value: /consul/tls/ca/tls.crt
         {{- else }}
         - name: CONSUL_HTTP_ADDR
-          value: http://$(HOST_IP):8500
+          value: http://$(HOST_IP):{{ .Values.client.ports.http.port }}
         {{- end }}
       {{- if .Values.global.tls.enabled }}
       volumeMounts:

--- a/test/unit/client-podsecuritypolicy.bats
+++ b/test/unit/client-podsecuritypolicy.bats
@@ -67,6 +67,41 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# client.ports
+
+@test "client/PodSecurityPolicy: hostPort default ports are set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'client.grpc=true' \
+      --set 'client.exposeGossipPorts=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":8500,"max":8500},{"min":8501,"max":8501},{"min":8502,"max":8502},{"min":8301,"max":8301}]' ]
+}
+
+@test "client/PodSecurityPolicy: hostPort default ports are customizable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'client.grpc=true' \
+      --set 'client.exposeGossipPorts=true' \
+      --set 'client.ports.http.port=32500' \
+      --set 'client.ports.https.port=32501' \
+      --set 'client.ports.grpc.port=32502' \
+      --set 'client.ports.serflanTcp.port=32301' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":32500,"max":32500},{"min":32501,"max":32501},{"min":32502,"max":32502},{"min":32301,"max":32301}]' ]
+}
+
+#--------------------------------------------------------------------
 # client.dataDirectoryHostPath
 
 @test "client/PodSecurityPolicy: disallows hostPath volume by default" {

--- a/test/unit/client-snapshot-agent-deployment.bats
+++ b/test/unit/client-snapshot-agent-deployment.bats
@@ -204,7 +204,36 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
-@test "client/SnapshotAgentDeployment: sets TLS env vars when global.tls.enabled" {
+@test "client/SnapshotAgentDeployment: sets Consul environment variables when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "client/SnapshotAgentDeployment: sets Consul environment variables when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
+@test "client/SnapshotAgentDeployment: sets Consul environment variables when global.tls.enabled" {
   cd `chart_dir`
   local env=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
@@ -216,6 +245,24 @@ load _helpers
   local actual
   actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "client/SnapshotAgentDeployment: sets Consul environment variables when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-snapshot-agent-deployment.yaml  \
+      --set 'client.snapshotAgent.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
 
   actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]

--- a/test/unit/controller-deployment.bats
+++ b/test/unit/controller-deployment.bats
@@ -78,6 +78,70 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
+@test "controller/Deployment: sets Consul environment variables when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "controller/Deployment: sets Consul environment variables when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
+@test "controller/Deployment: sets Consul environment variables when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "controller/Deployment: sets Consul environment variables when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
+
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
 @test "controller/Deployment: Adds tls-ca-cert volume when global.tls.enabled is true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/sync-catalog-deployment.bats
+++ b/test/unit/sync-catalog-deployment.bats
@@ -477,6 +477,33 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
+@test "syncCatalog/Deployment: sets Consul environment variables when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "syncCatalog/Deployment: sets Consul environment variables when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
 @test "syncCatalog/Deployment: sets Consul environment variables when global.tls.enabled" {
   cd `chart_dir`
   local env=$(helm template \
@@ -484,14 +511,30 @@ load _helpers
       --set 'syncCatalog.enabled=true' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
 
-  local actual
-  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = 'https://$(HOST_IP):8501' ]
 
-  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
-    [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "syncCatalog/Deployment: sets Consul environment variables when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
 }
 
 @test "syncCatalog/Deployment: can overwrite CA secret with the provided one" {

--- a/test/unit/terminating-gateways-deployment.bats
+++ b/test/unit/terminating-gateways-deployment.bats
@@ -101,10 +101,110 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
-@test "terminatingGateways/Deployment: sets TLS env variables when global.tls.enabled" {
+@test "terminatingGateways/Deployment: sets Consul environment variables for init container when global.tls.enabled=false" {
   cd `chart_dir`
   local env=$(helm template \
-      -s templates/terminating-gateways-deployment.yaml \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables for init container when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables for init container when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables for init container when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = '$(HOST_IP):8502' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables when global.tls.enabled=false and custom client HTTP/GRPC port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      --set 'client.ports.grpc.port=32502' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = '$(HOST_IP):32502' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.tls.enabled=true' \
@@ -121,10 +221,61 @@ load _helpers
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]
 }
 
-@test "terminatingGateways/Deployment: sets TLS env variables in consul sidecar when global.tls.enabled" {
+@test "terminatingGateways/Deployment: sets Consul environment variables when global.tls.enabled and custom client HTTPS/GRPC port set" {
   cd `chart_dir`
   local env=$(helm template \
-      -s templates/terminating-gateways-deployment.yaml \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      --set 'client.ports.grpc.port=32502' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_GRPC_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32502' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables in consul sidecar when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables in consul sidecar when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables in consul sidecar when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.tls.enabled=true' \
@@ -133,6 +284,24 @@ load _helpers
 
   local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: sets Consul environment variables in consul sidecar when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
 
   local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]

--- a/test/unit/test-runner.bats
+++ b/test/unit/test-runner.bats
@@ -18,3 +18,66 @@ load _helpers
       --set 'tests.enabled=false' \
       .
 }
+
+#--------------------------------------------------------------------
+# global.tls.enabled
+
+@test "testRunner/Pod: sets Consul environment variables when global.tls.enabled=false" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'tests.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):8500' ]
+}
+
+@test "testRunner/Pod: sets Consul environment variables when global.tls.enabled=false and custom client HTTP port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'tests.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'client.ports.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'http://$(HOST_IP):32500' ]
+}
+
+@test "testRunner/Pod: sets Consul environment variables when global.tls.enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'tests.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):8501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "testRunner/Pod: sets Consul environment variables when global.tls.enabled and custom client HTTPS port set" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'tests.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'client.ports.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.containers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOST_IP):32501' ]
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -736,6 +736,23 @@ client:
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
 
+  ports:
+  # Customizes ports for the different client functionalities.
+    serflanTcp:
+      port: 8301
+    serflanUdp:
+      port: 8301
+    http:
+      port: 8500
+    https:
+      port: 8501
+    grpc:
+      port: 8502
+    dnsTcp:
+      port: 8600
+    dnsUdp:
+      port: 8600
+
   serviceAccount:
     # This value defines additional annotations for the client service account. This should be formatted as a multi-line
     # string.


### PR DESCRIPTION
Changes proposed in this PR:
* The background and reasoning behind this PR is related to #997 (i.e. to avoid `--service-node-port-range` customization)
* Furthermore this PR is also related to various old PRs and issues to make the Consul client ports customizable. We are aware that changing the ports (especially for HTTPS and gRPC) will brick the inject workflow due to hardcoded ports in consul-k8s. 
  - #126
  - #268 
  - #597 
  - #803
  - #804
* For the consul-k8s counterpart see https://github.com/hashicorp/consul-k8s/issues/544
* Fixes #997

How I've tested this PR:
- Wrote unit tests and executed them
- Deployed on Rancher (K8s 1.18, 1.19 and 1.21.1) with adjusted ports (32500, 32501, 32502) + Mesh GWs, then check if Mesh GWs have been successfully registered. App inject depends on separate consul-k8s PR.

How I expect reviewers to test this PR:
- Run standard deployment using the default `values.yml`
- Adjust one of the Consul client ports, do a full deployment, check if the Mesh GWs have registered successfully

Checklist:
- [x] Bats tests added
- [n/a] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

