### PR TITLE
Remove Construction Signs from Readme to fit README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Consul Helm Chart
 
-## ⚠️	 ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s` ⚠️	
+## ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s`
 
 We are planning on consolidating our Consul Helm and Consul K8s repos soon! *TLDR:* The HashiCorp Helm chart will be moving to [`hashicorp/consul-k8s`](https://github.com/hashicorp/consul-k8s). We target completing the migration before the end of August 2021.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Consul Helm Chart
 
-## ANNOUNCEMENT: Consul Helm Chart moving to `hashicorp/consul-k8s`
+## Announcement: Consul Helm Chart moving to `hashicorp/consul-k8s`
 
 We are planning on consolidating our Consul Helm and Consul K8s repos soon! *TLDR:* The HashiCorp Helm chart will be moving to [`hashicorp/consul-k8s`](https://github.com/hashicorp/consul-k8s). We target completing the migration before the end of August 2021.
 


### PR DESCRIPTION
Changes proposed in this PR:
- Remove Construction signs as README.md does not show title all in one line about moving announcement
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

