### PR TITLE
Add new constructor for KubernetesEnvironment

### DIFF
--- a/test/acceptance/framework/environment/environment.go
+++ b/test/acceptance/framework/environment/environment.go
@@ -53,6 +53,17 @@ func NewKubernetesEnvironmentFromConfig(config *config.TestConfig) *KubernetesEn
 	return kenv
 }
 
+func NewKubernetesEnvironmentFromContext(context *kubernetesContext) *KubernetesEnvironment {
+	// Create a kubernetes environment with default context.
+	kenv := &KubernetesEnvironment{
+		contexts: map[string]*kubernetesContext{
+			DefaultContextName: context,
+		},
+	}
+
+	return kenv
+}
+
 func (k *KubernetesEnvironment) Context(t *testing.T, name string) TestContext {
 	ctx, ok := k.contexts[name]
 	require.Truef(t, ok, fmt.Sprintf("requested context %s not found", name))


### PR DESCRIPTION
This constructor can be used by the consul-k8s-cli to create a
KubernetesEnvironment and leverage the helpers in the environment and
k8s framework packages.

Once this is merged I can remove the replace directive in go.mod in consul-k8s-cli `acceptance-test-setup` branch.

How I've tested this PR:
The suite package in consul-k8s-cli uses this new constructor, and the basic installation test makes use of the environment to use it's Kubernetes client:

https://github.com/hashicorp/consul-k8s-cli/blob/acceptance-test-setup/test/acceptance/tests/install/install_test.go#L31
https://github.com/hashicorp/consul-k8s-cli/blob/acceptance-test-setup/test/acceptance/framework/suite/suite.go#L41

How I expect reviewers to test this PR:
code review


