### PR TITLE
Add support for network segments

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -245,6 +245,9 @@ spec:
                 {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
                 -encrypt="${GOSSIP_KEY}" \
                 {{- end }}
+                {{- if .Values.client.partition }}
+                -segment={{ .Values.client.partition }} \
+                {{- end }}
                 {{- if .Values.client.join }}
                 {{- range $value := .Values.client.join }}
                 -retry-join={{ quote $value }} \

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -39,6 +39,18 @@ spec:
       port: 8501
       targetPort: 8501
     {{- end }}
+    {{- if .Values.server.partitions }}
+    {{- range $partition := .Values.server.partitions }}
+    - targetPort: {{ $partition.port }}
+      port: {{ $partition.port }}
+      protocol: "TCP"
+      name: {{ $partition.name }}-tcp
+    - targetPort: {{ $partition.port }}
+      port: {{ $partition.port }}
+      protocol: "UDP"
+      name: {{ $partition.name }}-udp
+    {{- end }}
+    {{- end }}
     - name: serflan-tcp
       protocol: "TCP"
       port: 8301

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -197,6 +197,13 @@ spec:
                 -hcl='ports { http = -1 }' \
                 {{- end }}
                 {{- end }}
+                {{- if .Values.server.partitions }}
+                {{- $partitions := "" }}
+                {{- range $partition := .Values.server.partitions }}
+                {{- $partitions = printf "%s{name = \\\"%s\\\", bind = \\\"0.0.0.0\\\", advertise = \\\"%s\\\", port = %v}," $partitions $partition.name "${ADVERTISE_IP}" $partition.port -}}
+                {{- end }}
+                -hcl="segments = [{{ $partitions }}]" \
+                {{- end }}
                 -client=0.0.0.0 \
                 -config-dir=/consul/config \
                 {{- /* Always include the extraVolumes at the end so that users can
@@ -268,6 +275,18 @@ spec:
             {{- if .Values.global.tls.enabled }}
             - name: https
               containerPort: 8501
+            {{- end }}
+            {{- if .Values.server.partitions }}
+            {{- range $partition := .Values.server.partitions }}
+            - containerPort: {{ $partition.port }}
+              hostPort: {{ $partition.port }}
+              protocol: "TCP"
+              name: {{ $partition.name }}-tcp
+            - containerPort: {{ $partition.port }}
+              hostPort: {{ $partition.port }}
+              protocol: "UDP"
+              name: {{ $partition.name }}-udp
+            {{- end }}
             {{- end }}
             - name: serflan-tcp
               containerPort: {{ .Values.server.ports.serflan.port }}

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -1291,3 +1291,25 @@ rollingUpdate:
       yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("-recursor=\"1.2.3.4\"")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# partitions
+
+@test "client/DaemonSet: does not have a segment by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      . | tee /dev/stderr |
+      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("-segment=")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/DaemonSet: adds segment flag when partition is provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.partition=test' \
+      . | tee /dev/stderr |
+      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("-segment=test")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -121,3 +121,59 @@ load _helpers
       yq -r '.metadata.annotations.key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
 }
+
+#--------------------------------------------------------------------
+# partitions
+
+@test "server/Service: no partitions by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports | length' | tee /dev/stderr)
+  [ "${actual}" = "8" ]
+}
+
+@test "server/Service: adds tcp port for partition" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      --set 'server.partitions[0].name=test' \
+      --set 'server.partitions[0].port=8503' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "test-tcp") | .port' | tee /dev/stderr)
+  [ "${actual}" = "8503" ]
+}
+
+@test "server/Service: adds udp port for partition" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      --set 'server.partitions[0].name=test' \
+      --set 'server.partitions[0].port=8503' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "test-udp") | .port' | tee /dev/stderr)
+  [ "${actual}" = "8503" ]
+}
+
+@test "server/Service: adds tcp protocol for partition" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      --set 'server.partitions[0].name=test' \
+      --set 'server.partitions[0].port=8503' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "test-tcp") | .protocol' | tee /dev/stderr)
+  [ "${actual}" = "TCP" ]
+}
+
+@test "server/Service: adds udp protocol for partition" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      --set 'server.partitions[0].name=test' \
+      --set 'server.partitions[0].port=8503' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[] | select(.name == "test-udp") | .protocol' | tee /dev/stderr)
+  [ "${actual}" = "UDP" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1283,7 +1283,7 @@ load _helpers
   [ "${actual}" = "8503" ]
 }
 
-@test "server/StatefulSet: creates upd container port when partition provided" {
+@test "server/StatefulSet: creates udp container port when partition provided" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
@@ -1305,7 +1305,7 @@ load _helpers
   [ "${actual}" = '"TCP"' ]
 }
 
-@test "server/StatefulSet: creates upd container protocol when partition provided" {
+@test "server/StatefulSet: creates udp container protocol when partition provided" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \

--- a/values.yaml
+++ b/values.yaml
@@ -344,7 +344,7 @@ server:
   exposeGossipAndRPCPorts: false
 
   # [Enterprise Only] Configures the partitions and the port for each partition.
-  # Accepts an array of map with field name and port where where the name is the
+  # Accepts an array of map with field name and port where the name is the
   # name of the partition and port is the desired gossip port for that partition.
   # Example:
   #

--- a/values.yaml
+++ b/values.yaml
@@ -343,6 +343,21 @@ server:
   # `server.ports.serflan.port` must be set to something other than 8301.
   exposeGossipAndRPCPorts: false
 
+  # [Enterprise Only] Configures the partitions and the port for each partition.
+  # Accepts an array of map with field name and port where where the name is the
+  # name of the partition and port is the desired gossip port for that partition.
+  # Example:
+  #
+  # ```yaml
+  # partitions:
+  # - name: foo
+  #   port: 8503
+  # - name: bar
+  #   port: 8504
+  # ```
+  # @type: array<map>
+  partitions: []
+
   # Configures ports for the consul servers.
   ports:
     # Configures the LAN gossip port for the consul servers. If you choose to
@@ -720,6 +735,10 @@ client:
   # and the Consul servers are outside of the k8s cluster.
   # This also changes the clients' advertised IP to the `hostIP` rather than `podIP`.
   exposeGossipPorts: false
+
+  # [Enterprise Only] Name of the partition the clients are in.
+  # @type: string
+  partition: null
 
   serviceAccount:
     # This value defines additional annotations for the client service account. This should be formatted as a multi-line


### PR DESCRIPTION
Changes proposed in this PR:
- Add support for network segments as a first step to supporting Admin Partitions

How I've tested this PR: Created 2 kubernetes clusters.
values file for primary cluster:
```
global:
  image: "hashicorp/consul-enterprise:1.10.0-ent"
  acls:
    manageSystemACLs: true
server:
  enabled: true
  exposeGossipAndRPCPorts: true
  partitions:
  - name: "default"
    port: 8303
  - name: "alpha"
    port: 8304
client:
  partition: default
  join:
  - "${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8303"
  - "${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8303"
  - "${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc:8303"
```
Copy the bootstrap token into a secret in the secondary
values file for secondary cluster:
```
global:
  image: "hashicorp/consul-enterprise:1.10.0-ent"
  acls:
    manageSystemACLs: true
    bootstrapToken:
      secretName: consul-consul-bootstrap-acl-token
      secretKey: token
server:
  enabled: false
externalServers:
  enabled: true
  httpsPort: 8500
  hosts:
  - "*.*.*.205" # ips of the nodes of the server cluster
  - "*.*.*.206"
  - "*.*.*.207"
client:
  enabled: true
  exposeGossipPorts: true
  partition: alpha
  join:
  - "*.*.*.205:8304" # ips of the nodes of the server cluster with the port for alpha partition
  - "*.*.*.206:8304"
  - "*.*.*.207:8304"
```

How I expect reviewers to test this PR: Run the above and check `consul members`. The list should have the agents listed against their correct network segment


Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

