### PR TITLE
Bump api/sdk versions in acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,7 +661,6 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance-gke-1-17
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ commands:
       - run:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
+            env
+
             wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -225,7 +225,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,10 @@ commands:
       - run:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
-            env
-            which go
-            
             wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+            sudo rm -rf /home/circleci/.go_workspace/go && sudo tar -C /home/circleci/.go_workspace -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
+            go version
 
             go get gotest.tools/gotestsum
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run:
           name: go mod download
@@ -135,7 +135,7 @@ jobs:
 
       # Save go module cache if the go.mod file has changed
       - save_cache:
-          key: consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+          key: consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
           paths:
             - "/go/pkg/mod"
 
@@ -164,7 +164,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -193,7 +193,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -225,7 +225,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -286,7 +286,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -341,7 +341,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -407,7 +407,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -461,7 +461,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ commands:
             sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
-            go version
 
             go get gotest.tools/gotestsum
 
@@ -35,7 +34,6 @@ commands:
             echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
             sudo apt-get update
             sudo apt-get install helm
-            helm version
   create-kind-clusters:
     parameters:
       version:
@@ -108,7 +106,7 @@ commands:
 jobs:
   unit-helm:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.1
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
 
     steps:
       - checkout
@@ -192,7 +190,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -224,7 +222,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -247,7 +245,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
 
     steps:
       - run:
@@ -313,7 +311,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
 
     steps:
       - checkout
@@ -368,7 +366,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
 
     steps:
       - checkout
@@ -435,7 +433,7 @@ jobs:
     parallelism: 3
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
 
     steps:
       - checkout
@@ -623,7 +621,7 @@ jobs:
 
   cleanup-azure-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -637,7 +635,7 @@ jobs:
 
   cleanup-gcp-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -663,6 +661,7 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
+      - acceptance-gke-1-17
       - acceptance:
           requires:
             - unit-helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,13 @@ commands:
       - run:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
+            env
+            which go
+            
             wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
-            sudo rm -rf /home/circleci/.go_workspace/go && sudo tar -C /home/circleci/.go_workspace -xzf go1.16.5.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz
-            go version
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
 
             go get gotest.tools/gotestsum
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ commands:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
             env
-
+            which go
+            
             wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     environment:
       - TEST_RESULTS: /tmp/test-results
 
@@ -14,6 +14,12 @@ commands:
       - run:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
+            wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+            rm go1.16.5.linux-amd64.tar.gz
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
+            go version
+
             go get gotest.tools/gotestsum
 
             curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
@@ -29,6 +35,7 @@ commands:
             echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
             sudo apt-get update
             sudo apt-get install helm
+            helm version
   create-kind-clusters:
     parameters:
       version:
@@ -134,6 +141,7 @@ jobs:
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
           name: check go fmt
+          working_directory: test/acceptance
           command: |
             files=$(go fmt ./...)
             if [ -n "$files" ]; then
@@ -530,6 +538,7 @@ jobs:
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
           name: check go fmt
+          working_directory: hack/helm-reference-gen
           command: |
             files=$(go fmt ./...)
             if [ -n "$files" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run:
           name: go mod download
@@ -132,7 +132,7 @@ jobs:
 
       # Save go module cache if the go.mod file has changed
       - save_cache:
-          key: consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+          key: consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
           paths:
             - "/go/pkg/mod"
 
@@ -161,7 +161,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -190,7 +190,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -222,7 +222,7 @@ jobs:
           version: "v1.20.7"
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: test/acceptance
@@ -283,7 +283,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -338,7 +338,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -404,7 +404,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 
@@ -458,7 +458,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-helm-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-helm-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,14 @@ commands:
       - run:
           name: Install gotestsum, kind, kubectl, and helm
           command: |
-            env
-            which go
-            
             wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
             rm go1.16.5.linux-amd64.tar.gz
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
 
-            go get gotest.tools/gotestsum
+            wget https://github.com/gotestyourself/gotestsum/releases/download/v1.6.4/gotestsum_1.6.4_linux_amd64.tar.gz
+            sudo tar -C /usr/local/bin -xzf gotestsum_1.6.4_linux_amd64.tar.gz
+            rm gotestsum_1.6.4_linux_amd64.tar.gz
 
             curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
             chmod +x ./kind

--- a/test/acceptance/go.mod
+++ b/test/acceptance/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/gruntwork-io/terratest v0.31.2
-	github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad
-	github.com/hashicorp/consul/sdk v0.7.0
+	github.com/hashicorp/consul/api v1.9.0
+	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.19.3

--- a/test/acceptance/go.sum
+++ b/test/acceptance/go.sum
@@ -227,8 +227,12 @@ github.com/gruntwork-io/terratest v0.31.2 h1:xvYHA80MUq5kx670dM18HInewOrrQrAN+Xb
 github.com/gruntwork-io/terratest v0.31.2/go.mod h1:EEgJie28gX/4AD71IFqgMj6e99KP5mi81hEtzmDjxTo=
 github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad h1:nynVR0qTR2vUCY8j0PqwcyjhlkwcLov/mnNiDQoBRjw=
 github.com/hashicorp/consul/api v1.4.1-0.20210614201509-ffb13f35f1ad/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
+github.com/hashicorp/consul/api v1.9.0 h1:T6dKIWcaihG2c21YUi0BMAHbJanVXiYuz+mPgqxY3N4=
+github.com/hashicorp/consul/api v1.9.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.7.0 h1:H6R9d008jDcHPQPAqPNuydAshJ4v5/8URdFnUvK/+sc=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
+github.com/hashicorp/consul/sdk v0.8.0 h1:OJtKBtEjboEZvG6AOUdh4Z1Zbyu0WcxQ0qatRrZHTVU=
+github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -6,7 +6,7 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM circleci/golang:1.14
+FROM circleci/golang:1.16
 
 # change the user to root so we can install stuff
 USER root


### PR DESCRIPTION
Changes proposed in this PR:
- bump consul's api/sdk versions in acceptance tests
- Update go to 1.16 in machine executors and in the test docker image

How I've tested this PR:
- CI

How I expect reviewers to test this PR:
code review


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

