### PR TITLE
Remove kubeversion from Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: consul
 version: 0.32.1
 appVersion: 1.10.0
-kubeVersion: ">=1.17.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
 icon: https://raw.githubusercontent.com/hashicorp/consul-helm/master/assets/icon.png


### PR DESCRIPTION
Removing kubeversion as it is causing issues in development with `helm template`

```
helm template consul /Users/name/go/src/github.com/hashicorp/consul-helm -f consul-values.yaml
Error: chart requires kubeVersion: >=1.17.0-0 which is incompatible with Kubernetes v1.16.0`

kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.2", GitCommit:"092fbfbf53427de67cac1e9fa54aaa09a28371d7", GitTreeState:"clean", BuildDate:"2021-06-16T12:59:11Z", GoVersion:"go1.16.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.8-gke.900", GitCommit:"28ab8501be88ea42e897ca8514d7cd0b436253d9", GitTreeState:"clean", BuildDate:"2021-06-30T09:23:36Z", GoVersion:"go1.15.13b5", Compiler:"gc", Platform:"linux/amd64"}
```

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

