### PR TITLE
acceptance-tests: connect tests verify that the ACL token was deleted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "hashicorpdev/consul-k8s:2dfffed"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
     steps:
       - when:
           condition: << parameters.failfast >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:28d7141"
     steps:
       - when:
           condition: << parameters.failfast >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:28d7141"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
     steps:
       - when:
           condition: << parameters.failfast >>


### PR DESCRIPTION
Changes proposed in this PR:
- Add an assertion that ACL token gets deleted when service is deleted to the connect acceptance tests.

How I've tested this PR:
Don't need to test the tests 🐢 🐢 🐢 

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

