### PR TITLE
Add optional Consul client nodePort service if hostPorts are not available

### DIFF
--- a/templates/client-podsecuritypolicy.yaml
+++ b/templates/client-podsecuritypolicy.yaml
@@ -31,6 +31,7 @@ spec:
   {{- else }}
   hostNetwork: false
   {{- end }}
+  {{- if (not .Values.client.service.enabled) }}
   hostPorts:
   {{- if (not (and .Values.global.tls.enabled .Values.global.tls.httpsOnly)) }}
   # HTTP Port
@@ -50,6 +51,7 @@ spec:
   {{- if .Values.client.exposeGossipPorts }}
   - min: 8301
     max: 8301
+  {{- end }}
   {{- end }}
   hostIPC: false
   hostPID: false

--- a/templates/client-securitycontextconstraints.yaml
+++ b/templates/client-securitycontextconstraints.yaml
@@ -19,7 +19,11 @@ allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: {{ .Values.client.hostNetwork }}
 allowHostPID: false
+{{- if (not .Values.client.service.enabled) }}
 allowHostPorts: true
+{{- else }}
+allowHostPorts: false
+{{- end }}
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: null

--- a/templates/client-service.yaml
+++ b/templates/client-service.yaml
@@ -1,0 +1,51 @@
+{{- if (and (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) .Values.client.service.enabled) }}
+# Optional NodePort Service for Consul client
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "consul.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: client
+  {{- if .Values.client.service.annotations }}
+  annotations:
+    {{ tpl .Values.client.service.annotations . | nindent 4 | trim }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ template "consul.name" . }}
+    release: "{{ .Release.Name }}"
+    component: client
+  ports:
+    {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
+    - name: http
+      protocol: TCP
+      port: {{ .Values.client.service.nodePorts.http.port }}
+      nodePort: {{ .Values.client.service.nodePorts.http.nodePort }}
+      targetPort: {{ .Values.client.service.nodePorts.http.targetPort }}
+    {{- end }}
+    {{- if .Values.global.tls.enabled }}
+    - name: https
+      protocol: TCP
+      port: {{ .Values.client.service.nodePorts.https.port }}
+      nodePort: {{ .Values.client.service.nodePorts.https.nodePort }}
+      targetPort: {{ .Values.client.service.nodePorts.https.targetPort }}
+    {{- end }}
+    - name: grpc
+      protocol: TCP
+      port: {{ .Values.client.service.nodePorts.grpc.port }}
+      nodePort: {{ .Values.client.service.nodePorts.grpc.nodePort }}
+      targetPort: {{ .Values.client.service.nodePorts.grpc.targetPort }}
+  type: NodePort
+  {{- if .Values.client.service.topologyKeys }}
+  topologyKeys:
+    {{ tpl .Values.client.service.topologyKeys . | nindent 4 | trim }}
+  {{- end }}
+  {{- if .Values.client.service.additionalSpec }}
+  {{ tpl .Values.client.service.additionalSpec . | nindent 2 | trim }}
+  {{- end }}
+{{- end }}

--- a/test/unit/client-podsecuritypolicy.bats
+++ b/test/unit/client-podsecuritypolicy.bats
@@ -67,6 +67,30 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# client.service
+
+@test "client/PodSecurityPolicy: hostPorts enabled and nodePort service disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" != '' ]
+}
+
+@test "client/PodSecurityPolicy: hostPorts disabled when nodePort service is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = 'null' ]
+}
+
+#--------------------------------------------------------------------
 # client.dataDirectoryHostPath
 
 @test "client/PodSecurityPolicy: disallows hostPath volume by default" {

--- a/test/unit/client-securitycontextconstraints.bats
+++ b/test/unit/client-securitycontextconstraints.bats
@@ -28,6 +28,9 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# client.service
+
 @test "client/SecurityContextConstraints: host ports are allowed by default" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -38,6 +41,16 @@ load _helpers
   [ "${actual}" = 'true' ]
 }
 
+@test "client/SecurityContextConstraints: host ports are disallowed with client.service.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-securitycontextconstraints.yaml  \
+      --set 'global.openshift.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -c '.allowHostPorts' | tee /dev/stderr)
+  [ "${actual}" = 'false' ]
+}
 
 #--------------------------------------------------------------------
 # client.dataDirectoryHostPath

