### PR TITLE
update the wording for the consul sidecar to reflect current behaviour

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -271,8 +271,8 @@ global:
     # @type: boolean
     enableGatewayMetrics: true
 
-  # The consul sidecar is responsible for metrics merging and in the case of ingress/mesh/terminating gateways
-  # it additionally ensures the Consul services are always registered with their local Consul client.
+  # For connect-injected pods, the consul sidecar is responsible for metrics merging. For ingress/mesh/terminating 
+  # gateways, it additionally ensures the Consul services are always registered with their local Consul client.
   # @recurse: false
   # @type: map
   consulSidecarContainer:

--- a/values.yaml
+++ b/values.yaml
@@ -271,9 +271,8 @@ global:
     # @type: boolean
     enableGatewayMetrics: true
 
-  # The consul sidecar ensures the Consul services
-  # are always registered with their local Consul clients and is used by the
-  # ingress/terminating/mesh gateways as well as with every Connect-injected service.
+  # The consul sidecar is responsible for metrics merging and in the case of ingress/mesh/terminating gateways
+  # it additionally ensures the Consul services are always registered with their local Consul client.
   # @recurse: false
   # @type: map
   consulSidecarContainer:


### PR DESCRIPTION
Changes proposed in this PR:
- consulSidecar is only used for re-registering consul services for the gateways, and also does metrics merging now.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

