### PR TITLE
add hostIP as env variable to server statefulset and client daemonset

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -31,7 +31,6 @@ the trimSuffix removes the trailing newline that occurs when there are no overri
               [ -n "${HOSTNAME}" ] && sed -Ei "s|HOSTNAME|${HOSTNAME?}|g" /consul/extra-config/extra-from-values.json
 {{- end -}}
 
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -16,17 +16,18 @@ as well as the global.name setting.
 {{- end -}}
 
 {{/*
-Set's the args for custom command to render the Vault configuration
-file with IP addresses to make the out of box experience easier
-for users looking to use this chart with Consul Helm.
+Sets up the extra-from-values config file passed to consul and then uses sed to do any necessary
+substitution for HOST_IP/POD_IP/HOSTNAME. Useful for dogstats telemetry. The output file
+is passed to consul as a -config-file param on command line.
 */}}
 {{- define "consul.extraargs" -}}
               mkdir -p /consul/extra-config
-              echo '{{ tpl .Values.server.extraConfig . | trimAll "\"" }}' > /consul/extra-config/extra-from-values.json
+              {{- $conf := toJson .extraConfig }}
+              echo '{{ regexReplaceAll "\\\\\"" $conf "\"" | trimAll "\"" | trimSuffix "\\n" }}' > /consul/extra-config/extra-from-values.json
               [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /consul/extra-config/extra-from-values.json
               [ -n "${POD_IP}" ] && sed -Ei "s|POD_IP|${POD_IP?}|g" /consul/extra-config/extra-from-values.json
               [ -n "${HOSTNAME}" ] && sed -Ei "s|HOSTNAME|${HOSTNAME?}|g" /consul/extra-config/extra-from-values.json
-{{- end}}
+{{- end -}}
 
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -19,8 +19,10 @@ as well as the global.name setting.
 Sets up the extra-from-values config file passed to consul and then uses sed to do any necessary
 substitution for HOST_IP/POD_IP/HOSTNAME. Useful for dogstats telemetry. The output file
 is passed to consul as a -config-file param on command line.
+The regexReplaceAll removes excess escaped quotes, the trim removes excess quotes,
+the trimSuffix removes the trailing newline that occurs when there are no overrides (default).
 */}}
-{{- define "consul.extraargs" -}}
+{{- define "consul.extraconfig" -}}
               mkdir -p /consul/extra-config
               {{- $conf := toJson .extraConfig }}
               echo '{{ regexReplaceAll "\\\\\"" $conf "\"" | trimAll "\"" | trimSuffix "\\n" }}' > /consul/extra-config/extra-from-values.json

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -16,6 +16,20 @@ as well as the global.name setting.
 {{- end -}}
 
 {{/*
+Set's the args for custom command to render the Vault configuration
+file with IP addresses to make the out of box experience easier
+for users looking to use this chart with Consul Helm.
+*/}}
+{{- define "consul.extraargs" -}}
+              mkdir -p /consul/extra-config
+              echo '{{ tpl .Values.server.extraConfig . | trimAll "\"" }}' > /consul/extra-config/extra-from-values.json
+              [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /consul/extra-config/extra-from-values.json
+              [ -n "${POD_IP}" ] && sed -Ei "s|POD_IP|${POD_IP?}|g" /consul/extra-config/extra-from-values.json
+              [ -n "${HOSTNAME}" ] && sed -Ei "s|HOSTNAME|${HOSTNAME?}|g" /consul/extra-config/extra-from-values.json
+{{- end}}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "consul.chart" -}}