--- a/test/unit/client-service.bats
+++ b/test/unit/client-service.bats
@@ -1,0 +1,390 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "client/Service: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/client-service.yaml  \
+      .
+}
+
+@test "client/Service: disabled with global.enabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.enabled=true' \
+      .
+}
+
+@test "client/Service: disabled with client.enabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      .
+}
+
+@test "client/Service: enabled with global.enabled=true and client.service.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/Service: enabled with client.enabled=true and client.service.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# global.tls.enabled
+
+@test "client/Service: no HTTPS listener when TLS is disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=false' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "https") | .port' | tee /dev/stderr)
+  [ "${actual}" == "" ]
+}
+
+@test "client/Service: HTTPS listener set when TLS is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "https") | .port' | tee /dev/stderr)
+  [ "${actual}" == "8501" ]
+}
+
+@test "client/Service: HTTP listener still active when httpsOnly is disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "http") | .port' | tee /dev/stderr)
+  [ "${actual}" == "8500" ]
+}
+
+@test "client/Service: no HTTP listener when httpsOnly is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "http") | .port' | tee /dev/stderr)
+  [ "${actual}" == "" ]
+}
+
+#--------------------------------------------------------------------
+# nodePorts http
+
+@test "client/Service: has default HTTP port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8500" ]
+}
+
+@test "client/Service: can set HTTP port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.http.port=32500' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "32500" ]
+}
+
+@test "client/Service: has default HTTP nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "8500" ]
+}
+
+@test "client/Service: can set HTTP nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.http.nodePort=32500' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "32500" ]
+}
+
+@test "client/Service: has default HTTP targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8500" ]
+}
+
+@test "client/Service: can set HTTP targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.http.targetPort=32500' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "32500" ]
+}
+
+#--------------------------------------------------------------------
+# nodePorts https
+
+@test "client/Service: has default HTTPS port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8501" ]
+}
+
+@test "client/Service: can set HTTPS port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.https.port=32501' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "32501" ]
+}
+
+@test "client/Service: has default HTTPS nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "8501" ]
+}
+
+@test "client/Service: can set HTTPS nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.https.nodePort=32501' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "32501" ]
+}
+
+@test "client/Service: has default HTTPS targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8501" ]
+}
+
+@test "client/Service: can set HTTPS targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.https.targetPort=32501' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "32501" ]
+}
+
+#--------------------------------------------------------------------
+# nodePorts grpc
+
+@test "client/Service: has default GRPC port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].port' | tee /dev/stderr)
+  [ "${actual}" = "8502" ]
+}
+
+@test "client/Service: can set GRPC port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.grpc.port=32502' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].port' | tee /dev/stderr)
+  [ "${actual}" = "32502" ]
+}
+
+@test "client/Service: has default GRPC nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "8502" ]
+}
+
+@test "client/Service: can set GRPC nodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.grpc.nodePort=32502' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "32502" ]
+}
+
+@test "client/Service: has default GRPC targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8502" ]
+}
+
+@test "client/Service: can set GRPC targetPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.nodePorts.grpc.targetPort=32502' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[1].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "32502" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "client/Service: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "client/Service: can set annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.annotations=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+#--------------------------------------------------------------------
+# topologyKeys
+
+@test "client/Service: no topologyKeys by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.topologyKeys' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "client/Service: can add topologyKeys" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.topologyKeys=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.topologyKeys.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+#--------------------------------------------------------------------
+# additionalSpec
+
+@test "client/Service: can add additionalSpec" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-service.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.service.enabled=true' \
+      --set 'client.service.additionalSpec=key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -736,6 +736,72 @@ client:
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
 
+  # Configure an optional NodePort service for the Consul client in case
+  # HostPorts are not available. Activating this service will also disable any
+  # hostPort security capabilities.
+  #
+  # Note: This will also require the feature gate `ServiceTopology` for
+  # Kubernetes < v1.21 and `TopologyAwareHints` for Kubernetes >= v1.21
+  # respectively activated. If the Consul client standard ports (e.g. `8051`)
+  # are used the `--service-node-port-range` of Kubernetes must be extended
+  # from the default range `30000-32767` to also include the Consul client
+  # ports (e.g. `8500-32767`). In most scenarios it is recommended to adjust
+  # the Consul client ports to be within the default NodePort service range.
+  service:
+    # This will enable/disable registering a Kubernetes NodePort Service for
+    # the Consul client. This value only takes effect if `client.enabled` or
+    # `global.enabled` is true.
+    enabled: false
+
+    # Customize the nodePort values of the client NodePort service.
+    # Note: These ports must match with the configured client ports.
+    nodePorts:
+      http:
+        port: 8500
+        nodePort: 8500
+        targetPort: 8500
+      https:
+        port: 8501
+        nodePort: 8501
+        targetPort: 8501
+      grpc:
+        port: 8502
+        nodePort: 8502
+        targetPort: 8502
+
+    # Annotations to apply to the nodePort client service. If
+    # `TopologyAwareHints` are used with Kubernetes >= v1.21 configure the
+    # required hints here.
+    #
+    # Example:
+    #
+    # ```yaml
+    # annotations: |
+    #   'annotation-key': annotation-value
+    #   service.kubernetes.io/topology-aware-hints: auto
+    # ```
+    # @type: string
+    annotations: null
+
+    # TopologyKeys to apply to the nodePort client service. If
+    # `ServiceTopology` is used with Kubernetes < v1.21 configure the required
+    # keys here.
+    #
+    # Example:
+    #
+    # ```yaml
+    # topologyKeys: |
+    #   - "kubernetes.io/hostname"
+    # ```
+    # @type: string
+    topologyKeys: null
+
+    # Additional ServiceSpec values
+    # This should be a multi-line string mapping directly to a Kubernetes
+    # ServiceSpec object.
+    # @type: string
+    additionalSpec: null
+
   serviceAccount:
     # This value defines additional annotations for the client service account. This should be formatted as a multi-line
     # string.


### PR DESCRIPTION
Changes proposed in this PR:
- The background and reasoning behind this PR is related to #997 (i.e. to make it possible to deploy Consul in K8s environments where `hostPort` is not available or simply not permitted) and https://github.com/hashicorp/consul-k8s/issues/544
- Fixes #997

How I've tested this PR:
- Wrote unit tests and executed them
- Deployed on Rancher with Kubernetes 1.18, 1.19 and 1.21 to test the topologyKeys and topology hints annotations
- Deployed in combination with the other PRs referenced in the issue

How I expect reviewers to test this PR:
- Ideally this is tested in combination with the other PRs referenced in the issue to allow the client port customization
- If the ports can't be customized the `--service-node-port-range` K8s option must be extended to include the 85XY ports

Checklist:
- [x] Bats tests added
- [n/a] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

