### PR TITLE
acceptance-tests: disable DNS by default in tests to avoid false positives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s:latest"
+        default: "hashicorpdev/consul-k8s:2dfffed"
     steps:
       - when:
           condition: << parameters.failfast >>

--- a/test/acceptance/framework/consul/consul_cluster.go
+++ b/test/acceptance/framework/consul/consul_cluster.go
@@ -77,6 +77,10 @@ func NewHelmCluster(
 		"server.bootstrapExpect":       "1",
 		"connectInject.envoyExtraArgs": "--log-level debug",
 		"connectInject.logLevel":       "debug",
+		// Disable DNS since enabling it changes the policy for the anonymous token,
+		// which could result in tests passing due to that token having privileges to read services
+		// (false positive).
+		"dns.enabled": "false",
 	}
 	valuesFromConfig, err := cfg.HelmValuesFromConfig()
 	require.NoError(t, err)

--- a/test/acceptance/framework/consul/consul_cluster_test.go
+++ b/test/acceptance/framework/consul/consul_cluster_test.go
@@ -29,6 +29,7 @@ func TestNewHelmCluster(t *testing.T) {
 				"connectInject.envoyExtraArgs":                  "--log-level debug",
 				"connectInject.logLevel":                        "debug",
 				"connectInject.transparentProxy.defaultEnabled": "false",
+				"dns.enabled":                                   "false",
 			},
 		},
 		{
@@ -40,6 +41,7 @@ func TestNewHelmCluster(t *testing.T) {
 				"connectInject.envoyExtraArgs":                  "--foo",
 				"connectInject.logLevel":                        "debug",
 				"connectInject.transparentProxy.defaultEnabled": "true",
+				"dns.enabled":                                   "true",
 				"feature.enabled":                               "true",
 			},
 			want: map[string]string{
@@ -49,6 +51,7 @@ func TestNewHelmCluster(t *testing.T) {
 				"connectInject.envoyExtraArgs":                  "--foo",
 				"connectInject.logLevel":                        "debug",
 				"connectInject.transparentProxy.defaultEnabled": "true",
+				"dns.enabled":                                   "true",
 				"feature.enabled":                               "true",
 			},
 		},


### PR DESCRIPTION
Changes proposed in this PR:
- When DNS with ACLS is enabled, we'll attach a policy to an anonymous token that allows it read all services. This could lead to us not catching issues like hashicorp/consul-k8s#570

How I've tested this PR:
🐢 

How I expect reviewers to test this PR:
- code review

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

