### PR TITLE
feat: support setting connect inject deployment replicas

### DIFF
--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.connectInject.replicas }}
   selector:
     matchLabels:
       app: {{ template "consul.name" . }}

--- a/test/unit/connect-inject-deployment.bats
+++ b/test/unit/connect-inject-deployment.bats
@@ -1447,3 +1447,30 @@ EOF
 
   [ "${actual}" = "true" ]
 }
+
+
+#--------------------------------------------------------------------
+# replicas
+
+@test "connectInject/Deployment: replicas defaults to 2" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.replicas' | tee /dev/stderr)
+
+  [ "${actual}" = "2" ]
+}
+
+@test "connectInject/Deployment: replicas can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.replicas=3' \
+      . | tee /dev/stderr |
+      yq '.spec.replicas' | tee /dev/stderr)
+
+  [ "${actual}" = "3" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1376,6 +1376,9 @@ connectInject:
   # global.enabled.
   enabled: false
 
+  # The number of deployment replicas.
+  replicas: 2
+
   # Image for consul-k8s that contains the injector
   # @type: string
   image: null


### PR DESCRIPTION
Changes proposed in this PR:
- Allow setting the replicas for the connect inject deployment (defaults to 2)

Checklist:
- [x] Bats tests added

