### PR TITLE
Add ability to specify port for ui service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 * Allow setting global.logLevel and global.logJSON and propogate this to all consul-k8s commands. [[GH-980](https://github.com/hashicorp/consul-helm/pull/980)]
 * Allow setting `connectInject.replicas` to control number of replicas of webhook injector. [[GH-1029](https://github.com/hashicorp/consul-helm/pull/1029)]
 * Add the ability to manually specify a k8s secret containing server-cert via the value `server.serverCert.secretName`. [[GH-1024](https://github.com/hashicorp/consul-helm/pull/1046)]
+* Add ability to specify UI service ports. [[GH-1062](https://github.com/hashicorp/consul-helm/pull/1062)]
 
 ## 0.32.1 (June 29, 2021)
 

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
     {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
     - name: http
-      port: 80
+      port: {{ .Values.ui.service.port.http }}
       targetPort: 8500
       {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.http) }}
       nodePort: {{ .Values.ui.service.nodePort.http }}
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     {{- if .Values.global.tls.enabled }}
     - name: https
-      port: 443
+      port: {{ .Values.ui.service.port.https }}
       targetPort: 8501
       {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.https) }}
       nodePort: {{ .Values.ui.service.nodePort.https }}

--- a/values.yaml
+++ b/values.yaml
@@ -1075,6 +1075,15 @@ ui:
     # @type: string
     type: null
 
+    # Set the port value of the UI service.
+    port:
+
+      # HTTP port.
+      http: 80
+
+      # HTTPS port.
+      https: 443
+
     # Optionally set the nodePort value of the ui service if using a NodePort service.
     # If not set and using a NodePort service, Kubernetes will automatically assign
     # a port.


### PR DESCRIPTION
I followed the same pattern as for `nodePort`. This is generally useful for specifying load balancer ports and we have this option already for mesh gateways. This is also useful for running in Minikube because `minikube tunnel` will open up `localhost:<port>` and so you can have the Consul UI on `localhost:8500` rather than `localhost:80`.

How I've tested this PR:
* helm tests

How I expect reviewers to test this PR: code

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

