### PR TITLE
Revamp issue template and provide verbiage on +1 for tracking interest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ labels: bug
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
 * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ labels: bug
 ### Community Note
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
 * If you are interested in working on this issue or have submitted a pull request, please leave a comment
 
 <!--- Thank you for keeping this note for the community --->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,13 +5,27 @@ labels: bug
 
 ---
 
-When filing a bug, please include the following headings if possible. Any example text in this template can be deleted.
+<!--- Please keep this note for the community --->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
+
+<!--- When filing a bug, please include the following headings if possible. Any example text in this template can be deleted. --->
 
 ### Overview of the Issue
 
-A paragraph or two about the issue you're experiencing.
+<!--- Please describe the issue you are having and how you encountered the problem. --->
 
 ### Reproduction Steps
+
+<!--- 
+
+In order to effectively and quickly resolve the issue, please provide exact steps that allow us the reproduce the problem. If no steps are provided, then it will likely take longer to get the issue resolved. An example that you can follow is provided below. 
 
 Steps to reproduce this issue, eg:
 
@@ -30,9 +44,13 @@ controller:
 ```
 1. View error
 
+  --->
+
 ### Logs
 
-Include any relevant logs.
+<!---
+
+Provide log files from Consul Kubernetes components by providing output from `kubectl logs` from the pod and container that is surfacing the issue. 
 
 <details>
   <summary>Logs</summary>
@@ -43,23 +61,32 @@ output from 'kubectl logs' in relevant components
 
 </details>
 
+--->
+
 ### Expected behavior
 
-What was the expected result?
+<!--- What was the expected result after following the reproduction steps? --->
 
 ### Environment details
+
+<!---
 
 If not already included, please provide the following:
 - `consul-k8s` version:
 - `consul-helm` version:
 - `values.yaml` used to deploy the helm chart:
 
-Additionally, please provide details regarding the Kubernetes Infrastructure, if known:
-- Cloud Provider (If self-hosted, the Kubernetes provider utilized):
-- Networking CNI plugin in use:
+Additionally, please provide details regarding the Kubernetes Infrastructure, as shown below:
+- Kubernetes version: v1.22.x
+- Cloud Provider (If self-hosted, the Kubernetes provider utilized): EKS, AKS, GKE, OpenShift (and version), Rancher (and version), TKGI (and version)
+- Networking CNI plugin in use: Calico, Cilium, NSX-T 
 
 Any other information you can provide about the environment/deployment.
+--->
+
 
 ### Additional Context
 
-Additional context on the problem.
+<!---
+Additional context on the problem. Docs, links to blogs, or other material that lead you to discover this issue or were helpful in troubleshooting the issue. 
+--->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,8 @@ labels: bug
 
 <!--- Thank you for keeping this note for the community --->
 
+---
+
 <!--- When filing a bug, please include the following headings if possible. Any example text in this template can be deleted. --->
 
 ### Overview of the Issue

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ labels: enhancement
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
 * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,7 +27,7 @@ labels: enhancement
 
 #### Use Case(s)
 
-<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery). --->
+<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul use case i.e. Service Mesh, Service Disovery). --->
 
 #### Contributions
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,7 +27,7 @@ labels: enhancement
 
 #### Use Case(s)
 
-<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery) --->
+<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery). --->
 
 #### Contributions
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,6 +15,8 @@ labels: enhancement
 
 <!--- Thank you for keeping this note for the community --->
 
+---
+
 #### Is your feature request related to a problem? Please describe.
 
 <!--- A clear and concise description of the problem you are facing. Describe what workarounds, if any, that you have tried prior to creating this feature request. --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ labels: enhancement
 ### Community Note
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
 * If you are interested in working on this issue or have submitted a pull request, please leave a comment
 
 <!--- Thank you for keeping this note for the community --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,21 +5,28 @@ labels: enhancement
 
 ---
 
-Please search the existing issues for relevant feature requests, and use the reaction feature (https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to add upvotes to pre-existing requests.
+<!--- Please keep this note for the community --->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
 
 #### Is your feature request related to a problem? Please describe.
 
-A clear and concise description of what the problem is.
+<!--- A clear and concise description of the problem you are facing. Describe what workarounds, if any, that you have tried prior to creating this feature request. --->
 
 #### Feature Description
 
-A written overview of the feature.
+<!--- A description what this feature is and how it addresses the problem you are having. Describe potential UX for the feature if possible. --->
 
 #### Use Case(s)
 
-Any relevant use-cases that you see.
+<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery) --->
 
 #### Contributions
 
-Are you able to contribute the changes to make this feature work?
-
+<!--- Are you able to contribute the changes to make this feature work? --->


### PR DESCRIPTION
Changes proposed in this PR:
- Added thumbs up verbiage to the feature and bug report issue templates. Best viewed in RAW file format due to instructions that are embedded as comments, which will not be displayed when filing.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

