### PR TITLE
Update disruptionbudget api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 * Allow setting global.logLevel and global.logJSON and propogate this to all consul-k8s commands. [[GH-980](https://github.com/hashicorp/consul-helm/pull/980)]
 * Allow setting `connectInject.replicas` to control number of replicas of webhook injector. [[GH-1029](https://github.com/hashicorp/consul-helm/pull/1029)]
 * Add the ability to manually specify a k8s secret containing server-cert via the value `server.serverCert.secretName`. [[GH-1024](https://github.com/hashicorp/consul-helm/pull/1046)]
+* Use policy/v1 for Consul server PodDisruptionBudget if supported. [[GH-1063](https://github.com/hashicorp/consul-helm/pull/1063)]
 
 ## 0.32.1 (June 29, 2021)
 

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -1,7 +1,11 @@
 {{- if (and .Values.server.disruptionBudget.enabled (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
 # PodDisruptionBudget to prevent degrading the server cluster through
 # voluntary cluster changes.
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "consul.fullname" . }}-server

--- a/test/unit/server-disruptionbudget.bats
+++ b/test/unit/server-disruptionbudget.bats
@@ -119,3 +119,26 @@ load _helpers
       yq '.spec.maxUnavailable' | tee /dev/stderr)
   [ "${actual}" = "3" ]
 }
+
+#--------------------------------------------------------------------
+# apiVersion
+
+@test "server/DisruptionBudget: uses policy/v1 if supported" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-disruptionbudget.yaml \
+      --api-versions 'policy/v1' \
+      . | tee /dev/stderr |
+      yq -r '.apiVersion' | tee /dev/stderr)
+  [ "${actual}" = "policy/v1" ]
+}
+
+@test "server/DisruptionBudget: uses policy/v1beta1 if policy/v1 not supported" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-disruptionbudget.yaml \
+      --api-versions 'policy/v1beta1' \
+      . | tee /dev/stderr |
+      yq -r '.apiVersion' | tee /dev/stderr)
+  [ "${actual}" = "policy/v1beta1" ]
+}

--- a/test/unit/server-disruptionbudget.bats
+++ b/test/unit/server-disruptionbudget.bats
@@ -132,13 +132,8 @@ load _helpers
       yq -r '.apiVersion' | tee /dev/stderr)
   [ "${actual}" = "policy/v1" ]
 }
+# NOTE: can't test that it uses policy/v1beta1 if policy/v1 is *not* supported
+# because the supported API versions depends on the Helm version and there's
+# no flag to *remove* an API version so some Helm versions will always have
+# policy/v1 support and will always use that API version.
 
-@test "server/DisruptionBudget: uses policy/v1beta1 if policy/v1 not supported" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-disruptionbudget.yaml \
-      --api-versions 'policy/v1beta1' \
-      . | tee /dev/stderr |
-      yq -r '.apiVersion' | tee /dev/stderr)
-  [ "${actual}" = "policy/v1beta1" ]
-}


### PR DESCRIPTION
policy/v1beta1 is deprecated in Kubernetes 1.21+

```
W0726 17:27:19.007398 4427 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

How I've tested this PR:
* installed on a 1.21 kube cluster with/without the change

How I expect reviewers to test this PR:
* code

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

