### PR TITLE
server-acl-init: Support connecting to external servers with an SNI header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+BUG FIXES:
+* ACLs: Support connecting to external Consul servers with an SNI header. [[GH-1005](https://github.com/hashicorp/consul-helm/pull/1005)]
+
 ## 0.32.0 (June 22, 2021)
 
 FEATURES:

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -121,6 +121,9 @@ spec:
                 {{- if not .Values.externalServers.enabled }}
                 -server-port=8501 \
                 {{- end }}
+                {{- if .Values.externalServers.tlsServerName }}
+                -consul-tls-server-name={{ .Values.externalServers.tlsServerName }} \
+                {{- end }}
                 {{- end }}
 
                 {{- if .Values.syncCatalog.enabled }}

--- a/test/unit/server-acl-init-job.bats
+++ b/test/unit/server-acl-init-job.bats
@@ -1244,6 +1244,18 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/Job: sets TLS server name if externalServers.tlsServerName is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'externalServers.tlsServerName=foo' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-tls-server-name=foo"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # global.acls.bootstrapToken
 


### PR DESCRIPTION
Changes proposed in this PR:
Currently, when running with consul servers outside the k8s clusters and using ACLs, the server-acl-init job will expect the server's host to be included in the server's certificate. However, if you're connecting to the server over pod or node IPs, that IP will not be included in the certificate. These use cases are typically solved by providing an SNI header when connecting to the server (`externalServers.tlsServerName` in this case), however, we were not setting this property as a flag for the server-acl-init command.

How I've tested this PR:
Manually by deploying external servers on another k8s cluster and using a flat pod and node networks.

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