--- a/templates/client-config-configmap.yaml
+++ b/templates/client-config-configmap.yaml
@@ -12,8 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-  extra-from-values.json: |-
-{{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}
   central-config.json: |-
     {
       "enable_central_service_config": true

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -193,6 +193,8 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
+              {{ template "consul.extraargs" . }}
+
               exec /bin/consul agent \
                 -node="${NODE}" \
                 -advertise="${ADVERTISE_IP}" \
@@ -261,6 +263,7 @@ spec:
                 {{- range $value := .Values.global.recursors }}
                 -recursor={{ quote $value }} \
                 {{- end }}
+                -config-file=/consul/extra-config/extra-from-values.json \
                 -domain={{ .Values.global.domain }}
           volumeMounts:
             - name: data

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -193,7 +193,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              {{ template "consul.extraargs" .Values.client }}
+              {{ template "consul.extraconfig" .Values.client }}
 
               exec /bin/consul agent \
                 -node="${NODE}" \

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -193,7 +193,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              {{ template "consul.extraargs" . }}
+              {{ template "consul.extraargs" .Values.client }}
 
               exec /bin/consul agent \
                 -node="${NODE}" \

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -11,8 +11,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-  extra-from-values.json: |-
-{{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
   {{- if .Values.global.acls.manageSystemACLs }}
   acl-config.json: |-
     {

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -180,6 +180,8 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
+              {{ template "consul.extraargs" . }}
+
               exec /bin/consul agent \
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
@@ -240,6 +242,7 @@ spec:
                 {{- range $value := .Values.global.recursors }}
                 -recursor={{ quote $value }} \
                 {{- end }}
+                -config-file=/consul/extra-config/extra-from-values.json \
                 -server
           volumeMounts:
             - name: data-{{ .Release.Namespace }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -141,6 +141,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              {{ template "consul.extraargs" . }}
+              {{ template "consul.extraargs" .Values.server }}
 
               exec /bin/consul agent \
                 -advertise="${ADVERTISE_IP}" \

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              {{ template "consul.extraargs" .Values.server }}
+              {{ template "consul.extraconfig" .Values.server }}
 
               exec /bin/consul agent \
                 -advertise="${ADVERTISE_IP}" \

--- a/test/unit/client-config-configmap.bats
+++ b/test/unit/client-config-configmap.bats
@@ -38,16 +38,6 @@ load _helpers
       .
 }
 
-@test "client/ConfigMap: extraConfig is set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/client-config-configmap.yaml  \
-      --set 'client.extraConfig="{\"hello\": \"world\"}"' \
-      . | tee /dev/stderr |
-      yq '.data["extra-from-values.json"] | match("world") | length > 1' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 #--------------------------------------------------------------------
 # connectInject.centralConfig [DEPRECATED]
 

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -576,7 +576,6 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[] | select(.name=="consul") | .command | join(" ") | contains("{}")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -586,7 +585,6 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[] | select(.name=="consul") | .command | join(" ") | contains("{\"hello\": \"world\"}")' | tee /dev/stderr)

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -574,10 +574,17 @@ load _helpers
 
 @test "client/DaemonSet: adds extra-from-vals by default" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local command=$(helm template \
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[] | select(.name=="consul") | .command | join(" ") | contains("{}")' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | join(" ")' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $command | jq -r '. | contains("{}")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual
+  actual=$(echo $command | jq -r '. | contains("-config-file=/consul/extra-config/extra-from-values.json")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/test/unit/server-config-configmap.bats
+++ b/test/unit/server-config-configmap.bats
@@ -38,16 +38,6 @@ load _helpers
       .
 }
 
-@test "server/ConfigMap: extraConfig is set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-config-configmap.yaml  \
-      --set 'server.extraConfig="{\"hello\": \"world\"}"' \
-      . | tee /dev/stderr |
-      yq '.data["extra-from-values.json"] | match("world") | length' | tee /dev/stderr)
-  [ ! -z "${actual}" ]
-}
-
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -837,19 +837,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[3].name' | tee /dev/stderr)
+      yq -r '.[4].name' | tee /dev/stderr)
   [ "${actual}" = "custom_proxy" ]
 
   local actual=$(echo $object |
-      yq -r '.[3].value' | tee /dev/stderr)
+      yq -r '.[4].value' | tee /dev/stderr)
   [ "${actual}" = "fakeproxy" ]
 
   local actual=$(echo $object |
-      yq -r '.[4].name' | tee /dev/stderr)
+      yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "no_proxy" ]
 
   local actual=$(echo $object |
-      yq -r '.[4].value' | tee /dev/stderr)
+      yq -r '.[5].value' | tee /dev/stderr)
   [ "${actual}" = "custom_no_proxy" ]
 }
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -650,11 +650,17 @@ load _helpers
 
 @test "server/StatefulSet: adds extra-from-vals by default" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local command=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[] | select(.name=="consul") | .command | join(" ") | contains("{}")' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | join(" ")' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $command | jq -r '. | contains("{}")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual
+  actual=$(echo $command | jq -r '. | contains("-config-file=/consul/extra-config/extra-from-values.json")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/values.yaml
+++ b/values.yaml
@@ -468,7 +468,7 @@ server:
     maxUnavailable: null
 
   # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
-  # servers. This will be saved as-is into a ConfigMap that is read by the Consul
+  # servers. This will be saved as-is and passed to Consul as a `-config-file` argument to the
   # server agents. This can be used to add additional configuration that
   # isn't directly exposed by the chart.
   #
@@ -484,7 +484,7 @@ server:
   # This can also be set using Helm's `--set` flag using the following syntax:
   #
   # ```shell
-  # --set 'server.extraConfig="{"log_level": "DEBUG"}"'
+  # --set 'server.extraConfig='{"log_level": "DEBUG"}"'
   # ```
   extraConfig: |
     {}
@@ -778,8 +778,8 @@ client:
     fsGroup: 1000
 
   # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
-  # clients. This will be saved as-is into a ConfigMap that is read by the Consul
-  # client agents. This can be used to add additional configuration that
+  # clients. This will be saved as-is and passed to Consul as a `-config-file` argument to the
+  # clients agents. This can be used to add additional configuration that
   # isn't directly exposed by the chart.
   #
   # Example:
@@ -794,7 +794,7 @@ client:
   # This can also be set using Helm's `--set` flag using the following syntax:
   #
   # ```shell
-  # --set 'client.extraConfig="{"log_level": "DEBUG"}"'
+  # --set 'client.extraConfig='{"log_level": "DEBUG"}"'
   # ```
   extraConfig: |
     {}

--- a/values.yaml
+++ b/values.yaml
@@ -484,7 +484,7 @@ server:
   # This can also be set using Helm's `--set` flag using the following syntax:
   #
   # ```shell
-  # --set 'server.extraConfig='{"log_level": "DEBUG"}"'
+  # --set 'server.extraConfig="{\"log_level\": \"DEBUG\"}"'
   # ```
   extraConfig: |
     {}
@@ -794,7 +794,7 @@ client:
   # This can also be set using Helm's `--set` flag using the following syntax:
   #
   # ```shell
-  # --set 'client.extraConfig='{"log_level": "DEBUG"}"'
+  # --set 'client.extraConfig="{\"log_level\": \"DEBUG\"}"'
   # ```
   extraConfig: |
     {}


### PR DESCRIPTION
Changes proposed in this PR:
- Add hostIP as env variable to server statefulset
- Template and process the extra-env-args and pass them to consul as a new config file instead of using a configmap for the client daemonset and server statefulset.
- Remove existing config-map tests specific to extraConfig and move them to the respective server-statefulset/client-daemonset bats tests.

Resolves https://github.com/hashicorp/consul-helm/issues/657.

How I've tested this PR:
unit tests added and existing ones pass, manually tested using the extra-env-args telemetry specified in issue #657 : 
```
global:
  imageK8S: kschoche/consul-k8s-dev
  image: hashicorp/consul:1.10.0
  tls:
    enabled: true
  acls:
    manageSystemACLs: true
  metrics:
    enabled: true
controller:
  enabled: true
server:
  extraConfig: '{ "telemetry": [ { "disable_hostname": true, "dogstatsd_addr": "HOST_IP:8125", "dogstatsd_tags": ["env:weweq","service:consul","version:1.10.0"] } ] }'
  replicas: 1
```
And confirmed that the server and clients comes online with the changes and fails to come online with existing code.

How I expect reviewers to test this PR:
unit tests pass, code review.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

