### PR TITLE
Announcement for migrating Helm chart GitHub repo to `hashicorp/consul-k8s`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The single repository name will be consul-k8s. It will contain the Helm charts, 
 Some additional details regarding the Consul Helm chart migration:
 
 1. All open and closed issues will be migrated from `consul-helm` to `consul-k8s`.
-2. PRs from consul-helm will not be migrated consul-k8s. Users will need to do that themselves, since it would be too complex to perform the migration with CI automation. The new repo will have a charts folder where the Helm chart will reside and PRs can be made against the contents in that folder in the same structure as before.
+2. PRs from consul-helm will not be migrated `consul-k8s`. Users will need to do that themselves, since it would be too complex to perform the migration with CI automation. The new repo will have a charts folder where the Helm chart will reside and PRs can be made against the contents in that folder in the same structure as before.
 3. We will be archiving the `consul-helm` repo, as no more changes will be made to the repository.
 4. A new Docker image that hosts the renamed consul-k8s binary will now exist in the following Docker Hub repo: `hashicorp/consul-k8s-control-plane`.
 5. Most importantly, there will be no change to any users that are installing Consul Kubernetes via the Helm chart, since the Helm chart will still be released to same location (i.e. https://helm.releases.hashicorp.com).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Some additional details regarding the Consul Helm chart migration:
 4. A new Docker image that hosts the renamed consul-k8s binary will now exist in the following Docker Hub repo: `hashicorp/consul-k8s-control-plane`.
 5. Most importantly, there will be no change to any users that are installing Consul Kubernetes via the Helm chart, since the Helm chart will still be released to same location (i.e. https://helm.releases.hashicorp.com).
 
-After the integration, all of our Consul on Kubernetes components will be versioned together. For each new release of Consul Kubernets, a new tag of the repository will be created. We will use that tag as the version for the control-plane docker image, the upcoming CLI binary, and the Consul Helm charts.
+After the integration, all of our Consul on Kubernetes components will be versioned together. For each new release of Consul Kubernetes, a new tag of the repository will be created. We will use that tag as the version for the control-plane docker image, the upcoming CLI binary, and the Consul Helm charts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # Consul Helm Chart
 
-⭐ **We're looking for feedback on how folks are using Consul on Kubernetes. Please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_4MANbw1BUku7YhL)!** ⭐
+## ⚠️	 ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s` ⚠️	
+
+We are planning on consolidating our Consul Helm and Consul K8s repos soon!
+
+For users, the separate repositories lead to difficulty on new releases and confusion surrounding versioning. Most of the time new releases that include changes to consul-k8s also change consul-helm. But separate repositories mean separate GitHub PR's and added confusion in opening new Github Issues. In addition, we maintain separate versions of the consul-k8s binary and the Consul Helm chart, which in most cases are more tightly coupled together with dependencies. This versioning strategy has also led to confusion as to which Helm charts are compatible with which versions of consul-k8s.
+
+The single repository name will be consul-k8s. It will contain the Helm charts, control-plane code, and other components of Consul on Kubernetes. The original consul-k8s binary will be renamed to consul-k8s-control-plane, and an upcoming user-facing CLI binary will be called consul-k8s.
+
+Some additional details regarding the Consul Helm chart migration:
+
+1. All open and closed issues will be migrated from consul-helm to consul-k8s.
+2. PRs from consul-helm will not be migrated consul-k8s. Users will need to do that themselves, since it would be too complex to perform the migration with CI automation. The new repo will have a charts folder where the Helm chart will reside and PRs can be made against the contents in that folder in the same structure as before.
+3. We will be archiving the consul-helm repo, as no more changes will be made to the repository.
+4. A new Docker image that hosts the renamed consul-k8s binary will now exist in the following Docker Hub repo: hashicorp/consul-k8s-control-plane.
+5. Most importantly, there will be no change to any users that are installing Consul Kubernetes via the Helm chart, since the Helm chart will still be released to same location (i.e. https://helm.releases.hashicorp.com).
+
+After the integration, all of our Consul on Kubernetes components will be versioned together, and the release process will consist of creating a new tag of the repository, and using that tag as the version for the control-plane docker image, the upcoming CLI binary, and the Helm charts.
+
+---
+
+ **We're looking for feedback on how folks are using Consul on Kubernetes. Please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_4MANbw1BUku7YhL)!** 
 
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Consul on Kubernetes. This chart supports multiple use

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ After the integration, all of our Consul on Kubernetes components will be versio
 
 ---
 
-## HashiCorp Consul Helm Chart Survey
-
  **We're looking for feedback on how folks are using Consul on Kubernetes. Please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_4MANbw1BUku7YhL)!** 
  
 ----

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ After the integration, all of our Consul on Kubernetes components will be versio
 
 ---
 
+## HashiCorp Consul Helm Chart Survey
+
  **We're looking for feedback on how folks are using Consul on Kubernetes. Please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_4MANbw1BUku7YhL)!** 
+ 
+----
+
+## Overview
 
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Consul on Kubernetes. This chart supports multiple use

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## ⚠️	 ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s` ⚠️	
 
-We are planning on consolidating our Consul Helm and Consul K8s repos soon!
+We are planning on consolidating our Consul Helm and Consul K8s repos soon! TLDR: The HashiCorp Helm chart will be moving to [`hashicorp/consul-k8s`](https://github.com/hashicorp/consul-k8s). We target completing the migration before the end of August 2021.
 
 ### Background
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ For users, the separate repositories lead to difficulty on new releases and conf
 
 ### Proposal
 
-The single repository name will be consul-k8s. It will contain the Helm charts, control-plane code, and other components of Consul on Kubernetes. The original consul-k8s binary will be renamed to consul-k8s-control-plane, and an upcoming user-facing CLI binary will be called consul-k8s.
+The single repository name will be consul-k8s. It will contain the Helm charts, control-plane code, and other components of Consul on Kubernetes. The original `consul-k8s` binary will be renamed to `consul-k8s-control-plane`, and an upcoming user-facing CLI binary will be called `consul-k8s`.
 
 Some additional details regarding the Consul Helm chart migration:
 
-1. All open and closed issues will be migrated from consul-helm to consul-k8s.
+1. All open and closed issues will be migrated from `consul-helm` to `consul-k8s`.
 2. PRs from consul-helm will not be migrated consul-k8s. Users will need to do that themselves, since it would be too complex to perform the migration with CI automation. The new repo will have a charts folder where the Helm chart will reside and PRs can be made against the contents in that folder in the same structure as before.
-3. We will be archiving the consul-helm repo, as no more changes will be made to the repository.
-4. A new Docker image that hosts the renamed consul-k8s binary will now exist in the following Docker Hub repo: hashicorp/consul-k8s-control-plane.
+3. We will be archiving the `consul-helm` repo, as no more changes will be made to the repository.
+4. A new Docker image that hosts the renamed consul-k8s binary will now exist in the following Docker Hub repo: `hashicorp/consul-k8s-control-plane`.
 5. Most importantly, there will be no change to any users that are installing Consul Kubernetes via the Helm chart, since the Helm chart will still be released to same location (i.e. https://helm.releases.hashicorp.com).
 
-After the integration, all of our Consul on Kubernetes components will be versioned together, and the release process will consist of creating a new tag of the repository, and using that tag as the version for the control-plane docker image, the upcoming CLI binary, and the Helm charts.
+After the integration, all of our Consul on Kubernetes components will be versioned together. For each new release of Consul Kubernets, a new tag of the repository will be created. We will use that tag as the version for the control-plane docker image, the upcoming CLI binary, and the Consul Helm charts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## ⚠️	 ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s` ⚠️	
 
-We are planning on consolidating our Consul Helm and Consul K8s repos soon! TLDR: The HashiCorp Helm chart will be moving to [`hashicorp/consul-k8s`](https://github.com/hashicorp/consul-k8s). We target completing the migration before the end of August 2021.
+We are planning on consolidating our Consul Helm and Consul K8s repos soon! *TLDR:* The HashiCorp Helm chart will be moving to [`hashicorp/consul-k8s`](https://github.com/hashicorp/consul-k8s). We target completing the migration before the end of August 2021.
 
 ### Background
 
-For users, the separate repositories lead to difficulty on new releases and confusion surrounding versioning. Most of the time new releases that include changes to consul-k8s also change consul-helm. But separate repositories mean separate GitHub PR's and added confusion in opening new Github Issues. In addition, we maintain separate versions of the consul-k8s binary and the Consul Helm chart, which in most cases are more tightly coupled together with dependencies. This versioning strategy has also led to confusion as to which Helm charts are compatible with which versions of consul-k8s.
+For users, the separate repositories lead to difficulty on new releases and confusion surrounding versioning. Most of the time new releases that include changes to `consul-k8s` also change `consul-helm`. But separate repositories mean separate GitHub PR's and added confusion in opening new Github Issues. In addition, we maintain separate versions of the `consul-k8s` binary and the Consul Helm chart, which in most cases are more tightly coupled together with dependencies. This versioning strategy has also led to confusion as to which Helm charts are compatible with which versions of `consul-k8s`.
 
 ### Proposal
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 We are planning on consolidating our Consul Helm and Consul K8s repos soon!
 
+### Background
+
 For users, the separate repositories lead to difficulty on new releases and confusion surrounding versioning. Most of the time new releases that include changes to consul-k8s also change consul-helm. But separate repositories mean separate GitHub PR's and added confusion in opening new Github Issues. In addition, we maintain separate versions of the consul-k8s binary and the Consul Helm chart, which in most cases are more tightly coupled together with dependencies. This versioning strategy has also led to confusion as to which Helm charts are compatible with which versions of consul-k8s.
+
+### Proposal
 
 The single repository name will be consul-k8s. It will contain the Helm charts, control-plane code, and other components of Consul on Kubernetes. The original consul-k8s binary will be renamed to consul-k8s-control-plane, and an upcoming user-facing CLI binary will be called consul-k8s.
 


### PR DESCRIPTION


Changes proposed in this PR:
- Announcing that the Helm Chart is now moving to `hashicorp/consul-k8s` as per https://github.com/hashicorp/consul-helm/issues/1051
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

