### PR TITLE
Fail scheduling all pods that are not part of consul when the webhook is offline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,12 +663,14 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - cleanup-gcp-resources
-      - acceptance-gke-1-17:
+      - acceptance:
           requires:
-            - unit-acceptance-framework
             - unit-helm
-            - cleanup-gcp-resources
+            - unit-acceptance-framework
+      - acceptance-tproxy:
+          requires:
+            - unit-helm
+            - unit-acceptance-framework
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,14 +663,12 @@ workflows:
             - go-fmt-and-vet-helm-gen
       - test-helm-gen
       - unit-helm
-      - acceptance:
+      - cleanup-gcp-resources
+      - acceptance-gke-1-17:
           requires:
-            - unit-helm
             - unit-acceptance-framework
-      - acceptance-tproxy:
-          requires:
             - unit-helm
-            - unit-acceptance-framework
+            - cleanup-gcp-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 IMPROVEMENTS:
+* Set failurePolicy to Fail for connectInject mutating webhook so that pods fail to schedule when the webhook is offline. [[GH-1024](https://github.com/hashicorp/consul-helm/pull/1024)]
 * Allow setting global.logLevel and global.logJSON and propogate this to all consul-k8s commands. [[GH-980](https://github.com/hashicorp/consul-helm/pull/980)]
 
 ## 0.32.1 (June 29, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 IMPROVEMENTS:
-* Set failurePolicy to Fail for connectInject mutating webhook so that pods fail to schedule when the webhook is offline. This can be controlled via `connectInject.failurePolicy` in helm.[[GH-1024](https://github.com/hashicorp/consul-helm/pull/1024)]
+* Set failurePolicy to Fail for connectInject mutating webhook so that pods fail to schedule when the webhook is offline. This can be controlled via `connectInject.failurePolicy`. [[GH-1024](https://github.com/hashicorp/consul-helm/pull/1024)]
 * Allow setting global.logLevel and global.logJSON and propogate this to all consul-k8s commands. [[GH-980](https://github.com/hashicorp/consul-helm/pull/980)]
 
 ## 0.32.1 (June 29, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 IMPROVEMENTS:
-* Set failurePolicy to Fail for connectInject mutating webhook so that pods fail to schedule when the webhook is offline. [[GH-1024](https://github.com/hashicorp/consul-helm/pull/1024)]
+* Set failurePolicy to Fail for connectInject mutating webhook so that pods fail to schedule when the webhook is offline. This can be controlled via `connectInject.failurePolicy` in helm.[[GH-1024](https://github.com/hashicorp/consul-helm/pull/1024)]
 * Allow setting global.logLevel and global.logJSON and propogate this to all consul-k8s commands. [[GH-980](https://github.com/hashicorp/consul-helm/pull/980)]
 
 ## 0.32.1 (June 29, 2021)

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -13,12 +13,16 @@ metadata:
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
     # The webhook will fail scheduling all pods that are not part of consul if all replicas of the webhook are unhealthy.
+    {{- if .Values.connectInject.failurePolicy }}
     objectSelector:
       matchExpressions:
       - key: app
         operator: NotIn
         values: [ {{ template "consul.name" . }} ]
     failurePolicy: {{ .Values.connectInject.failurePolicy }}
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     sideEffects: None
     admissionReviewVersions:
     - "v1beta1"

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -18,7 +18,7 @@ webhooks:
       - key: app
         operator: NotIn
         values: [ {{ template "consul.name" . }} ]
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.connectInject.failurePolicy }}
     sideEffects: None
     admissionReviewVersions:
     - "v1beta1"

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -12,7 +12,13 @@ metadata:
     release: {{ .Release.Name }}
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
-    failurePolicy: Ignore
+    # The webhook will fail scheduling all pods that are not part of consul if all replicas of the webhook are unhealthy.
+    objectSelector:
+      matchExpressions:
+      - key: app
+        operator: NotIn
+        values: [ {{ template "consul.name" . }} ]
+    failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
     - "v1beta1"

--- a/templates/connect-inject-mutatingwebhook.yaml
+++ b/templates/connect-inject-mutatingwebhook.yaml
@@ -13,16 +13,12 @@ metadata:
 webhooks:
   - name: {{ template "consul.fullname" . }}-connect-injector.consul.hashicorp.com
     # The webhook will fail scheduling all pods that are not part of consul if all replicas of the webhook are unhealthy.
-    {{- if .Values.connectInject.failurePolicy }}
     objectSelector:
       matchExpressions:
       - key: app
         operator: NotIn
         values: [ {{ template "consul.name" . }} ]
     failurePolicy: {{ .Values.connectInject.failurePolicy }}
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     sideEffects: None
     admissionReviewVersions:
     - "v1beta1"

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -58,7 +58,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	// If Kind is being used they use a pod to provision the underlying PV which will hang if we
 	// use "Fail" for the webhook failurePolicy.
 	if t.UseKind {
-		setIfNotEmpty(helmValues, "global.connectInject.failurePolicy", "")
+		helmValues["global.connectInject.failurePolicy"] = ""
 	}
 	// Set the enterprise image first if enterprise tests are enabled.
 	// It can be overwritten by the -consul-image flag later.

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -58,7 +58,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	// If Kind is being used they use a pod to provision the underlying PV which will hang if we
 	// use "Fail" for the webhook failurePolicy.
 	if t.UseKind {
-		setIfNotEmpty(helmValues, "global.connectInject.failurePolicy", "Ignore")
+		setIfNotEmpty(helmValues, "global.connectInject.failurePolicy", "")
 	}
 	// Set the enterprise image first if enterprise tests are enabled.
 	// It can be overwritten by the -consul-image flag later.

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -58,7 +58,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	// If Kind is being used they use a pod to provision the underlying PV which will hang if we
 	// use "Fail" for the webhook failurePolicy.
 	if t.UseKind {
-		helmValues["global.connectInject.failurePolicy"] = ""
+		helmValues["connectInject.failurePolicy"] = "Ignore"
 	}
 	// Set the enterprise image first if enterprise tests are enabled.
 	// It can be overwritten by the -consul-image flag later.

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -55,6 +55,11 @@ type TestConfig struct {
 func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	helmValues := map[string]string{}
 
+	// If Kind is being used they use a pod to provision the underlying PV which will hang if we
+	// use "Fail" for the webhook failurePolicy.
+	if t.UseKind {
+		setIfNotEmpty(helmValues, "global.connectInject.failurePolicy", "Ignore")
+	}
 	// Set the enterprise image first if enterprise tests are enabled.
 	// It can be overwritten by the -consul-image flag later.
 	if t.EnableEnterprise {

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -58,7 +58,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	// If Kind is being used they use a pod to provision the underlying PV which will hang if we
 	// use "Fail" for the webhook failurePolicy.
 	if t.UseKind {
-		helmValues["connectInject.failurePolicy"] = "Ignore"
+		setIfNotEmpty(helmValues, "connectInject.failurePolicy", "Ignore")
 	}
 	// Set the enterprise image first if enterprise tests are enabled.
 	// It can be overwritten by the -consul-image flag later.

--- a/values.yaml
+++ b/values.yaml
@@ -1483,7 +1483,7 @@ connectInject:
       memory: "50Mi"
       cpu: "50m"
 
-  # Sets the failurePolicy for the mutating webhook. By default this will cause pods to fail scheduling while the webhook
+  # Sets the failurePolicy for the mutating webhook. By default this will cause pods not part of the consul installation to fail scheduling while the webhook
   # is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
   # Once the webhook is back online the pod will be scheduled.
   # In some environments such as Kind this may have an undesirable effect as it may prevent volume provisioner pods from running

--- a/values.yaml
+++ b/values.yaml
@@ -1484,10 +1484,11 @@ connectInject:
       cpu: "50m"
 
   # Sets the failurePolicy for the mutating webhook. By default this will cause pods to fail scheduling while the webhook
-  # is offline. This has the effect of forcing a pod which is connect-injected to avoid skipping mutation if the
-  # webhook were to be momentarily offline, once the webhook is back online the pod will be scheduled.
-  # In some docker based environments such as Kind this may have an undesirable effect as it uses pods to provision storage volumes in
-  # special namespaces which can cause hangs. This setting can be disabled by setting to "Ignore".
+  # is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
+  # Once the webhook is back online the pod will be scheduled.
+  # In some environments such as Kind this may have an undesirable effect as it may prevent provisioner pods from running
+  # which can lead to hangs. In these environments it is recommend to use "Ignore" instead.
+  # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
   # Selector for restricting the webhook to only

--- a/values.yaml
+++ b/values.yaml
@@ -1486,7 +1486,7 @@ connectInject:
   # Sets the failurePolicy for the mutating webhook. By default this will cause pods to fail scheduling while the webhook
   # is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
   # Once the webhook is back online the pod will be scheduled.
-  # In some environments such as Kind this may have an undesirable effect as it may prevent provisioner pods from running
+  # In some environments such as Kind this may have an undesirable effect as it may prevent volume provisioner pods from running
   # which can lead to hangs. In these environments it is recommend to use "Ignore" instead.
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"

--- a/values.yaml
+++ b/values.yaml
@@ -1483,6 +1483,13 @@ connectInject:
       memory: "50Mi"
       cpu: "50m"
 
+  # Sets the failurePolicy for the mutating webhook. By default this will cause pods to fail scheduling while the webhook
+  # is offline. This has the effect of forcing a pod which is connect-injected to avoid skipping mutation if the
+  # webhook were to be momentarily offline, once the webhook is back online the pod will be scheduled.
+  # In some docker based environments such as Kind this may have an undesirable effect as it uses pods to provision storage volumes in
+  # special namespaces which can cause hangs. This setting can be disabled by setting to "Ignore".
+  failurePolicy: "Fail"
+
   # Selector for restricting the webhook to only
   # specific namespaces. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector


### PR DESCRIPTION
Fail scheduling all pods that are not labeled with `app: consul.name`.
This ensures that no user apps are inadvertently scheduled and skip mutation while the webhook is offline (after consul has been installed).
I chose to match on `app: consul.name` so we do not fail to schedule our own pods in case the webhook object is applied to k8s before the rest of our consul components are scheduled.

Changes proposed in this PR:
- Set failure policy of the webhook to `Fail` instead of `Ignore`
- Add a new field to connectInject stanza: `connectInject.failurePolicy` default to `Fail` which controls the behaviour.

How I've tested this PR:
1. Manually tested by applying this patch which sets the webhook to unready, deploy consul.

```
diff --git a/templates/connect-inject-deployment.yaml b/templates/connect-inject-deployment.yaml
index 9c35728..e0745d9 100644
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -39,6 +39,13 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
       containers:
         - name: sidecar-injector
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 30
+            periodSeconds: 5
           image: "{{ default .Values.global.imageK8S .Values.connectInject.image }}"
           ports:
           - containerPort: 8080
```
2. Wait for everything to come "online" and the readinessProbe to fail so that both copies of the webhook are unready:
```
% k get pods
NAME                                                              READY   STATUS    RESTARTS   AGE
consul-consul-4v7ml                                               1/1     Running   0          66s
consul-consul-5sgcd                                               1/1     Running   0          66s
consul-consul-connect-injector-webhook-deployment-84cb5c9758crk   0/1     Running   0          65s
consul-consul-connect-injector-webhook-deployment-84cb5c97llxd9   0/1     Running   0          65s
consul-consul-controller-7dbd5c45d4-6wbt7                         1/1     Running   0          65s
consul-consul-p4wq4                                               1/1     Running   0          65s
consul-consul-server-0                                            1/1     Running   0          65s
consul-consul-webhook-cert-manager-d4598f84-t8qg9                 1/1     Running   0          65s
consul-consul-x9k46                                               1/1     Running   0          66s
```
3. Deploy a sample app that is connect injected and see that it does not get scheduled.
4. Set a copy of the webhook to healthy: `kubectl exec -it consul-consul-connect-injector-webhook-deployment-84cb5c97llxd9 -- touch /tmp/healthy`
5. Sample app gets scheduled:
```
 % k get pods
NAME                                                              READY   STATUS    RESTARTS   AGE
consul-consul-4v7ml                                               1/1     Running   0          7m13s
consul-consul-5sgcd                                               1/1     Running   0          7m13s
consul-consul-connect-injector-webhook-deployment-84cb5c9758crk   0/1     Running   0          7m12s
consul-consul-connect-injector-webhook-deployment-84cb5c97llxd9   1/1     Running   0          7m12s
consul-consul-controller-7dbd5c45d4-6wbt7                         1/1     Running   0          7m12s
consul-consul-p4wq4                                               1/1     Running   0          7m12s
consul-consul-server-0                                            1/1     Running   0          7m12s
consul-consul-webhook-cert-manager-d4598f84-t8qg9                 1/1     Running   0          7m12s
consul-consul-x9k46                                               1/1     Running   0          7m13s
whoami-75f5b5f654-4vtcs                                           2/2     Running   0          5m28s
```
How I expect reviewers to test this PR:
Code review
CI run against GKE: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3370/workflows/2ae29e9c-a234-407a-a4c9-84a96fad0979
CI run against Kind: https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3369/workflows/5a0f3727-e04a-4b03-902a-0bc0137e45f4

Checklist:
- [ ] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

