### PR TITLE
Use docker-entrypoint when running consul 

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -164,6 +164,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: CONSUL_DISABLE_PERM_MGMT
+              value: "true"
             {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
             - name: GOSSIP_KEY
               valueFrom:
@@ -195,7 +197,7 @@ spec:
 
               {{ template "consul.extraconfig" }}
 
-              exec /bin/consul agent \
+              exec /usr/local/bin/docker-entrypoint.sh consul agent \
                 -node="${NODE}" \
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -154,6 +154,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CONSUL_DISABLE_PERM_MGMT
+              value: "true"
             {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
             - name: GOSSIP_KEY
               valueFrom:
@@ -187,7 +189,7 @@ spec:
 
               {{ template "consul.extraconfig" }}
 
-              exec /bin/consul agent \
+              exec /usr/local/bin/docker-entrypoint.sh consul agent \
                 -advertise="${ADVERTISE_IP}" \
                 -bind=0.0.0.0 \
                 -bootstrap-expect={{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }} \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -877,19 +877,11 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[4].name' | tee /dev/stderr)
-  [ "${actual}" = "custom_proxy" ]
-
-  local actual=$(echo $object |
-      yq -r '.[4].value' | tee /dev/stderr)
+      yq -r 'map(select(.name == "custom_proxy")) | .[0].value' | tee /dev/stderr)
   [ "${actual}" = "fakeproxy" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "no_proxy" ]
-
-  local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
+      yq -r 'map(select(.name == "no_proxy")) | .[0].value' | tee /dev/stderr)
   [ "${actual}" = "custom_no_proxy" ]
 }
 


### PR DESCRIPTION
Previously we were executing consul directly via /bin/consul and we were
using the Kubernetes `command` key which overrides the default Docker
ENTRYPOINT.

This had no issues, however I propose that it's best to execute via the
entrypoint so we keep things consistent with how the Docker image was
supposed to be run. This is also consistent with Vault's Helm chart. If
you step through the entrypoint script, nothing actually changes with
how we execute consul because we don't trigger any of the `if`
statements. So there is no real effect right now.

In order to support using the entrypoint script, we need to disable part of the
script that attempts to change the ownership of the /consul directory
because the ownership is already set via Kube.

Entrypoint script is here: https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh

How I've tested this PR:
* acceptance tests

How I expect reviewers to test this PR:
* code

Checklist:
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

