### PR TITLE
Fix all outstanding acceptance test errors from golangci-lint

### DIFF
--- a/test/acceptance/framework/environment/environment.go
+++ b/test/acceptance/framework/environment/environment.go
@@ -85,8 +85,6 @@ type kubernetesContext struct {
 
 	client  kubernetes.Interface
 	options *k8s.KubectlOptions
-
-	logDirectory string
 }
 
 func (k kubernetesContext) KubectlOptions(t *testing.T) *k8s.KubectlOptions {

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -57,7 +57,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 // Sets up a goroutine that will wait for interrupt signals
 // and call cleanup function when it catches it.
 func SetupInterruptHandler(cleanup func()) {
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c

--- a/test/acceptance/framework/k8s/debug.go
+++ b/test/acceptance/framework/k8s/debug.go
@@ -80,30 +80,33 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 		statefulSets, err := client.AppsV1().StatefulSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			logger.Log(t, "unable to get statefulsets", "err", err)
-		}
-		for _, statefulSet := range statefulSets.Items {
-			// Describe stateful set and write it to a file.
-			writeResourceInfoToFile(t, statefulSet.Name, "statefulset", testDebugDirectory, kubectlOptions)
+		} else {
+			for _, statefulSet := range statefulSets.Items {
+				// Describe stateful set and write it to a file.
+				writeResourceInfoToFile(t, statefulSet.Name, "statefulset", testDebugDirectory, kubectlOptions)
+			}
 		}
 
 		// Describe any daemonsets.
 		daemonsets, err := client.AppsV1().DaemonSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			logger.Log(t, "unable to get daemonsets", "err", err)
-		}
-		for _, daemonSet := range daemonsets.Items {
-			// Describe daemon set and write it to a file.
-			writeResourceInfoToFile(t, daemonSet.Name, "daemonset", testDebugDirectory, kubectlOptions)
+		} else {
+			for _, daemonSet := range daemonsets.Items {
+				// Describe daemon set and write it to a file.
+				writeResourceInfoToFile(t, daemonSet.Name, "daemonset", testDebugDirectory, kubectlOptions)
+			}
 		}
 
 		// Describe any deployments.
 		deployments, err := client.AppsV1().Deployments(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			logger.Log(t, "unable to get deployments", "err", err)
-		}
-		for _, deployment := range deployments.Items {
-			// Describe deployment and write it to a file.
-			writeResourceInfoToFile(t, deployment.Name, "deployment", testDebugDirectory, kubectlOptions)
+		} else {
+			for _, deployment := range deployments.Items {
+				// Describe deployment and write it to a file.
+				writeResourceInfoToFile(t, deployment.Name, "deployment", testDebugDirectory, kubectlOptions)
+			}
 		}
 	}
 }

--- a/test/acceptance/framework/k8s/debug.go
+++ b/test/acceptance/framework/k8s/debug.go
@@ -78,6 +78,9 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 		// Describe any stateful sets.
 		statefulSets, err := client.AppsV1().StatefulSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			logger.Log(t, "unable to get statefulsets", "err", err)
+		}
 		for _, statefulSet := range statefulSets.Items {
 			// Describe stateful set and write it to a file.
 			writeResourceInfoToFile(t, statefulSet.Name, "statefulset", testDebugDirectory, kubectlOptions)
@@ -85,6 +88,9 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 		// Describe any daemonsets.
 		daemonsets, err := client.AppsV1().DaemonSets(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			logger.Log(t, "unable to get daemonsets", "err", err)
+		}
 		for _, daemonSet := range daemonsets.Items {
 			// Describe daemon set and write it to a file.
 			writeResourceInfoToFile(t, daemonSet.Name, "daemonset", testDebugDirectory, kubectlOptions)
@@ -92,6 +98,9 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 		// Describe any deployments.
 		deployments, err := client.AppsV1().Deployments(kubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			logger.Log(t, "unable to get deployments", "err", err)
+		}
 		for _, deployment := range deployments.Items {
 			// Describe deployment and write it to a file.
 			writeResourceInfoToFile(t, deployment.Name, "deployment", testDebugDirectory, kubectlOptions)

--- a/test/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/test/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -198,7 +198,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 				}
 
 				logger.Log(t, "creating intention")
-				_, _, err := consulClient.Connect().IntentionCreate(intention, nil)
+				_, err := consulClient.Connect().IntentionUpsert(intention, nil)
 				require.NoError(t, err)
 			}
 

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -132,7 +132,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 
 				// Now we create the allow intention.
 				logger.Log(t, "creating ingress-gateway => static-server intention")
-				_, _, err = consulClient.Connect().IntentionCreate(&api.Intention{
+				_, err = consulClient.Connect().IntentionUpsert(&api.Intention{
 					SourceName:      "ingress-gateway",
 					SourceNS:        testNamespace,
 					DestinationName: "static-server",
@@ -252,7 +252,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 
 				// Now we create the allow intention.
 				logger.Log(t, "creating ingress-gateway => static-server intention")
-				_, _, err = consulClient.Connect().IntentionCreate(&api.Intention{
+				_, err = consulClient.Connect().IntentionUpsert(&api.Intention{
 					SourceName:      "ingress-gateway",
 					SourceNS:        "default",
 					DestinationName: "static-server",

--- a/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/test/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -96,7 +96,7 @@ func TestIngressGateway(t *testing.T) {
 
 				// Now we create the allow intention.
 				logger.Log(t, "creating ingress-gateway => static-server intention")
-				_, _, err = consulClient.Connect().IntentionCreate(&api.Intention{
+				_, err = consulClient.Connect().IntentionUpsert(&api.Intention{
 					SourceName:      "ingress-gateway",
 					DestinationName: "static-server",
 					Action:          api.IntentionActionAllow,

--- a/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/test/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -249,7 +249,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 			k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
 			logger.Log(t, "creating intention")
-			_, _, err = primaryClient.Connect().IntentionCreate(&api.Intention{
+			_, err = primaryClient.Connect().IntentionUpsert(&api.Intention{
 				SourceName:      staticClientName,
 				DestinationName: "static-server",
 				Action:          api.IntentionActionAllow,

--- a/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/test/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -194,7 +194,7 @@ func assertNoConnectionAndAddIntention(t *testing.T, consulClient *api.Client, k
 	k8s.CheckStaticServerConnectionFailing(t, k8sOptions, "http://localhost:1234")
 
 	logger.Log(t, "creating static-client => static-server intention")
-	_, _, err := consulClient.Connect().IntentionCreate(&api.Intention{
+	_, err := consulClient.Connect().IntentionUpsert(&api.Intention{
 		SourceName:      staticClientName,
 		SourceNS:        sourceNS,
 		DestinationName: staticServerName,


### PR DESCRIPTION
Changes proposed in this PR:
- Pre-emptive fixes to acceptance tests so that golangci-lint does not fail when monorepo is merged.

How I've tested this PR:
tests should still pass

How I expect reviewers to test this PR:
code review, tests still pass
Note to reviewers:  To test this out locally check out the branch from the PR and run `golangci-lint run --config=/path/to/consul-k8s/.golangci.yaml` from `consul-helm/tests/acceptance` 

Checklist:
- [ ] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

