### PR TITLE
Some providers do not support ingress pathType: Prefix

### DIFF
--- a/templates/ui-ingress.yaml
+++ b/templates/ui-ingress.yaml
@@ -40,7 +40,7 @@ spec:
             port:
               number: 80
         path: {{ . }}
-        pathType: Prefix
+        pathType: {{ $.Values.ui.ingress.pathType }}
       {{- end }}
       {{- if $global.tls.enabled }}
       - backend:
@@ -49,7 +49,7 @@ spec:
             port:
               number: 443
         path: {{ . }}
-        pathType: Prefix
+        pathType: {{ $.Values.ui.ingress.pathType }}
       {{- end }}
       {{- end }}
   {{- end }}

--- a/test/unit/ui-ingress.bats
+++ b/test/unit/ui-ingress.bats
@@ -202,3 +202,29 @@ load _helpers
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# pathtype
+
+@test "ui/Ingress: default PathType Prefix" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'global.tls.enabled=false' \
+    --set 'ui.ingress.hosts[0].host=foo.com' \
+    . | tee /dev/stderr |
+    yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
+  [ "${actual}" = "Prefix" ]
+}
+
+@test "ui/Ingress: set PathType ImplementationSpecific" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'ui.ingress.pathType=ImplementationSpecific' \
+    --set 'global.tls.enabled=false' \
+    --set 'ui.ingress.hosts[0].host=foo.com' \
+    . | tee /dev/stderr |
+    yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
+  [ "${actual}" = "ImplementationSpecific" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1400,7 +1400,7 @@ connectInject:
     defaultEnabled: "-"
     # Configures the Consul sidecar to run a merged metrics server
     # to combine and serve both Envoy and Connect service metrics.
-    # This feature is available only in Consul v1.10-alpha or greater.
+    # This feature is available only in Consul v1.10.0 or greater.
     defaultEnableMerging: false
     # Configures the port at which the Consul sidecar will listen on to return
     # combined metrics. This port only needs to be changed if it conflicts with

--- a/values.yaml
+++ b/values.yaml
@@ -1072,6 +1072,9 @@ ui:
     # @type: boolean
     enabled: false
 
+    # pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+    pathType: Prefix
+
     # hosts is a list of host name to create Ingress rules.
     #
     # ```yaml


### PR DESCRIPTION
Changes proposed in this PR:
- Make PathType a parameter so it can be overridden (for example on the latest GKE 1.19.10)

How I've tested this PR:
`helm template` with a test.yaml that enables ingress and has a test host
Also tried the "bats" test? (`make`)


How I expect reviewers to test this PR:
see above?

If you want to test overriding the value, it would be like

`helm install consul . -f test.yaml`

test.yaml:
```yaml
ui:
  ingress:
    enabled: true
    pathType: ImplementationSpecific
    hosts:
      - host: foo.bar
        paths:
          - /
```

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)


Fixes: #1011 