### PR TITLE
Set security contexts on consul-k8s containers

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,9 +97,9 @@ This template is for an init container.
     {{- end }}
     - name: consul-auto-encrypt-ca-cert
       mountPath: /consul/tls/client/ca
-  {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+  {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
   securityContext:
-    {{- toYaml .Values.global.securityContext | nindent 10 }}
+    {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
   {{- end }}
   resources:
     requests:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,6 +97,10 @@ This template is for an init container.
     {{- end }}
     - name: consul-auto-encrypt-ca-cert
       mountPath: /consul/tls/client/ca
+  {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+  securityContext:
+    {{- toYaml .Values.global.securityContext | nindent 10 }}
+  {{- end }}
   resources:
     requests:
       memory: "50Mi"

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -364,6 +364,10 @@ spec:
         volumeMounts:
           - name: aclconfig
             mountPath: /consul/aclconfig
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           requests:
             memory: "25Mi"

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -364,9 +364,9 @@ spec:
         volumeMounts:
           - name: aclconfig
             mountPath: /consul/aclconfig
-        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8s) }}
         securityContext:
-          {{- toYaml .Values.global.securityContext | nindent 10 }}
+          {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
         {{- end }}
         resources:
           requests:

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -193,6 +193,10 @@ spec:
                 -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: certs
             mountPath: /etc/connect-injector/certs
@@ -246,6 +250,10 @@ spec:
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-connect-inject-acl-token" \
               -k8s-namespace={{ .Release.Namespace }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           requests:
             memory: "25Mi"

--- a/templates/connect-inject-deployment.yaml
+++ b/templates/connect-inject-deployment.yaml
@@ -193,9 +193,9 @@ spec:
                 -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: certs
@@ -250,9 +250,9 @@ spec:
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-connect-inject-acl-token" \
               -k8s-namespace={{ .Release.Namespace }}
-        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
         securityContext:
-          {{- toYaml .Values.global.securityContext | nindent 10 }}
+          {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
         {{- end }}
         resources:
           requests:

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -41,6 +41,10 @@ spec:
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-controller-acl-token" \
               -k8s-namespace={{ .Release.Namespace }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           requests:
             memory: "25Mi"
@@ -114,6 +118,10 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
         {{- with .Values.controller.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -41,9 +41,9 @@ spec:
             consul-k8s acl-init \
               -secret-name="{{ template "consul.fullname" . }}-controller-acl-token" \
               -k8s-namespace={{ .Release.Namespace }}
-        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
         securityContext:
-          {{- toYaml .Values.global.securityContext | nindent 10 }}
+          {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
         {{- end }}
         resources:
           requests:
@@ -118,9 +118,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
         securityContext:
-          {{- toYaml .Values.global.securityContext | nindent 10 }}
+          {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
         {{- end }}
         {{- with .Values.controller.resources }}
         resources:

--- a/templates/create-federation-secret-job.yaml
+++ b/templates/create-federation-secret-job.yaml
@@ -111,9 +111,9 @@ spec:
               mountPath: /consul/gossip
               readOnly: true
             {{- end }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           command:
             - "/bin/sh"

--- a/templates/create-federation-secret-job.yaml
+++ b/templates/create-federation-secret-job.yaml
@@ -111,6 +111,10 @@ spec:
               mountPath: /consul/gossip
               readOnly: true
             {{- end }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -100,9 +100,9 @@ spec:
             mountPath: /consul-bin
           {{- if .Values.meshGateway.initCopyConsulContainer }}
           {{- if .Values.meshGateway.initCopyConsulContainer.resources }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           resources: {{ toYaml .Values.meshGateway.initCopyConsulContainer.resources | nindent 12 }}
           {{- end }}
@@ -229,9 +229,9 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           resources:
             requests:
@@ -251,9 +251,9 @@ spec:
             {{- toYaml .Values.meshGateway.resources | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: consul-bin

--- a/templates/mesh-gateway-deployment.yaml
+++ b/templates/mesh-gateway-deployment.yaml
@@ -100,6 +100,10 @@ spec:
             mountPath: /consul-bin
           {{- if .Values.meshGateway.initCopyConsulContainer }}
           {{- if .Values.meshGateway.initCopyConsulContainer.resources }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           resources: {{ toYaml .Values.meshGateway.initCopyConsulContainer.resources | nindent 12 }}
           {{- end }}
           {{- end }}
@@ -225,6 +229,10 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: "50Mi"
@@ -242,6 +250,10 @@ spec:
             {{- else }}
             {{- toYaml .Values.meshGateway.resources | nindent 12 }}
             {{- end }}
+          {{- end }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: consul-bin

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -54,6 +54,10 @@ spec:
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: "50Mi"

--- a/templates/server-acl-init-cleanup-job.yaml
+++ b/templates/server-acl-init-cleanup-job.yaml
@@ -54,9 +54,9 @@ spec:
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           resources:
             requests:

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -75,9 +75,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.global.tls.enabled }}

--- a/templates/server-acl-init-job.yaml
+++ b/templates/server-acl-init-job.yaml
@@ -75,6 +75,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           {{- if (or .Values.global.tls.enabled (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.global.tls.enabled }}
             - name: consul-ca-cert

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -63,9 +63,9 @@ spec:
         readOnly: true
       {{- end }}
       {{- end }}
-      {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+      {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
       securityContext:
-        {{- toYaml .Values.global.securityContext | nindent 8 }}
+        {{- toYaml .Values.global.securityContextK8S | nindent 8 }}
       {{- end }}
       command:
         - "/bin/sh"

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -63,6 +63,10 @@ spec:
         readOnly: true
       {{- end }}
       {{- end }}
+      {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       command:
         - "/bin/sh"
         - "-ec"

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -52,9 +52,9 @@ spec:
               curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-server-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           resources:
             requests:

--- a/templates/tls-init-cleanup-job.yaml
+++ b/templates/tls-init-cleanup-job.yaml
@@ -52,6 +52,10 @@ spec:
               curl -s -X DELETE --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/{{ template "consul.fullname" . }}-server-cert \
                 -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: "50Mi"

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -53,9 +53,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           workingDir: /tmp
-          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.securityContextK8S | nindent 12 }}
           {{- end }}
           command:
             - "/bin/sh"

--- a/templates/tls-init-job.yaml
+++ b/templates/tls-init-job.yaml
@@ -53,6 +53,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           workingDir: /tmp
+          {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/templates/webhook-cert-manager-deployment.yaml
+++ b/templates/webhook-cert-manager-deployment.yaml
@@ -44,9 +44,9 @@ spec:
             -deployment-namespace={{ .Release.Namespace }}
         image: {{ .Values.global.imageK8S }}
         name: webhook-cert-manager
-        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContextK8S) }}
         securityContext:
-          {{- toYaml .Values.global.securityContext | nindent 10 }}
+          {{- toYaml .Values.global.securityContextK8S | nindent 10 }}
         {{- end }}
         resources:
           limits:

--- a/templates/webhook-cert-manager-deployment.yaml
+++ b/templates/webhook-cert-manager-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             -deployment-namespace={{ .Release.Namespace }}
         image: {{ .Values.global.imageK8S }}
         name: webhook-cert-manager
+        {{- if (and (not .Values.global.openshift.enabled) .Values.global.securityContext) }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           limits:
             cpu: 100m

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,19 @@ global:
   # @default: hashicorp/consul-k8s:<latest version>
   imageK8S: "hashicorp/consul-k8s:0.26.0"
 
+  # The security context for any consul-k8s pods. This should be a YAML map corresponding to a
+  # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
+  # By default, consul-k8s image has non-numeric user (consul-k8s) and so k8s cannot veryify user is non-root.
+  # This overrides that with the equivalent numerical values.
+  # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
+  # by the OpenShift platform.
+  # @type: map
+  # @recurse: false
+  securityContextK8S:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value currently:
@@ -271,7 +284,7 @@ global:
     # @type: boolean
     enableGatewayMetrics: true
 
-  # For connect-injected pods, the consul sidecar is responsible for metrics merging. For ingress/mesh/terminating 
+  # For connect-injected pods, the consul sidecar is responsible for metrics merging. For ingress/mesh/terminating
   # gateways, it additionally ensures the Consul services are always registered with their local Consul client.
   # @recurse: false
   # @type: map
@@ -296,19 +309,6 @@ global:
     # If true, the Helm chart will create necessary configuration for running
     # its components on OpenShift.
     enabled: false
-
-  # The security context for any consul-k8s pods. This should be a YAML map corresponding to a
-  # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
-  # By default, consul-k8s image has non-numeric user (consul-k8s) and so k8s cannot veryify user is non-root.
-  # This overrides that with the equivalent numerical values.
-  # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
-  # by the OpenShift platform.
-  # @type: map
-  # @recurse: false
-  securityContext:
-    runAsNonRoot: true
-    runAsGroup: 1000
-    runAsUser: 100
 
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to

--- a/values.yaml
+++ b/values.yaml
@@ -297,6 +297,19 @@ global:
     # its components on OpenShift.
     enabled: false
 
+  # The security context for any consul-k8s pods. This should be a YAML map corresponding to a
+  # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
+  # By default, consul-k8s image has non-numeric user (consul-k8s) and so k8s cannot veryify user is non-root.
+  # This overrides that with the equivalent numerical values.
+  # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
+  # by the OpenShift platform.
+  # @type: map
+  # @recurse: false
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.
@@ -724,7 +737,7 @@ client:
   # required for Connect.
   grpc: true
 
-  # nodeMeta specifies an arbitrary metadata key/value pair to associate with the node 
+  # nodeMeta specifies an arbitrary metadata key/value pair to associate with the node
   # (see https://www.consul.io/docs/agent/options.html#_node_meta)
   nodeMeta:
     pod-name: ${HOSTNAME}


### PR DESCRIPTION
Changes proposed in this PR:
-
- Enable setting of securityContext on consul-k8s containers to allow them to work with the standard 'restricted' PSP, as the consul-k8s docker image runs as a non-numeric user - https://github.com/hashicorp/consul-k8s/issues/560.

How I've tested this PR:
Used to deploy consul into both local 'kind' cluster and AWS EKS cluster.


How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

