### PR TITLE
Add new options to overwrite consul-k8s inject-connect Consul client ports

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -92,6 +92,9 @@ spec:
                 -release-name="{{ .Release.Name }}" \
                 -release-namespace="{{ .Release.Namespace }}" \
                 -listen=:8080 \
+                -consul-client-port-http={{ .Values.connectInject.clientPorts.http }} \
+                -consul-client-port-https={{ .Values.connectInject.clientPorts.https }} \
+                -consul-client-port-grpc={{ .Values.connectInject.clientPorts.grpc }} \
                 {{- if .Values.connectInject.transparentProxy.defaultEnabled }}
                 -default-enable-transparent-proxy=true \
                 {{- else }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -913,6 +913,54 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# clientPorts
+
+@test "connectInject/Deployment: default client ports" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-http=8500"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-https=8501"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-grpc=8502"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: can set client ports" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.clientPorts.http=32500' \
+      --set 'connectInject.clientPorts.https=32501' \
+      --set 'connectInject.clientPorts.grpc=32502' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-http=32500"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-https=32501"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-consul-client-port-grpc=32502"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # resources
 
 @test "connectInject/Deployment: default resources" {

--- a/values.yaml
+++ b/values.yaml
@@ -1617,6 +1617,13 @@ connectInject:
     # @type: string
     secretKey: null
 
+  # Configures on which ports the Consul clients are reachable for the Connect
+  # inject init container.
+  clientPorts:
+    http: 8500
+    https: 8501
+    grpc: 8502
+
   sidecarProxy:
     # Set default resources for sidecar proxy. If null, that resource won't
     # be set.


### PR DESCRIPTION
Changes proposed in this PR:
- This PR is the counterpart to https://github.com/hashicorp/consul-k8s/issues/544 and https://github.com/hashicorp/consul-k8s/pull/545. It allows the customization of new consul-k8s inject-connect parameters. These make it possible to adjust on which ports the Consul clients are reachable for the inject-connect init containers. Currently all Consul client ports are hardcoded, this PR tries to solve that.
- The background and reasoning behind this PR is related to #997 (i.e. to avoid `--service-node-port-range` customization)
- Fixes #997 

How I've tested this PR:
- Wrote unit tests and executed them
- Deployed connect-inject based on the self-built consul-k8s image that includes the above mentioned PR, then checked the connect-inject deployment if it included the new parameters and also if an example NGINX hello world app was registered correctly
- Did the same again but this time with all the PRs referenced in the issue and customized the ports to `3250X`

How I expect reviewers to test this PR:
- Quickly build a consul-k8s image with the above mentioned PR, then deploy connect-inject. Check if the Helm-provided parameters of this PR are part of the connect-inject deployment. Finally verify that service registration still works. Testing the deployment with custom ports is only possible if all PRs referenced in #997 are used.

Checklist:
- [x] Bats tests added
- [n/a] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

