### PR TITLE
Bump eks cleanup token duration to 3h from 1h

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,7 +670,7 @@ jobs:
           name: cleanup eks resources
           command: |
             # Assume the role and set environment variables.
-            aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "consul-helm-$CIRCLE_BUILD_NUM" > assume-role.json
+            aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "consul-helm-$CIRCLE_BUILD_NUM" --duration-seconds 10800 > assume-role.json
             export AWS_ACCESS_KEY_ID="$(jq -r .Credentials.AccessKeyId assume-role.json)"
             export AWS_SECRET_ACCESS_KEY="$(jq -r .Credentials.SecretAccessKey assume-role.json)"
             export AWS_SESSION_TOKEN="$(jq -r .Credentials.SessionToken assume-role.json)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,6 +647,10 @@ jobs:
               az group delete -n $group --yes
             done
 
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS cleanup failed"
+
   cleanup-gcp-resources:
     docker:
       - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
@@ -660,6 +664,10 @@ jobs:
               echo "Deleting $cluster GKE cluster"
               gcloud container clusters delete $cluster --zone us-central1-a --project ${CLOUDSDK_CORE_PROJECT} --quiet
             done
+
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE cleanup failed"
 
   cleanup-eks-resources:
     docker:
@@ -677,6 +685,10 @@ jobs:
 
             cd hack/aws-acceptance-test-cleanup
             go run ./... -auto-approve
+
+      - slack/status:
+          fail_only: true
+          failure_message: "EKS cleanup failed"
 
 workflows:
   version: 2


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3420/workflows/412efdb5-93f4-4f33-b57b-1b42d41723d9/jobs/15294

Also add slack notifications cuz if the cleanup fails then the actual builds don't run.