### PR TITLE
values.yaml: remove alpha reference in metrics merging defaultEnableMerging config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1400,7 +1400,7 @@ connectInject:
     defaultEnabled: "-"
     # Configures the Consul sidecar to run a merged metrics server
     # to combine and serve both Envoy and Connect service metrics.
-    # This feature is available only in Consul v1.10-alpha or greater.
+    # This feature is available only in Consul v1.10.0 or greater.
     defaultEnableMerging: false
     # Configures the port at which the Consul sidecar will listen on to return
     # combined metrics. This port only needs to be changed if it conflicts with


### PR DESCRIPTION
Changes proposed in this PR:
- Remove `alpha` from defaultEnableMerging` config comments so it is properly reflected on the Helm reference docs which are currently generated. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

