### PR TITLE
Pin to aws provider 3.51.0

### DIFF
--- a/test/terraform/eks/main.tf
+++ b/test/terraform/eks/main.tf
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.51.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = ">= 2.28.1"
   region  = var.region
 
   assume_role {


### PR DESCRIPTION
Version 3.51.2 requires Terraform 0.14.6 and we're running 0.13.5. 3.51.2 was released a couple days ago which is why our tests started failing.

I didn't upgrade Terraform because I didn't want to make any major changes unless it was necessary.

